### PR TITLE
fix(db): migrazione init robusta per il SQL editor di Supabase

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -12,11 +12,10 @@ Entrambe le migrazioni sono state validate applicandole in sequenza a un Postgre
 ## Ripristino su un nuovo progetto (il vecchio è in pausa non riattivabile)
 
 1. **Crea il progetto**: [dashboard Supabase](https://supabase.com/dashboard) → *New project* (stessa organizzazione va bene). Salva la password del database.
-2. **Abilita pgvector**: *Database → Extensions* → cerca `vector` → abilita (serve alla funzione `match_listings`).
-3. **Applica le migrazioni**: *SQL Editor* → incolla il contenuto di `20260711160000_init.sql` → *Run*; poi ripeti con `20260711160001_security_hardening.sql`.
+2. **Applica le migrazioni**: *SQL Editor* → incolla il contenuto di `20260711160000_init.sql` → *Run*; poi ripeti con `20260711160001_security_hardening.sql`.
    In alternativa con la CLI: `supabase link --project-ref <nuovo-ref>` poi `supabase db push`.
-4. **(Facoltativo) Dati vecchi**: il backup scaricato (`db_cluster*.backup.gz`) contiene i dati di prova (59 annunci, 5 profili). Gli account utente (`auth.users`) si recuperano solo col restore completo del backup, non con queste migrazioni — per una beta conviene ripartire con utenti nuovi.
-5. **Aggiorna le chiavi** (*Settings → API* del nuovo progetto):
+3. **(Facoltativo) Dati vecchi**: il backup scaricato (`db_cluster*.backup.gz`) contiene i dati di prova (59 annunci, 5 profili). Gli account utente (`auth.users`) si recuperano solo col restore completo del backup, non con queste migrazioni — per una beta conviene ripartire con utenti nuovi.
+4. **Aggiorna le chiavi** (*Settings → API* del nuovo progetto):
    - App — `travelswap_ai/travelswapai/.env`: `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_ANON_KEY`
    - Server (Render) — variabili d'ambiente: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
 

--- a/supabase/migrations/20260711160000_init.sql
+++ b/supabase/migrations/20260711160000_init.sql
@@ -2,7 +2,6 @@
 -- TravelSwapAI — Schema iniziale (public)
 -- Ricostruito dal backup del progetto Supabase originale
 -- (dump del 05/10/2025), ripulito da OWNER/ACL.
--- Prerequisito: estensione pgvector (Dashboard → Database → Extensions → vector)
 -- ============================================================
 
 -- Impostazioni di sessione (come nel dump pg_dump originale):
@@ -10,7 +9,10 @@
 set check_function_bodies = off;
 set client_min_messages = warning;
 
-create extension if not exists vector with schema public;
+
+-- NB: blocchi ordinati per dipendenza (tipi -> tabelle -> viste -> funzioni
+-- -> vincoli -> indici -> trigger -> policy): il file e' applicabile anche
+-- da editor che eseguono gli statement in sessioni separate.
 
 --
 -- Name: gender_enum; Type: TYPE; Schema: public; Owner: postgres
@@ -74,6 +76,429 @@ CREATE TYPE public.transaction_type AS ENUM (
 
 
 --
+-- Name: offers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.offers (
+    id bigint NOT NULL,
+    from_listing_id uuid,
+    to_listing_id uuid NOT NULL,
+    status public.offer_status DEFAULT 'pending'::public.offer_status,
+    message text,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    type text,
+    proposer_id uuid,
+    amount numeric(10,2),
+    currency text,
+    CONSTRAINT offers_type_check CHECK ((type = ANY (ARRAY['swap'::text, 'buy'::text])))
+);
+
+
+
+--
+-- Name: ai_import_logs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.ai_import_logs (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    user_id uuid NOT NULL,
+    listing_id uuid,
+    source text NOT NULL,
+    raw_payload text,
+    parsed jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT ai_import_logs_source_check CHECK ((source = ANY (ARRAY['pnr'::text, 'qr'::text])))
+);
+
+
+
+--
+-- Name: fb_sessions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.fb_sessions (
+    sender_id text NOT NULL,
+    payload jsonb DEFAULT '{}'::jsonb NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+--
+-- Name: listing_ai_scores; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.listing_ai_scores (
+    id bigint NOT NULL,
+    listing_id uuid NOT NULL,
+    reliability numeric(5,2) NOT NULL,
+    payload jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+--
+-- Name: listing_images; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.listing_images (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    listing_id uuid NOT NULL,
+    url text NOT NULL,
+    "position" integer DEFAULT 0 NOT NULL
+);
+
+
+
+--
+-- Name: listing_secrets; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.listing_secrets (
+    listing_id uuid NOT NULL,
+    pnr text
+);
+
+
+
+--
+-- Name: listing_translations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.listing_translations (
+    listing_id uuid NOT NULL,
+    lang text NOT NULL,
+    title_translated text,
+    description_translated text,
+    provider text,
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+
+--
+-- Name: listings; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.listings (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    user_id uuid NOT NULL,
+    type public.listing_type NOT NULL,
+    title text NOT NULL,
+    location text NOT NULL,
+    check_in date,
+    check_out date,
+    depart_at timestamp with time zone,
+    arrive_at timestamp with time zone,
+    is_named_ticket boolean,
+    gender public.gender_enum,
+    pnr text,
+    description text,
+    price numeric(10,2) NOT NULL,
+    image_url text,
+    status public.listing_status DEFAULT 'active'::public.listing_status NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    start_date date GENERATED ALWAYS AS (
+CASE
+    WHEN (type = 'hotel'::public.listing_type) THEN check_in
+    WHEN (type = 'train'::public.listing_type) THEN ((depart_at AT TIME ZONE 'UTC'::text))::date
+    ELSE NULL::date
+END) STORED,
+    currency text DEFAULT 'EUR'::text NOT NULL,
+    route_from text,
+    route_to text,
+    cerco_vendo text DEFAULT 'VENDO'::text,
+    published_at timestamp with time zone DEFAULT now(),
+    source text,
+    external_id text,
+    contact_url text,
+    ai_reliability numeric(5,2),
+    ai_reliability_expl jsonb,
+    ai_reliability_updated_at timestamp with time zone,
+    trust_score numeric(5,2),
+    CONSTRAINT listings_cerco_vendo_check CHECK ((cerco_vendo = ANY (ARRAY['CERCO'::text, 'VENDO'::text]))),
+    CONSTRAINT listings_price_check CHECK ((price >= (0)::numeric))
+);
+
+
+
+--
+-- Name: match_snapshots; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.match_snapshots (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    generated_at timestamp with time zone DEFAULT now() NOT NULL,
+    items jsonb DEFAULT '[]'::jsonb NOT NULL
+);
+
+
+
+--
+-- Name: matches; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.matches (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    from_listing_id uuid NOT NULL,
+    to_listing_id uuid NOT NULL,
+    score integer NOT NULL,
+    dims jsonb,
+    explanation text,
+    model text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    items jsonb DEFAULT '[]'::jsonb NOT NULL,
+    user_id uuid NOT NULL,
+    bidirectional boolean DEFAULT false NOT NULL,
+    generated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT matches_score_check CHECK (((score >= 0) AND (score <= 100)))
+);
+
+
+
+--
+-- Name: profiles; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.profiles (
+    id uuid NOT NULL,
+    username text,
+    avatar_url text,
+    bio text,
+    counters jsonb DEFAULT jsonb_build_object('active', 0, 'sold', 0, 'exchanged', 0, 'total', 0),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    email text,
+    full_name text,
+    phone text,
+    prefs jsonb DEFAULT '{}'::jsonb NOT NULL
+);
+
+
+
+--
+-- Name: saved_listings; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.saved_listings (
+    user_id uuid NOT NULL,
+    listing_id uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+--
+-- Name: transactions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.transactions (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    listing_id uuid NOT NULL,
+    buyer_id uuid,
+    seller_id uuid NOT NULL,
+    ttype public.transaction_type NOT NULL,
+    price numeric(10,2),
+    status text DEFAULT 'completed'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+--
+-- Name: trust_audit; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.trust_audit (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    user_id uuid NOT NULL,
+    listing_id uuid,
+    trust_score smallint NOT NULL,
+    flags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    suggested_fixes jsonb DEFAULT '[]'::jsonb NOT NULL,
+    sub_scores jsonb NOT NULL,
+    raw jsonb NOT NULL
+);
+
+
+
+--
+-- Name: listing_ai_scores_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.listing_ai_scores_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+
+--
+-- Name: offers_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.offers ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.offers_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: listing_ai_scores_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.listing_ai_scores_id_seq OWNED BY public.listing_ai_scores.id;
+
+
+--
+-- Name: listing_ai_scores id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.listing_ai_scores ALTER COLUMN id SET DEFAULT nextval('public.listing_ai_scores_id_seq'::regclass);
+
+
+--
+-- Name: v_perfect_matches; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_perfect_matches AS
+ SELECT m1.id,
+    m1.from_listing_id,
+    m1.to_listing_id,
+    m1.score,
+    m1.dims,
+    m1.explanation,
+    m1.model,
+    m1.created_at
+   FROM (public.matches m1
+     JOIN public.matches m2 ON (((m2.from_listing_id = m1.to_listing_id) AND (m2.to_listing_id = m1.from_listing_id))));
+
+
+
+--
+-- Name: v_compatible_matches_60; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_compatible_matches_60 AS
+ SELECT m.id,
+    m.from_listing_id,
+    m.to_listing_id,
+    m.score,
+    m.dims,
+    m.explanation,
+    m.model,
+    m.created_at
+   FROM (public.matches m
+     LEFT JOIN public.v_perfect_matches p ON ((p.id = m.id)))
+  WHERE ((p.id IS NULL) AND (m.score >= 60));
+
+
+
+--
+-- Name: v_last_minute; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_last_minute AS
+ SELECT id,
+    user_id,
+    type,
+    title,
+    location,
+    check_in,
+    check_out,
+    depart_at,
+    arrive_at,
+    is_named_ticket,
+    gender,
+    pnr,
+    description,
+    price,
+    image_url,
+    status,
+    created_at,
+    updated_at,
+    start_date
+   FROM public.listings
+  WHERE ((status = 'active'::public.listing_status) AND (start_date IS NOT NULL) AND (start_date <= (CURRENT_DATE + '3 days'::interval)));
+
+
+
+--
+-- Name: v_latest_trustscore; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_latest_trustscore AS
+ SELECT t1.listing_id,
+    t1.trust_score,
+    t1.created_at AS evaluated_at
+   FROM (public.trust_audit t1
+     JOIN ( SELECT trust_audit.listing_id,
+            max(trust_audit.created_at) AS max_created
+           FROM public.trust_audit
+          GROUP BY trust_audit.listing_id) t2 ON (((t1.listing_id = t2.listing_id) AND (t1.created_at = t2.max_created))));
+
+
+
+--
+-- Name: v_perfect_matches_80; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_perfect_matches_80 AS
+ SELECT id,
+    from_listing_id,
+    to_listing_id,
+    score,
+    dims,
+    explanation,
+    model,
+    created_at
+   FROM public.v_perfect_matches
+  WHERE (score >= 80);
+
+
+
+--
+-- Name: v_top_matches_per_from; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.v_top_matches_per_from AS
+ SELECT m.from_listing_id,
+    m.to_listing_id,
+    m.score,
+    l.title,
+    l.type,
+    l.location,
+    l.price
+   FROM (( SELECT matches.id,
+            matches.from_listing_id,
+            matches.to_listing_id,
+            matches.score,
+            matches.dims,
+            matches.explanation,
+            matches.model,
+            matches.created_at,
+            matches.updated_at,
+            matches.items,
+            row_number() OVER (PARTITION BY matches.from_listing_id ORDER BY matches.score DESC) AS rn
+           FROM public.matches) m
+     JOIN public.listings l ON (((l.id = m.to_listing_id) AND (l.status = 'active'::public.listing_status))))
+  WHERE (m.rn <= 3);
+
+
+
+--
 -- Name: _norm(text); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
@@ -100,27 +525,6 @@ $$;
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
-
---
--- Name: offers; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.offers (
-    id bigint NOT NULL,
-    from_listing_id uuid,
-    to_listing_id uuid NOT NULL,
-    status public.offer_status DEFAULT 'pending'::public.offer_status,
-    message text,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
-    type text,
-    proposer_id uuid,
-    amount numeric(10,2),
-    currency text,
-    CONSTRAINT offers_type_check CHECK ((type = ANY (ARRAY['swap'::text, 'buy'::text])))
-);
-
-
 
 --
 -- Name: accept_offer(uuid); Type: FUNCTION; Schema: public; Owner: postgres
@@ -651,64 +1055,6 @@ $$;
 
 
 --
--- Name: match_listings(public.vector, text, uuid, integer, numeric, numeric, integer, date, date, date); Type: FUNCTION; Schema: public; Owner: postgres
---
-
-CREATE FUNCTION public.match_listings(p_embedding public.vector, p_type text, p_exclude_id uuid, p_k integer DEFAULT 8, p_min_price numeric DEFAULT 0, p_max_price numeric DEFAULT 999999, p_day_tol integer DEFAULT 7, p_base_check_in date DEFAULT NULL::date, p_base_check_out date DEFAULT NULL::date, p_base_departure date DEFAULT NULL::date) RETURNS TABLE(id uuid, type text, title text, description text, location text, check_in date, check_out date, departure_date date, price numeric, currency text, main_photo_url text, created_at timestamp with time zone, score double precision)
-    LANGUAGE sql STABLE
-    AS $$
-with base as (
-  select p_embedding::vector as emb
-),
-filtered as (
-  select *
-  from public.listings
-  where embedding is not null
-    and id <> p_exclude_id
-    and type = p_type
-    and price between p_min_price and p_max_price
-    and (
-      (p_type = 'hotel' and (
-        (
-          p_base_check_in is not null and p_base_check_out is not null
-          and check_in is not null and check_out is not null
-          and daterange(check_in - p_day_tol, check_out + p_day_tol, '[]')
-              && daterange(p_base_check_in, p_base_check_out, '[]')
-        )
-        or (p_base_check_in is null or p_base_check_out is null)
-      ))
-      or
-      (p_type = 'train' and (
-        (
-          p_base_departure is not null and departure_date is not null
-          and departure_date between (p_base_departure - p_day_tol) and (p_base_departure + p_day_tol)
-        )
-        or p_base_departure is null
-      ))
-    )
-)
-select
-  l.id                                    as id,
-  l.type                                  as type,
-  l.title                                  as title,
-  l.description                            as description,
-  l.location                               as location,
-  l.check_in                               as check_in,
-  l.check_out                              as check_out,
-  l.departure_date                         as departure_date,
-  l.price                                  as price,
-  l.currency                               as currency,
-  l.main_photo_url                         as main_photo_url,
-  l.created_at                             as created_at,
-  1 - (l.embedding <=> (select emb from base)) as score
-from filtered l
-order by l.embedding <=> (select emb from base) asc
-limit p_k;
-$$;
-
-
-
---
 -- Name: on_listing_status_change(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
@@ -836,408 +1182,6 @@ $$;
 
 
 --
--- Name: ai_import_logs; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.ai_import_logs (
-    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
-    user_id uuid NOT NULL,
-    listing_id uuid,
-    source text NOT NULL,
-    raw_payload text,
-    parsed jsonb,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT ai_import_logs_source_check CHECK ((source = ANY (ARRAY['pnr'::text, 'qr'::text])))
-);
-
-
-
---
--- Name: fb_sessions; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.fb_sessions (
-    sender_id text NOT NULL,
-    payload jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
-
---
--- Name: listing_ai_scores; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.listing_ai_scores (
-    id bigint NOT NULL,
-    listing_id uuid NOT NULL,
-    reliability numeric(5,2) NOT NULL,
-    payload jsonb,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
-
---
--- Name: listing_ai_scores_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
---
-
-CREATE SEQUENCE public.listing_ai_scores_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-
---
--- Name: listing_ai_scores_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
---
-
-ALTER SEQUENCE public.listing_ai_scores_id_seq OWNED BY public.listing_ai_scores.id;
-
-
---
--- Name: listing_images; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.listing_images (
-    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
-    listing_id uuid NOT NULL,
-    url text NOT NULL,
-    "position" integer DEFAULT 0 NOT NULL
-);
-
-
-
---
--- Name: listing_secrets; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.listing_secrets (
-    listing_id uuid NOT NULL,
-    pnr text
-);
-
-
-
---
--- Name: listing_translations; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.listing_translations (
-    listing_id uuid NOT NULL,
-    lang text NOT NULL,
-    title_translated text,
-    description_translated text,
-    provider text,
-    updated_at timestamp with time zone DEFAULT now()
-);
-
-
-
---
--- Name: listings; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.listings (
-    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
-    user_id uuid NOT NULL,
-    type public.listing_type NOT NULL,
-    title text NOT NULL,
-    location text NOT NULL,
-    check_in date,
-    check_out date,
-    depart_at timestamp with time zone,
-    arrive_at timestamp with time zone,
-    is_named_ticket boolean,
-    gender public.gender_enum,
-    pnr text,
-    description text,
-    price numeric(10,2) NOT NULL,
-    image_url text,
-    status public.listing_status DEFAULT 'active'::public.listing_status NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    start_date date GENERATED ALWAYS AS (
-CASE
-    WHEN (type = 'hotel'::public.listing_type) THEN check_in
-    WHEN (type = 'train'::public.listing_type) THEN ((depart_at AT TIME ZONE 'UTC'::text))::date
-    ELSE NULL::date
-END) STORED,
-    currency text DEFAULT 'EUR'::text NOT NULL,
-    route_from text,
-    route_to text,
-    cerco_vendo text DEFAULT 'VENDO'::text,
-    published_at timestamp with time zone DEFAULT now(),
-    source text,
-    external_id text,
-    contact_url text,
-    ai_reliability numeric(5,2),
-    ai_reliability_expl jsonb,
-    ai_reliability_updated_at timestamp with time zone,
-    trust_score numeric(5,2),
-    CONSTRAINT listings_cerco_vendo_check CHECK ((cerco_vendo = ANY (ARRAY['CERCO'::text, 'VENDO'::text]))),
-    CONSTRAINT listings_price_check CHECK ((price >= (0)::numeric))
-);
-
-
-
---
--- Name: match_snapshots; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.match_snapshots (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    user_id uuid NOT NULL,
-    generated_at timestamp with time zone DEFAULT now() NOT NULL,
-    items jsonb DEFAULT '[]'::jsonb NOT NULL
-);
-
-
-
---
--- Name: matches; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.matches (
-    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
-    from_listing_id uuid NOT NULL,
-    to_listing_id uuid NOT NULL,
-    score integer NOT NULL,
-    dims jsonb,
-    explanation text,
-    model text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    items jsonb DEFAULT '[]'::jsonb NOT NULL,
-    user_id uuid NOT NULL,
-    bidirectional boolean DEFAULT false NOT NULL,
-    generated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT matches_score_check CHECK (((score >= 0) AND (score <= 100)))
-);
-
-
-
---
--- Name: offers_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.offers ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
-    SEQUENCE NAME public.offers_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1
-);
-
-
---
--- Name: profiles; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.profiles (
-    id uuid NOT NULL,
-    username text,
-    avatar_url text,
-    bio text,
-    counters jsonb DEFAULT jsonb_build_object('active', 0, 'sold', 0, 'exchanged', 0, 'total', 0),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    email text,
-    full_name text,
-    phone text,
-    prefs jsonb DEFAULT '{}'::jsonb NOT NULL
-);
-
-
-
---
--- Name: saved_listings; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.saved_listings (
-    user_id uuid NOT NULL,
-    listing_id uuid NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
-
---
--- Name: transactions; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.transactions (
-    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
-    listing_id uuid NOT NULL,
-    buyer_id uuid,
-    seller_id uuid NOT NULL,
-    ttype public.transaction_type NOT NULL,
-    price numeric(10,2),
-    status text DEFAULT 'completed'::text NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
-
---
--- Name: trust_audit; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.trust_audit (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    user_id uuid NOT NULL,
-    listing_id uuid,
-    trust_score smallint NOT NULL,
-    flags jsonb DEFAULT '[]'::jsonb NOT NULL,
-    suggested_fixes jsonb DEFAULT '[]'::jsonb NOT NULL,
-    sub_scores jsonb NOT NULL,
-    raw jsonb NOT NULL
-);
-
-
-
---
--- Name: v_perfect_matches; Type: VIEW; Schema: public; Owner: postgres
---
-
-CREATE VIEW public.v_perfect_matches AS
- SELECT m1.id,
-    m1.from_listing_id,
-    m1.to_listing_id,
-    m1.score,
-    m1.dims,
-    m1.explanation,
-    m1.model,
-    m1.created_at
-   FROM (public.matches m1
-     JOIN public.matches m2 ON (((m2.from_listing_id = m1.to_listing_id) AND (m2.to_listing_id = m1.from_listing_id))));
-
-
-
---
--- Name: v_compatible_matches_60; Type: VIEW; Schema: public; Owner: postgres
---
-
-CREATE VIEW public.v_compatible_matches_60 AS
- SELECT m.id,
-    m.from_listing_id,
-    m.to_listing_id,
-    m.score,
-    m.dims,
-    m.explanation,
-    m.model,
-    m.created_at
-   FROM (public.matches m
-     LEFT JOIN public.v_perfect_matches p ON ((p.id = m.id)))
-  WHERE ((p.id IS NULL) AND (m.score >= 60));
-
-
-
---
--- Name: v_last_minute; Type: VIEW; Schema: public; Owner: postgres
---
-
-CREATE VIEW public.v_last_minute AS
- SELECT id,
-    user_id,
-    type,
-    title,
-    location,
-    check_in,
-    check_out,
-    depart_at,
-    arrive_at,
-    is_named_ticket,
-    gender,
-    pnr,
-    description,
-    price,
-    image_url,
-    status,
-    created_at,
-    updated_at,
-    start_date
-   FROM public.listings
-  WHERE ((status = 'active'::public.listing_status) AND (start_date IS NOT NULL) AND (start_date <= (CURRENT_DATE + '3 days'::interval)));
-
-
-
---
--- Name: v_latest_trustscore; Type: VIEW; Schema: public; Owner: postgres
---
-
-CREATE VIEW public.v_latest_trustscore AS
- SELECT t1.listing_id,
-    t1.trust_score,
-    t1.created_at AS evaluated_at
-   FROM (public.trust_audit t1
-     JOIN ( SELECT trust_audit.listing_id,
-            max(trust_audit.created_at) AS max_created
-           FROM public.trust_audit
-          GROUP BY trust_audit.listing_id) t2 ON (((t1.listing_id = t2.listing_id) AND (t1.created_at = t2.max_created))));
-
-
-
---
--- Name: v_perfect_matches_80; Type: VIEW; Schema: public; Owner: postgres
---
-
-CREATE VIEW public.v_perfect_matches_80 AS
- SELECT id,
-    from_listing_id,
-    to_listing_id,
-    score,
-    dims,
-    explanation,
-    model,
-    created_at
-   FROM public.v_perfect_matches
-  WHERE (score >= 80);
-
-
-
---
--- Name: v_top_matches_per_from; Type: VIEW; Schema: public; Owner: postgres
---
-
-CREATE VIEW public.v_top_matches_per_from AS
- SELECT m.from_listing_id,
-    m.to_listing_id,
-    m.score,
-    l.title,
-    l.type,
-    l.location,
-    l.price
-   FROM (( SELECT matches.id,
-            matches.from_listing_id,
-            matches.to_listing_id,
-            matches.score,
-            matches.dims,
-            matches.explanation,
-            matches.model,
-            matches.created_at,
-            matches.updated_at,
-            matches.items,
-            row_number() OVER (PARTITION BY matches.from_listing_id ORDER BY matches.score DESC) AS rn
-           FROM public.matches) m
-     JOIN public.listings l ON (((l.id = m.to_listing_id) AND (l.status = 'active'::public.listing_status))))
-  WHERE (m.rn <= 3);
-
-
-
---
--- Name: listing_ai_scores id; Type: DEFAULT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.listing_ai_scores ALTER COLUMN id SET DEFAULT nextval('public.listing_ai_scores_id_seq'::regclass);
-
-
---
 -- Name: ai_import_logs ai_import_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -1355,6 +1299,142 @@ ALTER TABLE ONLY public.transactions
 
 ALTER TABLE ONLY public.trust_audit
     ADD CONSTRAINT trust_audit_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ai_import_logs ai_import_logs_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ai_import_logs
+    ADD CONSTRAINT ai_import_logs_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE SET NULL;
+
+
+--
+-- Name: ai_import_logs ai_import_logs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ai_import_logs
+    ADD CONSTRAINT ai_import_logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: listing_ai_scores listing_ai_scores_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.listing_ai_scores
+    ADD CONSTRAINT listing_ai_scores_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: listing_images listing_images_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.listing_images
+    ADD CONSTRAINT listing_images_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: listing_secrets listing_secrets_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.listing_secrets
+    ADD CONSTRAINT listing_secrets_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: listing_translations listing_translations_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.listing_translations
+    ADD CONSTRAINT listing_translations_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: listings listings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.listings
+    ADD CONSTRAINT listings_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: matches matches_from_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.matches
+    ADD CONSTRAINT matches_from_listing_id_fkey FOREIGN KEY (from_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: matches matches_to_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.matches
+    ADD CONSTRAINT matches_to_listing_id_fkey FOREIGN KEY (to_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: offers offers_from_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.offers
+    ADD CONSTRAINT offers_from_listing_id_fkey FOREIGN KEY (from_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: offers offers_to_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.offers
+    ADD CONSTRAINT offers_to_listing_id_fkey FOREIGN KEY (to_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: profiles profiles_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.profiles
+    ADD CONSTRAINT profiles_id_fkey FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: saved_listings saved_listings_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.saved_listings
+    ADD CONSTRAINT saved_listings_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: saved_listings saved_listings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.saved_listings
+    ADD CONSTRAINT saved_listings_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: transactions transactions_buyer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.transactions
+    ADD CONSTRAINT transactions_buyer_id_fkey FOREIGN KEY (buyer_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: transactions transactions_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.transactions
+    ADD CONSTRAINT transactions_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: transactions transactions_seller_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.transactions
+    ADD CONSTRAINT transactions_seller_id_fkey FOREIGN KEY (seller_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -1638,142 +1718,6 @@ CREATE TRIGGER trg_update_listing_trust_score AFTER INSERT ON public.trust_audit
 
 
 --
--- Name: ai_import_logs ai_import_logs_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.ai_import_logs
-    ADD CONSTRAINT ai_import_logs_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE SET NULL;
-
-
---
--- Name: ai_import_logs ai_import_logs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.ai_import_logs
-    ADD CONSTRAINT ai_import_logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
--- Name: listing_ai_scores listing_ai_scores_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.listing_ai_scores
-    ADD CONSTRAINT listing_ai_scores_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: listing_images listing_images_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.listing_images
-    ADD CONSTRAINT listing_images_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: listing_secrets listing_secrets_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.listing_secrets
-    ADD CONSTRAINT listing_secrets_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: listing_translations listing_translations_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.listing_translations
-    ADD CONSTRAINT listing_translations_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: listings listings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.listings
-    ADD CONSTRAINT listings_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
--- Name: matches matches_from_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.matches
-    ADD CONSTRAINT matches_from_listing_id_fkey FOREIGN KEY (from_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: matches matches_to_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.matches
-    ADD CONSTRAINT matches_to_listing_id_fkey FOREIGN KEY (to_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: offers offers_from_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.offers
-    ADD CONSTRAINT offers_from_listing_id_fkey FOREIGN KEY (from_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: offers offers_to_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.offers
-    ADD CONSTRAINT offers_to_listing_id_fkey FOREIGN KEY (to_listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: profiles profiles_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.profiles
-    ADD CONSTRAINT profiles_id_fkey FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
--- Name: saved_listings saved_listings_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.saved_listings
-    ADD CONSTRAINT saved_listings_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: saved_listings saved_listings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.saved_listings
-    ADD CONSTRAINT saved_listings_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
--- Name: transactions transactions_buyer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.transactions
-    ADD CONSTRAINT transactions_buyer_id_fkey FOREIGN KEY (buyer_id) REFERENCES auth.users(id) ON DELETE SET NULL;
-
-
---
--- Name: transactions transactions_listing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.transactions
-    ADD CONSTRAINT transactions_listing_id_fkey FOREIGN KEY (listing_id) REFERENCES public.listings(id) ON DELETE CASCADE;
-
-
---
--- Name: transactions transactions_seller_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.transactions
-    ADD CONSTRAINT transactions_seller_id_fkey FOREIGN KEY (seller_id) REFERENCES auth.users(id) ON DELETE CASCADE;
-
-
---
 -- Name: offers Create offer if both listings exist; Type: POLICY; Schema: public; Owner: postgres
 --
 
@@ -1866,12 +1810,6 @@ CREATE POLICY "Users read own listings" ON public.listings FOR SELECT USING ((au
 
 
 --
--- Name: ai_import_logs; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.ai_import_logs ENABLE ROW LEVEL SECURITY;
-
---
 -- Name: ai_import_logs ai_logs_read_own; Type: POLICY; Schema: public; Owner: postgres
 --
 
@@ -1884,12 +1822,6 @@ CREATE POLICY ai_logs_read_own ON public.ai_import_logs FOR SELECT USING ((user_
 
 CREATE POLICY ai_logs_write_own ON public.ai_import_logs FOR INSERT WITH CHECK ((user_id = auth.uid()));
 
-
---
--- Name: listing_images; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.listing_images ENABLE ROW LEVEL SECURITY;
 
 --
 -- Name: listing_images listing_images_read; Type: POLICY; Schema: public; Owner: postgres
@@ -1910,24 +1842,6 @@ CREATE POLICY listing_images_write_user ON public.listing_images USING ((EXISTS 
    FROM public.listings l
   WHERE ((l.id = listing_images.listing_id) AND (l.user_id = auth.uid())))));
 
-
---
--- Name: listing_secrets; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.listing_secrets ENABLE ROW LEVEL SECURITY;
-
---
--- Name: listing_translations; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.listing_translations ENABLE ROW LEVEL SECURITY;
-
---
--- Name: listings; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.listings ENABLE ROW LEVEL SECURITY;
 
 --
 -- Name: listings listings_delete_user; Type: POLICY; Schema: public; Owner: postgres
@@ -1993,12 +1907,6 @@ CREATE POLICY listings_update_user ON public.listings FOR UPDATE USING ((user_id
 
 
 --
--- Name: matches; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.matches ENABLE ROW LEVEL SECURITY;
-
---
 -- Name: matches matches_read_all; Type: POLICY; Schema: public; Owner: postgres
 --
 
@@ -2013,12 +1921,6 @@ CREATE POLICY matches_write_owner ON public.matches FOR INSERT WITH CHECK ((EXIS
    FROM public.listings l
   WHERE ((l.id = matches.from_listing_id) AND (l.user_id = auth.uid())))));
 
-
---
--- Name: offers; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.offers ENABLE ROW LEVEL SECURITY;
 
 --
 -- Name: offers offers_insert_buy_or_swap_by_owner; Type: POLICY; Schema: public; Owner: postgres
@@ -2126,12 +2028,6 @@ CREATE POLICY "own secrets" ON public.listing_secrets USING ((EXISTS ( SELECT 1
 
 
 --
--- Name: profiles; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
-
---
 -- Name: profiles profiles_read_all; Type: POLICY; Schema: public; Owner: postgres
 --
 
@@ -2174,12 +2070,6 @@ CREATE POLICY "public read translations" ON public.listing_translations FOR SELE
 
 
 --
--- Name: saved_listings; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.saved_listings ENABLE ROW LEVEL SECURITY;
-
---
 -- Name: saved_listings saved_read_own; Type: POLICY; Schema: public; Owner: postgres
 --
 
@@ -2194,12 +2084,6 @@ CREATE POLICY saved_write_own ON public.saved_listings USING ((user_id = auth.ui
 
 
 --
--- Name: transactions; Type: ROW SECURITY; Schema: public; Owner: postgres
---
-
-ALTER TABLE public.transactions ENABLE ROW LEVEL SECURITY;
-
---
 -- Name: transactions tx_read_involved; Type: POLICY; Schema: public; Owner: postgres
 --
 
@@ -2212,4 +2096,64 @@ CREATE POLICY tx_read_involved ON public.transactions FOR SELECT USING (((seller
 
 CREATE POLICY tx_write_seller_only ON public.transactions FOR INSERT WITH CHECK ((seller_id = auth.uid()));
 
+
+--
+-- Name: ai_import_logs; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.ai_import_logs ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: listing_images; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.listing_images ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: listing_secrets; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.listing_secrets ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: listing_translations; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.listing_translations ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: listings; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.listings ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: matches; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.matches ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: offers; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.offers ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: profiles; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: saved_listings; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.saved_listings ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: transactions; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.transactions ENABLE ROW LEVEL SECURITY;
 


### PR DESCRIPTION
## Descrizione

Il SQL editor di Supabase falliva ancora su `relation "public.matches" does not exist" anche col `SET check_function_bodies` in testa (l'editor può eseguire gli statement in contesti separati, perdendo le impostazioni di sessione). Soluzione definitiva:

- **Blocchi riordinati per dipendenza** (tipi → tabelle → sequenze → viste → funzioni → vincoli → FK → indici → trigger → policy → RLS): il file non dipende più da impostazioni di sessione né dall'ordine originale del dump.
- **Rimossa `match_listings()`**: funzione legacy **rotta anche nel DB originale** — legge `listings.embedding`, colonna che non esiste nello schema; era invocata solo dal `lib/api.js` eliminato nella PR #4.
- Senza `match_listings` non serve più **pgvector**: rimossi l'estensione dalla migrazione e il passo di abilitazione dal README.

## Test
Validazione in **modalità strict** su PostgreSQL 16 pulito: `check_function_bodies=on` forzato e SET di sessione rimossi dal file (condizioni peggiori di qualunque editor). Init + hardening applicate senza errori; verifiche post-apply: 7/7 RPC attese presenti, nessuna tabella senza RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_