### PR TITLE
fix(security): P0 — auth su endpoint AI, PNR segregato, hardening server

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,22 +17,31 @@ import { mergeParsed, missingFields, nextPromptFor } from './lib/announceRules.j
 import { getSession, saveSession, clearSession } from './models/fbSessionStore.js';
 import { mountParseDescriptionRoute } from './ai/descriptionParse.js';
 import { translateListingsRouter } from "./routes/translateListings.js";
+import { requireAuth } from './middleware/requireAuth.js';
+import { rateLimitParse } from './middleware/rateLimit.js';
 
 const app = express();
 
 // --- CORS ---
-app.use(cors({ origin: true, credentials: true }));
+// CORS_ORIGINS: lista separata da virgole degli origin ammessi (es. "https://app.travelswap.it,https://travelswap.it").
+// Se non impostata, resta permissivo (utile in dev; il traffico nativo mobile non è soggetto a CORS).
+const corsOrigins = (process.env.CORS_ORIGINS || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+app.use(cors({ origin: corsOrigins.length ? corsOrigins : true, credentials: true }));
 const rawBodySaver = (req, _res, buf) => { req.rawBody = buf; };
 app.use(express.json({ limit: '2mb', verify: rawBodySaver }));
 app.use(express.urlencoded({ extended: false }));
-const requireAuth = (req, _res, next) => next();
 
+// Ogni router è montato UNA volta, su prefisso esplicito.
+// (translateListingsRouter definisce internamente il path completo /api/listings/:id/translate)
 app.use('/ai', trustscoreRouter);
-app.use('/', listingsRouter);
+app.use('/api/listings', listingsRouter);
 app.use('/api/matches', matchesRouter);
-app.use("/", translateListingsRouter);
+app.use('/', translateListingsRouter);
 
-mountParseDescriptionRoute(app, requireAuth);
+mountParseDescriptionRoute(app, [requireAuth, rateLimitParse]);
 
 // ========== Helpers Messenger (TTL + riepilogo) ==========
 const SESSION_TTL_HOURS = 24;
@@ -87,7 +96,12 @@ function summaryText(s) {
 // =========================================================
 
 // --- Healthcheck / Debug ---
+const isDev = process.env.NODE_ENV === 'development';
+
 app.get('/health', (_req, res) => res.json({ ok: true }));
+
+// Endpoint di debug: SOLO in dev (rivelano stato di configurazione/ambiente)
+if (isDev) {
 app.get('/debug/env', (_req, res) => {
   res.json({
     NODE_ENV: process.env.NODE_ENV,
@@ -142,9 +156,9 @@ app.get('/debug/supabase', async (_req, res) => {
 app.get('/dev/ping', (_req, res) => {
   res.json({ ok: true, env: process.env.NODE_ENV || null });
 });
+}
 
 // --- Mini-logger in dev ---
-const isDev = process.env.NODE_ENV === 'development';
 if (isDev) {
   app.use((req, _res, next) => {
     console.log('[DEV]', req.method, req.path);
@@ -160,10 +174,6 @@ if (isDev) {
     });
   });
 }
-
-// --- Routers esistenti ---
-app.use('/api/listings', listingsRouter);
-app.use('/api/matches', matchesRouter);
 
 // --- Firma FB ---
 const FB_VERIFY_TOKEN = (process.env.FB_VERIFY_TOKEN || '').trim();
@@ -200,7 +210,9 @@ app.get('/webhooks/facebook', (req, res) => {
 
 // --- Webhook receiver (POST) ---
 app.post('/webhooks/facebook', async (req, res) => {
-  const allow = process.env.ALLOW_UNVERIFIED_WEBHOOK === 'true';
+  // Il bypass della firma è consentito SOLO fuori da produzione
+  const allow = process.env.ALLOW_UNVERIFIED_WEBHOOK === 'true'
+    && process.env.NODE_ENV !== 'production';
   if (!allow && !isDev && !verifyFacebookSignature(req)) {
     return res.sendStatus(403);
   }

--- a/server/src/middleware/rateLimit.js
+++ b/server/src/middleware/rateLimit.js
@@ -1,33 +1,47 @@
 // server/src/middleware/rateLimit.js
-// Limite: 10 valutazioni ogni 10 minuti per utente (o IP fallback)
-const BUCKET_WINDOW_MS = 10 * 60 * 1000; // 10 minuti
-const MAX_CALLS = 10;
-
-const buckets = new Map(); // key -> { count, resetAt }
+// Rate limiter in-memory per utente (o IP fallback), a finestra fissa.
+// NB: con più istanze del server serve uno store condiviso (Redis/Postgres).
 
 function keyFromReq(req) {
   // se hai req.user.id usa quello; altrimenti IP
   return req.user?.id || req.ip || 'anon';
 }
 
-export function rateLimitTrustScore(req, res, next) {
-  const key = keyFromReq(req);
-  const now = Date.now();
+/**
+ * Crea un middleware di rate limiting.
+ * @param {{ windowMs?: number, max?: number, name?: string }} opts
+ */
+export function makeRateLimiter({ windowMs = 10 * 60 * 1000, max = 10, name = 'richieste' } = {}) {
+  const buckets = new Map(); // key -> { count, resetAt }
 
-  let bucket = buckets.get(key);
-  if (!bucket || now > bucket.resetAt) {
-    bucket = { count: 0, resetAt: now + BUCKET_WINDOW_MS };
-    buckets.set(key, bucket);
-  }
+  return function rateLimit(req, res, next) {
+    const key = keyFromReq(req);
+    const now = Date.now();
 
-  if (bucket.count >= MAX_CALLS) {
-    const retrySec = Math.ceil((bucket.resetAt - now) / 1000);
-    return res.status(429).json({
-      error: 'rate_limited',
-      message: `Hai raggiunto il limite di ${MAX_CALLS} verifiche. Riprova tra ~${retrySec}s.`
-    });
-  }
+    let bucket = buckets.get(key);
+    if (!bucket || now > bucket.resetAt) {
+      bucket = { count: 0, resetAt: now + windowMs };
+      buckets.set(key, bucket);
+    }
 
-  bucket.count += 1;
-  next();
+    if (bucket.count >= max) {
+      const retrySec = Math.ceil((bucket.resetAt - now) / 1000);
+      return res.status(429).json({
+        error: 'rate_limited',
+        message: `Hai raggiunto il limite di ${max} ${name}. Riprova tra ~${retrySec}s.`
+      });
+    }
+
+    bucket.count += 1;
+    next();
+  };
 }
+
+// Limite: 10 valutazioni ogni 10 minuti per utente (o IP fallback)
+export const rateLimitTrustScore = makeRateLimiter({ windowMs: 10 * 60 * 1000, max: 10, name: 'verifiche' });
+
+// Limite traduzioni: 30 ogni 10 minuti per utente (le chiamate OpenAI hanno un costo)
+export const rateLimitTranslate = makeRateLimiter({ windowMs: 10 * 60 * 1000, max: 30, name: 'traduzioni' });
+
+// Limite parsing descrizioni: 20 ogni 10 minuti per utente
+export const rateLimitParse = makeRateLimiter({ windowMs: 10 * 60 * 1000, max: 20, name: 'analisi del testo' });

--- a/server/src/models/fbIngest.js
+++ b/server/src/models/fbIngest.js
@@ -127,7 +127,6 @@ export async function upsertListingFromFacebook({ channel, externalId, contactUr
     arrive_at: parsed?.arrive_at || null,
     is_named_ticket: parsed?.is_named_ticket ?? null,
     gender: parsed?.gender ?? null,
-    pnr: parsed?.pnr ?? null,
     description: pres.description || rawText || null,  // preferisci descrizione formattata
     price: pres.price,                        // NOT NULL
     image_url: parsed?.image_url || null,
@@ -150,6 +149,16 @@ export async function upsertListingFromFacebook({ channel, externalId, contactUr
     .single();
 
   if (error) throw error;
+
+  // Il PNR è un dato riservato: va nella tabella segregata, mai in `listings`
+  if (parsed?.pnr) {
+    const { error: errSecret } = await supabase
+      .from('listing_secrets')
+      .upsert({ listing_id: data.id, pnr: parsed.pnr });
+    if (errSecret) {
+      console.error('[fbIngest] listing_secrets upsert failed:', errSecret.message);
+    }
+  }
 
   return { id: data.id };
 }

--- a/server/src/models/matches.js
+++ b/server/src/models/matches.js
@@ -143,7 +143,7 @@ const tasks = fromListings.map((f) => async () => {
       to_listing_id: s.id,
       score: Number(s.score) || 0,
       bidirectional: !!s.bidirectional,
-      model: s.model || MODEL || 'gpt-4o-mini',
+      model: s.model || process.env.MATCH_AI_MODEL || 'gpt-4o-mini',
       explanation: s.explanation || null,
       generated_at: nowLocal,
     }));

--- a/server/src/routes/translateListings.js
+++ b/server/src/routes/translateListings.js
@@ -2,11 +2,13 @@
 import express from "express";
 import { supabase } from "../db.js";
 import { openaiTranslate } from "../services/trust/translate/openaiProvider.js";
+import { requireAuth } from "../middleware/requireAuth.js";
+import { rateLimitTranslate } from "../middleware/rateLimit.js";
 
 export const translateListingsRouter = express.Router();
 
 // GET /api/listings/:id/translate?lang=xx
-translateListingsRouter.get("/api/listings/:id/translate", async (req, res) => {
+translateListingsRouter.get("/api/listings/:id/translate", requireAuth, rateLimitTranslate, async (req, res) => {
   try {
     const id = String(req.params.id || "");
     const lang = String(req.query.lang || "").toLowerCase().split("-")[0];

--- a/travelswap_ai/travelswapai/lib/backendApi.js
+++ b/travelswap_ai/travelswapai/lib/backendApi.js
@@ -180,7 +180,7 @@ export async function fetchListings({ minTrust, sort } = {}) {
   if (minTrust != null) qs.set("minTrust", String(minTrust));
   if (sort) qs.set("sort", sort);
   const q = qs.toString();
-  return fetchJson(`/listings${q ? `?${q}` : ""}`);
+  return fetchJson(`/api/listings${q ? `?${q}` : ""}`);
 }
 
 // debug: stampa BASE una volta

--- a/travelswap_ai/travelswapai/lib/db.js
+++ b/travelswap_ai/travelswapai/lib/db.js
@@ -1,6 +1,12 @@
 // lib/db.js
 import { supabase } from "./supabase";
-const API_URL = "http://0.0.0.0:8080"; // oppure l’URL del tuo server
+
+// Colonne "pubbliche" di listings: MAI includere pnr o altri dati riservati
+// (i segreti vivono in listing_secrets, lato server)
+const LISTING_PUBLIC_COLUMNS =
+  "id, user_id, title, description, type, location, price, currency, status, created_at, " +
+  "cerco_vendo, route_from, route_to, depart_at, arrive_at, check_in, check_out, " +
+  "image_url, published_at, trust_score, is_named_ticket, contact_url";
 
 /** Utente corrente (o null) */
 export async function getCurrentUser() {
@@ -123,7 +129,7 @@ export async function listPublicListings({ limit = 50, excludeMine = true } = {}
   const me = await getCurrentUser().catch(() => null);
   let q = supabase
     .from("listings")
-    .select("*")
+    .select(LISTING_PUBLIC_COLUMNS)
     .eq("status", "active")
     .order("created_at", { ascending: false })
     .limit(limit);
@@ -166,7 +172,7 @@ export async function getListingById(id) {
   if (!id) throw new Error("Missing listing id");
   const { data, error } = await supabase
     .from("listings")
-    .select("*")
+    .select(LISTING_PUBLIC_COLUMNS)
     .eq("id", id)
     .single();
 


### PR DESCRIPTION
## Descrizione

Prima tranche di fix di sicurezza (i P0 di `docs/FUNCTIONAL_OVERVIEW.md`):

### Server
- **`/ai/parse-description`**: usava un `requireAuth` finto che lasciava passare tutti — ora usa il vero middleware JWT Supabase + rate limit (20/10min). L'app allega già il bearer token via `fetchJson`, quindi nessuna modifica lato client necessaria.
- **`/api/listings/:id/translate`**: era completamente pubblico — ora `requireAuth` + rate limit (30/10min).
- **`rateLimit.js`** generalizzato in una factory `makeRateLimiter` (comportamento del trustscore invariato).
- **PNR segregato**: l'ingest Facebook non scrive più `pnr` nella tabella `listings` ma in `listing_secrets`, come il resto del codice.
- **Endpoint di debug** (`/debug/env`, `/debug/supabase`, `/dev/ping`) disponibili solo con `NODE_ENV=development`.
- **`ALLOW_UNVERIFIED_WEBHOOK`** ignorato in produzione: la firma HMAC del webhook FB non è più bypassabile.
- **CORS** configurabile con env `CORS_ORIGINS` (lista separata da virgole); se assente il comportamento resta quello attuale.
- **Mount dei router deduplicati**: `listingsRouter` montato su `/` intercettava anche `/health` (rispondeva 400 "Invalid id"); ora ogni router è montato una sola volta sotto prefisso esplicito.
- **Bug crash latente**: `models/matches.js` usava la variabile `MODEL` mai definita → `ReferenceError` durante il ricalcolo match quando l'AI non valorizza `model`.

### App
- `listPublicListings` e `getListingById` non usano più `select("*")` ma una lista esplicita di colonne pubbliche → il PNR (e ogni colonna futura sensibile) non arriva più al client.
- `fetchListings` allineato al nuovo path `/api/listings`.

## Test

Smoke test manuale del server (production mode con credenziali fittizie):
- `/health` → 200; `/debug/env`, `/debug/supabase` → 404 (200 in dev)
- `POST /ai/parse-description`, `GET /api/listings/:id/translate`, `POST /ai/trustscore` senza token → 401
- `POST /webhooks/facebook` senza firma con `ALLOW_UNVERIFIED_WEBHOOK=true` in production → 403
- Syntax check ok su tutti i file modificati

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_