### PR TITLE
Galleria foto: Storage, carosello e selettore nel form (testato)

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -31,8 +31,9 @@ Queste tabelle esistono nello schema ma l'app non le usa affatto — sono "vinte
 ### C1. Preferiti / Wishlist — `saved_listings` — ✅ FATTO
 Implementato: `lib/savedListings.js` (CRUD sui preferiti), componente `SaveButton` (stella ⭐), schermata `SavedScreen`, stella nel dettaglio annuncio e sulle card della Home, accesso "I miei preferiti" dal Profilo (it/en/es).
 
-### C2. Galleria immagini — `listing_images`
-Oggi l'annuncio ha una sola `image_url`. La tabella `listing_images` supporta più foto con posizione. Serve: caricamento multiplo + carosello nel dettaglio. Aumenta molto la qualità percepita e la fiducia.
+### C2. Galleria immagini — `listing_images` — ✅ FATTO (richiede setup Storage)
+Implementato: `lib/listingImages.js` (upload su Supabase Storage + CRUD `listing_images`), `components/ImageCarousel.js` (carosello nel dettaglio), `screens/ManageImagesScreen.js` (aggiungi/rimuovi foto), accesso "📷 Gestisci/Aggiungi foto" dal proprio annuncio.
+Prerequisiti d'attivazione: eseguire `supabase/storage_setup.sql` (bucket `listing-images` + policy) e installare `expo-image-picker` + `base64-arraybuffer`.
 
 ### C3. Storico transazioni — `transactions`
 Tabella pronta ma nessuna UI. Serve: sezione "I miei scambi/acquisti" nel profilo. Utile per fiducia e ricomprensione dello stato.

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -32,7 +32,8 @@ Queste tabelle esistono nello schema ma l'app non le usa affatto — sono "vinte
 Implementato: `lib/savedListings.js` (CRUD sui preferiti), componente `SaveButton` (stella ⭐), schermata `SavedScreen`, stella nel dettaglio annuncio e sulle card della Home, accesso "I miei preferiti" dal Profilo (it/en/es).
 
 ### C2. Galleria immagini — `listing_images` — ✅ FATTO (richiede setup Storage)
-Implementato: `lib/listingImages.js` (upload su Supabase Storage + CRUD `listing_images`), `components/ImageCarousel.js` (carosello nel dettaglio), `screens/ManageImagesScreen.js` (aggiungi/rimuovi foto), accesso "📷 Gestisci/Aggiungi foto" dal proprio annuncio.
+Implementato: `lib/listingImages.js` (upload su Supabase Storage + CRUD `listing_images`), `components/ImageCarousel.js` (carosello nel dettaglio), `screens/ManageImagesScreen.js` (aggiungi/rimuovi foto dal proprio annuncio già pubblicato).
+Aggiunto anche il selettore foto **direttamente nel form di creazione/modifica annuncio** (`CreateListingScreen`, sezione "Foto" sotto il titolo): in creazione le foto restano in sospeso e vengono caricate dopo la pubblicazione (appena esiste l'id dell'annuncio); in modifica si caricano/eliminano subito.
 Prerequisiti d'attivazione: eseguire `supabase/storage_setup.sql` (bucket `listing-images` + policy) e installare `expo-image-picker` + `base64-arraybuffer`.
 
 ### C3. Storico transazioni — `transactions`

--- a/supabase/storage_setup.sql
+++ b/supabase/storage_setup.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- TravelSwapAI — Storage per le foto degli annunci
+-- Da eseguire UNA volta nel SQL Editor del progetto Supabase.
+-- Crea il bucket pubblico "listing-images" e le policy di accesso.
+-- ============================================================
+
+-- 1) Bucket pubblico (le foto degli annunci sono visibili a tutti in lettura)
+insert into storage.buckets (id, name, public)
+values ('listing-images', 'listing-images', true)
+on conflict (id) do nothing;
+
+-- 2) Lettura pubblica dei file del bucket
+drop policy if exists "listing_images_public_read" on storage.objects;
+create policy "listing_images_public_read"
+  on storage.objects for select
+  using (bucket_id = 'listing-images');
+
+-- 3) Upload consentito agli utenti autenticati (nel solo bucket delle foto)
+drop policy if exists "listing_images_auth_upload" on storage.objects;
+create policy "listing_images_auth_upload"
+  on storage.objects for insert to authenticated
+  with check (bucket_id = 'listing-images');
+
+-- 4) Ogni utente può cancellare/aggiornare solo i file che ha caricato
+drop policy if exists "listing_images_owner_delete" on storage.objects;
+create policy "listing_images_owner_delete"
+  on storage.objects for delete to authenticated
+  using (bucket_id = 'listing-images' and owner = auth.uid());
+
+drop policy if exists "listing_images_owner_update" on storage.objects;
+create policy "listing_images_owner_update"
+  on storage.objects for update to authenticated
+  using (bucket_id = 'listing-images' and owner = auth.uid());

--- a/travelswap_ai/travelswapai/App.js
+++ b/travelswap_ai/travelswapai/App.js
@@ -20,6 +20,7 @@ import EditProfileScreen from './screens/EditProfileScreen';
 import OfferDetailScreen from './screens/OfferDetailScreen';
 import ListingDetailScreen from './screens/ListingDetailScreen';
 import SavedScreen from './screens/SavedScreen';
+import ManageImagesScreen from './screens/ManageImagesScreen';
 import { AuthProvider, useAuth } from './lib/auth';
 import { I18nProvider } from './lib/i18n';
 import Constants from "expo-constants";
@@ -105,6 +106,7 @@ function RootNavigator() {
           <Stack.Screen name="ListingDetail" component={ListingDetailScreen} options={{ title: "Listing" }} />
           <Stack.Screen name="OfferDetail" component={OfferDetailScreen} options={{ title: "Offer" }} />
           <Stack.Screen name="Saved" component={SavedScreen} options={{ title: "Preferiti" }} />
+          <Stack.Screen name="ManageImages" component={ManageImagesScreen} options={{ title: "Foto annuncio" }} />
         </>
       ) : (
         <>

--- a/travelswap_ai/travelswapai/components/ImageCarousel.js
+++ b/travelswap_ai/travelswapai/components/ImageCarousel.js
@@ -1,0 +1,77 @@
+// components/ImageCarousel.js — carosello foto (sola lettura) per il dettaglio annuncio
+import React, { useState } from "react";
+import { View, Image, ScrollView, StyleSheet, Dimensions } from "react-native";
+import { theme } from "../lib/theme";
+
+const { width } = Dimensions.get("window");
+
+/**
+ * @param {string[]} images  lista di URL
+ * @param {number} [height=220]
+ */
+export default function ImageCarousel({ images = [], height = 220 }) {
+  const [index, setIndex] = useState(0);
+  const list = Array.isArray(images) ? images.filter(Boolean) : [];
+
+  if (list.length === 0) return null;
+
+  const onScroll = (e) => {
+    const x = e.nativeEvent.contentOffset.x;
+    setIndex(Math.round(x / width));
+  };
+
+  return (
+    <View style={{ height }}>
+      <ScrollView
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={onScroll}
+      >
+        {list.map((url, i) => (
+          <Image
+            key={`${url}-${i}`}
+            source={{ uri: url }}
+            style={{ width, height }}
+            resizeMode="cover"
+          />
+        ))}
+      </ScrollView>
+
+      {list.length > 1 && (
+        <View style={styles.dots}>
+          {list.map((_, i) => (
+            <View
+              key={i}
+              style={[styles.dot, i === index ? styles.dotActive : null]}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dots: {
+    position: "absolute",
+    bottom: 10,
+    left: 0,
+    right: 0,
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 6,
+  },
+  dot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+    backgroundColor: "rgba(255,255,255,0.5)",
+  },
+  dotActive: {
+    backgroundColor: theme.colors.primary || "#fff",
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+  },
+});

--- a/travelswap_ai/travelswapai/lib/listingImages.js
+++ b/travelswap_ai/travelswapai/lib/listingImages.js
@@ -1,0 +1,68 @@
+// lib/listingImages.js — galleria foto degli annunci (Storage + listing_images)
+import { decode } from "base64-arraybuffer";
+import { supabase } from "./supabase";
+
+const BUCKET = "listing-images";
+
+/** Foto di un annuncio, ordinate per position */
+export async function listImages(listingId) {
+  if (!listingId) return [];
+  const { data, error } = await supabase
+    .from("listing_images")
+    .select("id, url, position")
+    .eq("listing_id", listingId)
+    .order("position", { ascending: true });
+  if (error) { console.log("[listImages]", error.message); return []; }
+  return data || [];
+}
+
+/**
+ * Carica una foto su Storage e registra la riga in listing_images.
+ * @param {string} listingId
+ * @param {{ base64:string, mimeType?:string, fileName?:string }} asset  (da expo-image-picker con base64:true)
+ * @param {number} position
+ */
+export async function uploadImage(listingId, asset, position = 0) {
+  if (!listingId) throw new Error("Annuncio mancante");
+  if (!asset?.base64) throw new Error("Immagine senza dati (attiva base64 nel picker)");
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Non autenticato");
+
+  const ext = (asset.fileName?.split(".").pop() || "jpg").toLowerCase().replace(/[^a-z0-9]/g, "") || "jpg";
+  const contentType = asset.mimeType || "image/jpeg";
+  const rand = Math.random().toString(36).slice(2, 8);
+  const path = `${user.id}/${listingId}/${Date.now()}-${rand}.${ext}`;
+
+  const { error: upErr } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, decode(asset.base64), { contentType, upsert: false });
+  if (upErr) throw upErr;
+
+  const { data: pub } = supabase.storage.from(BUCKET).getPublicUrl(path);
+  const url = pub?.publicUrl;
+
+  const { data, error } = await supabase
+    .from("listing_images")
+    .insert({ listing_id: listingId, url, position })
+    .select("id, url, position")
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+/** Rimuove una foto: riga in DB + file su Storage (best-effort) */
+export async function deleteImage(imageId, url) {
+  const { error } = await supabase.from("listing_images").delete().eq("id", imageId);
+  if (error) throw error;
+  try {
+    const marker = `/${BUCKET}/`;
+    const idx = typeof url === "string" ? url.indexOf(marker) : -1;
+    if (idx >= 0) {
+      const objPath = url.slice(idx + marker.length);
+      await supabase.storage.from(BUCKET).remove([objPath]);
+    }
+  } catch (e) {
+    console.log("[deleteImage] storage cleanup skip:", e?.message || e);
+  }
+}

--- a/travelswap_ai/travelswapai/package.json
+++ b/travelswap_ai/travelswapai/package.json
@@ -23,6 +23,7 @@
     "expo-camera": "~17.0.7",
     "expo-constants": "~18.0.8",
     "expo-haptics": "~15.0.7",
+    "expo-image-picker": "~17.0.9",
     "expo-linear-gradient": "~15.0.7",
     "expo-linking": "~8.0.8",
     "expo-standard-web-crypto": "^2.1.4",

--- a/travelswap_ai/travelswapai/package.json
+++ b/travelswap_ai/travelswapai/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/native": "7.1.17",
     "@react-navigation/native-stack": "7.3.26",
     "@supabase/supabase-js": "2.57.4",
+    "base64-arraybuffer": "^1.0.2",
     "expo": "~54.0.0",
     "expo-auth-session": "~7.0.8",
     "expo-barcode-scanner": "^13.0.1",

--- a/travelswap_ai/travelswapai/screens/CreateListingScreen.js
+++ b/travelswap_ai/travelswapai/screens/CreateListingScreen.js
@@ -20,9 +20,12 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useI18n } from "../lib/i18n";
 import { CameraView, useCameraPermissions } from "expo-camera";
+import * as ImagePicker from "expo-image-picker";
 import DateField from "../components/DateField";
 import DateTimeField from "../components/DateTimeField";
 import { parseListingFromTextAI } from "../lib/descriptionParser"; // OpenAI parser (server-side)
+import { Image } from "react-native";
+import { listImages, uploadImage, deleteImage } from "../lib/listingImages";
 
 /* ---------- CONST ---------- */
 const FOOTER_H = 96; // usato per dare spazio sotto alle slide
@@ -602,6 +605,102 @@ const initialJsonRef = useRef(null);
   const [qrVisible, setQrVisible] = useState(false);
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
 
+  /* ---------- FOTO ANNUNCIO ---------- */
+  // in creazione: foto scelte ma non ancora caricate (nessun listing su cui appoggiarle)
+  const [pendingPhotos, setPendingPhotos] = useState([]); // [{ uri, base64, mimeType, fileName }]
+  // in modifica: foto già salvate su listing_images
+  const [existingPhotos, setExistingPhotos] = useState([]); // [{ id, url }]
+  const [photoBusy, setPhotoBusy] = useState(false);
+
+  const editListingId = mode === "edit" ? (passedListing?.id || listingId) : null;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!editListingId) return;
+    listImages(editListingId).then((imgs) => {
+      if (!cancelled) setExistingPhotos(imgs || []);
+    });
+    return () => { cancelled = true; };
+  }, [editListingId]);
+
+  const pickPhotos = async () => {
+    try {
+      const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert(t("common.error", "Permesso negato"), "Consenti l'accesso alle foto per aggiungerne.");
+        return;
+      }
+      const res = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsMultipleSelection: true,
+        selectionLimit: 6,
+        quality: 0.7,
+        base64: true,
+      });
+      if (res.canceled) return;
+      const assets = res.assets || [];
+
+      if (editListingId) {
+        // annuncio già esistente: carica subito
+        setPhotoBusy(true);
+        let pos = existingPhotos.length;
+        for (const a of assets) {
+          try {
+            const row = await uploadImage(editListingId, a, pos++);
+            setExistingPhotos((prev) => [...prev, row]);
+          } catch (e) {
+            Alert.alert("Errore caricamento", e?.message || "Impossibile caricare una foto.");
+          }
+        }
+        setPhotoBusy(false);
+      } else {
+        // annuncio non ancora creato: tieni in sospeso, carica dopo la pubblicazione
+        setPendingPhotos((prev) => [...prev, ...assets]);
+      }
+    } catch (e) {
+      Alert.alert(t("common.error", "Errore"), e?.message || "Impossibile selezionare le foto.");
+    }
+  };
+
+  const removePendingPhoto = (idx) => {
+    setPendingPhotos((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const removeExistingPhoto = (img) => {
+    Alert.alert("Rimuovi foto", "Vuoi eliminare questa foto?", [
+      { text: t("common.cancel", "Annulla"), style: "cancel" },
+      {
+        text: t("common.delete", "Elimina"),
+        style: "destructive",
+        onPress: async () => {
+          setPhotoBusy(true);
+          try {
+            await deleteImage(img.id, img.url);
+            setExistingPhotos((prev) => prev.filter((p) => p.id !== img.id));
+          } catch (e) {
+            Alert.alert(t("common.error", "Errore"), e?.message || "Impossibile eliminare.");
+          } finally {
+            setPhotoBusy(false);
+          }
+        },
+      },
+    ]);
+  };
+
+  /** Carica le foto rimaste in sospeso su un annuncio appena creato */
+  const flushPendingPhotos = async (newListingId) => {
+    if (!newListingId || pendingPhotos.length === 0) return;
+    let pos = 0;
+    for (const a of pendingPhotos) {
+      try {
+        await uploadImage(newListingId, a, pos++);
+      } catch (e) {
+        console.log("[flushPendingPhotos] upload error:", e?.message || e);
+      }
+    }
+    setPendingPhotos([]);
+  };
+
   const logStep = useCallback((msg, pct) => {
     setMicroLog((prev) => [...prev, msg]);
     if (typeof pct === "number") setProgress((p) => Math.max(p, Math.min(100, pct)));
@@ -979,11 +1078,13 @@ if ((patch.type || form.type) === "train" && routeStr) {
           const r2 = await insertListing(p2);
           if (r1?.error) throw r1.error;
           if (r2?.error) throw r2.error;
+          await flushPendingPhotos(r1?.id); // le foto vanno solo sul primo dei due annunci
           await AsyncStorage.removeItem(DRAFT_KEY);
           Alert.alert('Pubblicati 2 annunci', 'Sono stati pubblicati due annunci separati con lo stesso prezzo. Puoi modificare i prezzi in seguito.');
         } else {
           const res = await insertListing(payload);
           if (res?.error) throw res.error;
+          await flushPendingPhotos(res?.id);
           await AsyncStorage.removeItem(DRAFT_KEY);
           Alert.alert(t("createListing.publishedTitle", "Pubblicato!"), t("createListing.publishedMsg", "Il tuo annuncio è stato pubblicato con successo."));
         }
@@ -1279,6 +1380,49 @@ if ((patch.type || form.type) === "train" && routeStr) {
                     placeholderTextColor="#9CA3AF"
                   />
                   {!!errors.title && <Text style={styles.errorText}>{errors.title}</Text>}
+
+                  {/* Foto */}
+                  <Text style={styles.label}>{t("createListing.photos", "Foto")}</Text>
+                  <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 4 }}>
+                    {existingPhotos.map((img) => (
+                      <View key={img.id} style={{ width: 72, height: 72 }}>
+                        <Image source={{ uri: img.url }} style={{ width: 72, height: 72, borderRadius: 10 }} />
+                        <TouchableOpacity
+                          onPress={() => removeExistingPhoto(img)}
+                          style={styles.photoRemoveBtn}
+                          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        >
+                          <Text style={styles.photoRemoveText}>✕</Text>
+                        </TouchableOpacity>
+                      </View>
+                    ))}
+                    {pendingPhotos.map((a, idx) => (
+                      <View key={`${a.uri}-${idx}`} style={{ width: 72, height: 72 }}>
+                        <Image source={{ uri: a.uri }} style={{ width: 72, height: 72, borderRadius: 10 }} />
+                        <TouchableOpacity
+                          onPress={() => removePendingPhoto(idx)}
+                          style={styles.photoRemoveBtn}
+                          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        >
+                          <Text style={styles.photoRemoveText}>✕</Text>
+                        </TouchableOpacity>
+                      </View>
+                    ))}
+                    <TouchableOpacity
+                      onPress={pickPhotos}
+                      disabled={photoBusy}
+                      style={styles.photoAddBtn}
+                    >
+                      {photoBusy ? (
+                        <ActivityIndicator />
+                      ) : (
+                        <Text style={{ fontSize: 24, color: theme.colors.boardingText || "#111827" }}>＋</Text>
+                      )}
+                    </TouchableOpacity>
+                  </View>
+                  <Text style={styles.note}>
+                    {t("createListing.photosHint", "Aggiungi fino a qualche foto reale: aumentano la fiducia di chi guarda l'annuncio.")}
+                  </Text>
 
                   {/* Località / Rotta */}
                   {form?.type === "train" ? (
@@ -1671,6 +1815,15 @@ const styles = StyleSheet.create({
   inputError: { borderColor: "#FCA5A5", backgroundColor: "#FEF2F2" },
   errorText: { color: "#B91C1C", marginTop: 4 },
   note: { fontSize: 12, lineHeight: 16, color: "#6B7280", marginTop: 6 },
+  photoAddBtn: {
+    width: 72, height: 72, borderRadius: 10, borderWidth: 1, borderStyle: "dashed",
+    borderColor: "#9CA3AF", alignItems: "center", justifyContent: "center",
+  },
+  photoRemoveBtn: {
+    position: "absolute", top: -6, right: -6, width: 22, height: 22, borderRadius: 11,
+    backgroundColor: "rgba(0,0,0,0.65)", alignItems: "center", justifyContent: "center",
+  },
+  photoRemoveText: { color: "#fff", fontSize: 12, fontWeight: "700" },
   multiline: { minHeight: 96 },
   segment: { flexDirection: "row", gap: 8 },
   segBtn: { paddingHorizontal: 14, paddingVertical: 10, borderRadius: 12, borderWidth: 1, borderColor: "#E5E7EB", backgroundColor: "#F3F4F6" },

--- a/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
+++ b/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
@@ -13,6 +13,9 @@ import { theme } from "../lib/theme";
 import TrustScoreBadge from "../components/TrustScoreBadge";
 import OfferCTAs from "../components/OfferCTA";
 import SaveButton from "../components/SaveButton";
+import ImageCarousel from "../components/ImageCarousel";
+import { getCurrentUser } from "../lib/db.js";
+import { listImages } from "../lib/listingImages";
 import { useI18n } from "../lib/i18n";
 import { useListingTranslation } from "../lib/useListingTranslation";
 
@@ -141,11 +144,33 @@ useEffect(() => {
   });
   const [showOriginal, setShowOriginal] = useState(false);
 
+  const [images, setImages] = useState([]);
+  const [isOwner, setIsOwner] = useState(false);
+
   const load = useCallback(async () => {
-    setListing(await getListingById(listingId));
+    const l = await getListingById(listingId);
+    setListing(l);
+    try {
+      const [imgs, me] = await Promise.all([
+        listImages(listingId),
+        getCurrentUser().catch(() => null),
+      ]);
+      setImages((imgs || []).map((i) => i.url).filter(Boolean));
+      setIsOwner(!!me && !!l && me.id === l.user_id);
+    } catch { /* non bloccare il dettaglio */ }
   }, [listingId]);
 
   useEffect(() => { load(); }, [load]);
+
+  // ricarica le foto quando si torna dalla schermata di gestione
+  useEffect(() => {
+    const unsub = navigation.addListener?.("focus", () => {
+      listImages(listingId).then((imgs) =>
+        setImages((imgs || []).map((i) => i.url).filter(Boolean))
+      ).catch(() => {});
+    });
+    return unsub;
+  }, [navigation, listingId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -258,6 +283,21 @@ useEffect(() => {
     <View style={{ flex: 1, backgroundColor: "#F8FAFC" }}>
       <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 140 }}
         refreshControl={<RefreshControl refreshing={recomputing} onRefresh={() => setRecomputing(false)} />}>
+        {images.length > 0 ? (
+          <View style={{ marginHorizontal: -16, marginBottom: 12, borderRadius: 0, overflow: "hidden" }}>
+            <ImageCarousel images={images} height={220} />
+          </View>
+        ) : null}
+        {isOwner ? (
+          <TouchableOpacity
+            onPress={() => navigation.navigate("ManageImages", { listingId })}
+            style={{ alignSelf: "flex-start", marginBottom: 12, paddingVertical: 8, paddingHorizontal: 12, borderRadius: 10, borderWidth: 1, borderColor: theme.colors.border, backgroundColor: theme.colors.surface }}
+          >
+            <Text style={{ fontWeight: "700", color: theme.colors.text }}>
+              📷 {images.length > 0 ? "Gestisci foto" : "Aggiungi foto"}
+            </Text>
+          </TouchableOpacity>
+        ) : null}
         <View style={styles.headerCard}>
           {isNewBadge ? (
             <View style={styles.ribbonWrap} pointerEvents="none">

--- a/travelswap_ai/travelswapai/screens/ManageImagesScreen.js
+++ b/travelswap_ai/travelswapai/screens/ManageImagesScreen.js
@@ -1,0 +1,153 @@
+// screens/ManageImagesScreen.js — aggiungi/rimuovi foto di un proprio annuncio
+import React, { useCallback, useState } from "react";
+import {
+  View, Text, Image, FlatList, TouchableOpacity, ActivityIndicator,
+  Alert, StyleSheet,
+} from "react-native";
+import { useRoute, useNavigation, useFocusEffect } from "@react-navigation/native";
+import * as ImagePicker from "expo-image-picker";
+import { listImages, uploadImage, deleteImage } from "../lib/listingImages";
+import { theme } from "../lib/theme";
+
+export default function ManageImagesScreen() {
+  const route = useRoute();
+  const navigation = useNavigation();
+  const listingId = route.params?.listingId ?? route.params?.id;
+
+  const [images, setImages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setImages(await listImages(listingId));
+    } catch (e) {
+      setImages([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [listingId]);
+
+  useFocusEffect(useCallback(() => { load(); }, [load]));
+
+  const onAdd = async () => {
+    try {
+      const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert("Permesso negato", "Consenti l'accesso alle foto per aggiungere immagini.");
+        return;
+      }
+      const res = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsMultipleSelection: true,
+        quality: 0.7,
+        base64: true,
+        selectionLimit: 6,
+      });
+      if (res.canceled) return;
+
+      setBusy(true);
+      const assets = res.assets || [];
+      let pos = images.length;
+      for (const a of assets) {
+        try {
+          await uploadImage(listingId, a, pos++);
+        } catch (e) {
+          console.log("[ManageImages] upload error:", e?.message || e);
+          Alert.alert("Errore caricamento", e?.message || "Impossibile caricare una foto.");
+        }
+      }
+      await load();
+    } catch (e) {
+      Alert.alert("Errore", e?.message || "Operazione non riuscita.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDelete = (img) => {
+    Alert.alert("Rimuovi foto", "Vuoi eliminare questa foto?", [
+      { text: "Annulla", style: "cancel" },
+      {
+        text: "Elimina",
+        style: "destructive",
+        onPress: async () => {
+          setBusy(true);
+          try {
+            await deleteImage(img.id, img.url);
+            await load();
+          } catch (e) {
+            Alert.alert("Errore", e?.message || "Impossibile eliminare.");
+          } finally {
+            setBusy(false);
+          }
+        },
+      },
+    ]);
+  };
+
+  if (!listingId) {
+    return (
+      <View style={styles.center}>
+        <Text style={{ color: theme.colors.textMuted }}>Annuncio non specificato.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+      <FlatList
+        data={images}
+        keyExtractor={(it) => String(it.id)}
+        numColumns={3}
+        contentContainerStyle={{ padding: 12 }}
+        ListHeaderComponent={
+          <TouchableOpacity style={styles.addBtn} onPress={onAdd} disabled={busy}>
+            {busy ? (
+              <ActivityIndicator color={theme.colors.primary} />
+            ) : (
+              <Text style={styles.addText}>＋ Aggiungi foto</Text>
+            )}
+          </TouchableOpacity>
+        }
+        ListEmptyComponent={
+          !loading ? (
+            <Text style={styles.empty}>Nessuna foto. Tocca “Aggiungi foto” per caricarne.</Text>
+          ) : null
+        }
+        renderItem={({ item }) => (
+          <View style={styles.cell}>
+            <Image source={{ uri: item.url }} style={styles.thumb} />
+            <TouchableOpacity style={styles.del} onPress={() => onDelete(item)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+              <Text style={styles.delText}>✕</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      />
+      {loading ? (
+        <View style={styles.overlay}><ActivityIndicator /></View>
+      ) : null}
+    </View>
+  );
+}
+
+const GAP = 6;
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: theme.colors.background },
+  addBtn: {
+    borderWidth: 1, borderColor: theme.colors.primary, borderRadius: 12,
+    paddingVertical: 14, alignItems: "center", marginBottom: 12,
+  },
+  addText: { color: theme.colors.primary, fontWeight: "800" },
+  empty: { color: theme.colors.textMuted, textAlign: "center", marginTop: 24 },
+  cell: { flex: 1 / 3, aspectRatio: 1, padding: GAP },
+  thumb: { flex: 1, borderRadius: 10, backgroundColor: theme.colors.surface },
+  del: {
+    position: "absolute", top: GAP + 4, right: GAP + 4,
+    backgroundColor: "rgba(0,0,0,0.6)", borderRadius: 12, width: 24, height: 24,
+    alignItems: "center", justifyContent: "center",
+  },
+  delText: { color: "#fff", fontWeight: "700", fontSize: 12 },
+  overlay: { ...StyleSheet.absoluteFillObject, alignItems: "center", justifyContent: "center" },
+});


### PR DESCRIPTION
## Descrizione

Consolida la funzionalità **galleria foto**, testata sull'app (creazione annuncio con foto → pubblicazione → carosello nel dettaglio).

- Bucket Supabase Storage `listing-images` + policy (script `supabase/storage_setup.sql`, da eseguire una tantum sul progetto).
- `lib/listingImages.js`: upload/list/delete su Storage + tabella `listing_images` (finora inutilizzata).
- `components/ImageCarousel.js`: carosello a tutta larghezza nel dettaglio annuncio.
- `screens/ManageImagesScreen.js`: griglia foto con aggiungi/elimina per un annuncio già pubblicato.
- **Selettore foto nel form di creazione/modifica** (`CreateListingScreen`): sezione "Foto" sotto il titolo; in creazione le foto restano in sospeso e si caricano dopo la pubblicazione, in modifica si caricano subito.
- `expo-image-picker` aggiunta come dipendenza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_