### PR TITLE
fix(db): check_function_bodies=off in testa alla migrazione init

### DIFF
--- a/supabase/migrations/20260711160000_init.sql
+++ b/supabase/migrations/20260711160000_init.sql
@@ -5,6 +5,11 @@
 -- Prerequisito: estensione pgvector (Dashboard → Database → Extensions → vector)
 -- ============================================================
 
+-- Impostazioni di sessione (come nel dump pg_dump originale):
+-- le funzioni possono referenziare tabelle create piu' avanti nel file
+set check_function_bodies = off;
+set client_min_messages = warning;
+
 create extension if not exists vector with schema public;
 
 --


### PR DESCRIPTION
## Descrizione

Fix per l'errore riscontrato applicando la migrazione init nel SQL editor di Supabase:

```
ERROR: 42P01: relation "public.matches" does not exist
```

Il SQL editor valida i corpi delle funzioni `LANGUAGE sql` al momento della creazione: `fn_user_top_matches` referenzia `public.matches`, definita più avanti nel file. Il dump `pg_dump` originale includeva `SET check_function_bodies = false;` in testa, andato perso nell'estrazione. Ripristinato (+ `client_min_messages = warning`).

## Test
Rivalidata l'intera sequenza (init + hardening) su PostgreSQL 16 pulito **senza impostazioni esterne al file** — esattamente come la esegue il SQL editor: nessun errore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_