### PR TITLE
Restyling "Swap Gold": accento oro + ombre morbide (non ancora testato su device)

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -57,6 +57,22 @@ Raccogliere tratte/città preferite in onboarding per alimentare da subito il ma
 
 ---
 
+## F. Restyling "Swap Gold" — ✅ prima tranche applicata
+
+Direzione scelta dopo confronto visivo di 3 varianti (indigo raffinato / indigo saturo / **indigo + oro**): oro come accento dei CTA principali — richiama la moneta 3D dell'onboarding e il concetto di scambio di valore del nome "Swap".
+
+- `lib/theme.js`: nuovi token `accent`/`accentSoft`/`accentOn` (oro + inchiostro indigo abbinato); `primary` raffinato ma **ruolo invariato** (resta lo sfondo chiaro di badge/pill, per non rompere i ~25 punti che lo usano già); aggiunta `shadow.lg` e tipografia con letter-spacing.
+- `components/ui/Button.js`: CTA primario ora oro con testo indigo e ombra dorata; variante `outline` corretta (prima aveva un bug di contrasto: testo/bordo quasi invisibili).
+- `components/ui/Input.js`: bordo dorato al focus.
+- `components/SaveButton.js`, `components/ImageCarousel.js`, `screens/ManageImagesScreen.js`: allineati allo stesso oro (prima usavano tonalità scollegate o poco leggibili).
+- Pulsante "Pubblica/Modifica annuncio" (`CreateListingScreen`): oro con ombra dedicata — è il CTA più importante dell'app.
+- `MatchCard`: badge "💫 reciproco" passato da un blu generico all'oro (è un momento "premium" della UI, i match forti).
+- Card di Home/Offerte/Profilo: da bordo piatto grigio a ombra morbida coerente col tema (stesso ~1 riga di stile per file).
+
+Non ancora fatto (prossimi passi naturali): font custom (Sora/Plus Jakarta Sans — richiede installare `expo-font`, rimandato per non sommare un altro giro di installazione dopo quello di `expo-image-picker`), estensione dell'ombra morbida alle card rimanenti, unificazione delle 3 librerie di icone su una sola.
+
+---
+
 ## E. Qualità del codice / infrastruttura
 
 - **i18n incompleto**: molte stringhe sono hardcoded in italiano fuori dal dizionario (es. schermata login, alert). Completarle abilita davvero EN/ES.

--- a/travelswap_ai/travelswapai/components/ImageCarousel.js
+++ b/travelswap_ai/travelswapai/components/ImageCarousel.js
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(255,255,255,0.5)",
   },
   dotActive: {
-    backgroundColor: theme.colors.primary || "#fff",
+    backgroundColor: theme.colors.accent,
     width: 9,
     height: 9,
     borderRadius: 5,

--- a/travelswap_ai/travelswapai/components/MatchCard.js
+++ b/travelswap_ai/travelswapai/components/MatchCard.js
@@ -31,14 +31,18 @@ export default function MatchCard({ item, onPress }) {
 }
 
 const s = StyleSheet.create({
-  card:{ borderWidth:1, borderColor:"#E5E7EB", borderRadius:12, padding:12, backgroundColor:"#fff" },
+  card:{
+    borderWidth:1, borderColor:theme.colors.border, borderRadius:theme.radius.lg,
+    padding:14, backgroundColor:theme.colors.surface, ...theme.shadow.sm,
+  },
   topRow:{ flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
-  title:{ fontWeight:"800", flex:1, marginRight:8 },
-  sub:{ color:"#6B7280", marginTop:4 },
-  meta:{ color:"#111827", marginTop:6, fontWeight:"700" },
-  expl:{ color:"#374151", marginTop:8 },
+  title:{ fontWeight:"800", flex:1, marginRight:8, color: theme.colors.text },
+  sub:{ color:theme.colors.textMuted, marginTop:4 },
+  meta:{ color:theme.colors.text, marginTop:6, fontWeight:"700" },
+  expl:{ color:theme.colors.textMuted, marginTop:8 },
   bottomRow:{ flexDirection:"row", justifyContent:"space-between", marginTop:8 },
-  small:{ fontSize:12, color:"#6B7280" },
-  badge:{ paddingHorizontal:8, paddingVertical:2, borderRadius:999, backgroundColor:"#EAF7FF", borderWidth:1, borderColor:"#BAE6FD" },
-  badgeTxt:{ fontSize:12, color:"#0369A1", fontWeight:"700" },
+  small:{ fontSize:12, color:theme.colors.textMuted },
+  // badge oro per il match reciproco: un momento "premium" della UI, non un blu generico
+  badge:{ paddingHorizontal:8, paddingVertical:2, borderRadius:999, backgroundColor:theme.colors.accentSoft, borderWidth:1, borderColor:theme.colors.accent },
+  badgeTxt:{ fontSize:12, color:theme.colors.accentOn, fontWeight:"700" },
 });

--- a/travelswap_ai/travelswapai/components/SaveButton.js
+++ b/travelswap_ai/travelswapai/components/SaveButton.js
@@ -5,7 +5,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { isSaved, toggleSaved } from "../lib/savedListings";
 import { theme } from "../lib/theme";
 
-const SAVED_COLOR = "#f5a623";
+const SAVED_COLOR = theme.colors.accent;
 
 /**
  * @param {string} listingId

--- a/travelswap_ai/travelswapai/components/ui/Button.js
+++ b/travelswap_ai/travelswapai/components/ui/Button.js
@@ -26,18 +26,29 @@ export default function Button({
   };
 
   const variants = {
-    primary: { backgroundColor: theme.colors.primary },
+    // Accento oro: riservato al CTA principale, coerente con la moneta
+    // dell'onboarding e col concetto di scambio di valore dell'app.
+    primary: { backgroundColor: theme.colors.accent },
     secondary: { backgroundColor: theme.colors.surfaceMuted, borderWidth: 1, borderColor: theme.colors.border },
-    outline: { backgroundColor: "transparent", borderWidth: 1, borderColor: theme.colors.primary },
+    outline: { backgroundColor: "transparent", borderWidth: 1.4, borderColor: theme.colors.accent },
     subtle: { backgroundColor: "transparent" },
   };
 
   const textVar = {
-    primary: { color: theme.colors.boardingText, fontWeight: "800" },
+    // Testo indigo sopra il riempimento oro: l'oro non va mai usato come
+    // colore di testo (contrasto insufficiente su sfondo chiaro).
+    primary: { color: theme.colors.accentOn, fontWeight: "800" },
     secondary: { color: theme.colors.text, fontWeight: "800" },
-    outline: { color: theme.colors.primary, fontWeight: "800" },
+    outline: { color: theme.colors.text, fontWeight: "800" },
     subtle: { color: theme.colors.text, fontWeight: "700" },
   };
+
+  // Ombra leggermente dorata sotto il CTA principale: dà "peso" al pulsante
+  // più importante della schermata invece di una generica ombra neutra.
+  const shadowVar =
+    variant === "primary"
+      ? { ...theme.shadow.md, shadowColor: theme.colors.accent, shadowOpacity: 0.35 }
+      : theme.shadow.sm;
 
   const handle = () => {
     if (disabled || loading) return;
@@ -48,12 +59,19 @@ export default function Button({
   return (
     <Pressable
       onPress={handle}
-      style={[base, variants[variant], theme.shadow.sm, disabled && { opacity: 0.6 }, style]}
+      style={({ pressed }) => [
+        base,
+        variants[variant],
+        shadowVar,
+        disabled && { opacity: 0.6 },
+        pressed && !disabled && !loading && { opacity: 0.88 },
+        style,
+      ]}
     >
       <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
         {leftIcon || null}
         {loading ? (
-          <ActivityIndicator color={variant === "primary" ? "#fff" : theme.colors.text} />
+          <ActivityIndicator color={variant === "primary" ? theme.colors.accentOn : theme.colors.text} />
         ) : (
           <Text style={[textVar[variant], textStyle]}>{title}</Text>
         )}

--- a/travelswap_ai/travelswapai/components/ui/Input.js
+++ b/travelswap_ai/travelswapai/components/ui/Input.js
@@ -14,8 +14,8 @@ export default function Input({ label, error, style, inputStyle, ...props }) {
       <View
         style={[
           {
-            borderWidth: 1,
-            borderColor: focused ? theme.colors.text : theme.colors.border,
+            borderWidth: focused ? 1.4 : 1,
+            borderColor: focused ? theme.colors.accent : theme.colors.border,
             backgroundColor: theme.colors.surface,
             borderRadius: theme.radius.lg,
             paddingHorizontal: 12,

--- a/travelswap_ai/travelswapai/lib/theme.js
+++ b/travelswap_ai/travelswapai/lib/theme.js
@@ -1,33 +1,51 @@
+// Palette "Swap Gold": indigo profondo come inchiostro/brand, oro come
+// accento delle azioni principali (richiama la moneta 3D dell'onboarding
+// e il concetto di scambio di valore alla base di TravelSwap).
 export const theme = {
   colors: {
-    background: "#F8FAFC",
+    background: "#F9F8FC",
     surface: "#FFFFFF",
-    surfaceMuted: "#F3F4F6",
-    border: "#E5E7EB",
-    text: "#1D2B6B",
-    textMuted: "#6B7280",
-   primary: "#E7EEFF",      // Indigo 600
-   primaryMuted: "#6366F1", // Indigo 500/400 per hover/pressed
+    surfaceMuted: "#F4F1F8",
+    border: "#E6E2EE",
+    text: "#1B2159",
+    textMuted: "#6B6F92",
+
+    // "primary" resta il token storico: sfondo chiaro lavanda per badge,
+    // pill di selezione, avatar — sempre abbinato a testo scuro sopra
+    // (boardingText/text). Ruolo invariato, solo la tinta è raffinata.
+    primary: "#E4E1F7",
+    primaryMuted: "#C9C4EE", // variante più marcata per stati pressed/selected
+
+    // Accento oro: riservato ai CTA principali e ai momenti "premium".
+    // Non va mai usato come colore di testo su sfondo chiaro (contrasto
+    // insufficiente) — per il testo sopra un riempimento oro usare accentOn.
+    accent: "#C99A2E",
+    accentSoft: "#FBF0D9",
+    accentOn: "#1B2159",
+
     success: "#16A34A",
     danger: "#DC2626",
     warning: "#F59E0B",
     info: "#2563EB",
-    // UI CTA color inspired by screenshot "Boarding passes"
-    boardingBg: "#E7EEFF",
-    boardingText: "#1D2B6B",
-    boardingBgPressed: "#D6E0FF",
+
+    // UI CTA color "Boarding pass" (sfondi lavanda tenue per badge/pill secondarie)
+    boardingBg: "#EDEBFA",
+    boardingText: "#1B2159",
+    boardingBgPressed: "#DFDAF3",
   },
   radius: { sm: 10, md: 14, lg: 18, xl: 24, pill: 999 },
   spacing: { xs: 6, sm: 10, md: 14, lg: 18, xl: 24, xxl: 32 },
   shadow: {
     sm: { shadowColor: "#0F172A", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 6, elevation: 2 },
     md: { shadowColor: "#0F172A", shadowOffset: { width: 0, height: 6 }, shadowOpacity: 0.08, shadowRadius: 16, elevation: 6 },
+    lg: { shadowColor: "#0F172A", shadowOffset: { width: 0, height: 14 }, shadowOpacity: 0.14, shadowRadius: 28, elevation: 10 },
   },
   typography: {
-    title: { fontSize: 22, fontWeight: "800" },
-    subtitle: { fontSize: 16, fontWeight: "600", color: "#6B7280" },
-    body: { fontSize: 16, color: "#0F172A" },
-    small: { fontSize: 12, color: "#6B7280" },
+    title: { fontSize: 26, fontWeight: "800", letterSpacing: -0.3 },
+    sectionTitle: { fontSize: 17, fontWeight: "800", letterSpacing: -0.2 },
+    subtitle: { fontSize: 16, fontWeight: "600", color: "#6B6F92" },
+    body: { fontSize: 16, color: "#1B2159" },
+    small: { fontSize: 12, color: "#6B6F92" },
   }
 };
 export default theme;

--- a/travelswap_ai/travelswapai/screens/CreateListingScreen.js
+++ b/travelswap_ai/travelswapai/screens/CreateListingScreen.js
@@ -1650,11 +1650,11 @@ if ((patch.type || form.type) === "train" && routeStr) {
 
             {slideIndex === 0 ? (
               <TouchableOpacity onPress={onNextPress} style={[styles.footerBtn, styles.footerPrimary]}>
-                <Text style={[styles.footerText, { color: theme.colors.boardingText }]}>{t("common.next", "Avanti")}</Text>
+                <Text style={[styles.footerText, { color: theme.colors.accentOn }]}>{t("common.next", "Avanti")}</Text>
               </TouchableOpacity>
             ) : (
               <TouchableOpacity onPress={onPublishOrSave} disabled={publishing} style={[styles.footerBtn, styles.footerPrimary]}>
-                {publishing ? <ActivityIndicator color={theme.colors.boardingText} /> : <Text style={[styles.footerText, { color: theme.colors.boardingText }]}>{mode === "edit" ? "Modifica" : t("createListing.publish", "Pubblica")}</Text>}
+                {publishing ? <ActivityIndicator color={theme.colors.accentOn} /> : <Text style={[styles.footerText, { color: theme.colors.accentOn }]}>{mode === "edit" ? "Modifica" : t("createListing.publish", "Pubblica")}</Text>}
               </TouchableOpacity>
             )}
           </View>
@@ -1847,9 +1847,9 @@ const styles = StyleSheet.create({
   },
   footerBtn: { flex: 1, alignItems: "center", justifyContent: "center", paddingVertical: 16, borderRadius: 14 },
   footerPrimary: {
-    backgroundColor: theme.colors.primary,
-    shadowColor: "#000", shadowOpacity: 0.08, shadowRadius: 8, shadowOffset: {width:0, height:4},
-    elevation: 3
+    backgroundColor: theme.colors.accent,
+    shadowColor: theme.colors.accent, shadowOpacity: 0.35, shadowRadius: 10, shadowOffset: {width:0, height:5},
+    elevation: 4
   },
   footerGhost: {
     backgroundColor: "#F3F4F6", borderWidth: 1, borderColor: "#E5E7EB",

--- a/travelswap_ai/travelswapai/screens/HomeScreen.js
+++ b/travelswap_ai/travelswapai/screens/HomeScreen.js
@@ -230,7 +230,10 @@ const styles = StyleSheet.create({
   tabActive: { backgroundColor: theme.colors.primary, borderColor: "#111827" },
   tabText: { fontWeight: "700", color: theme.colors.boardingText },
   tabTextActive: { color: theme.colors.boardingText },
-  card: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, padding: 12, backgroundColor: "#fff" },
+  card: {
+    borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
+    padding: 14, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
   cardTitle: { fontWeight: "800", color: theme.colors.boardingText },
   cardSub: { color: "#6B7280", marginTop: 4 },
   cardMeta: { color: "#111827", marginTop: 6, fontWeight: "600" },

--- a/travelswap_ai/travelswapai/screens/ManageImagesScreen.js
+++ b/travelswap_ai/travelswapai/screens/ManageImagesScreen.js
@@ -105,7 +105,7 @@ export default function ManageImagesScreen() {
         ListHeaderComponent={
           <TouchableOpacity style={styles.addBtn} onPress={onAdd} disabled={busy}>
             {busy ? (
-              <ActivityIndicator color={theme.colors.primary} />
+              <ActivityIndicator color={theme.colors.accent} />
             ) : (
               <Text style={styles.addText}>＋ Aggiungi foto</Text>
             )}
@@ -136,10 +136,10 @@ const GAP = 6;
 const styles = StyleSheet.create({
   center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: theme.colors.background },
   addBtn: {
-    borderWidth: 1, borderColor: theme.colors.primary, borderRadius: 12,
+    borderWidth: 1.4, borderColor: theme.colors.accent, borderStyle: "dashed", borderRadius: 12,
     paddingVertical: 14, alignItems: "center", marginBottom: 12,
   },
-  addText: { color: theme.colors.primary, fontWeight: "800" },
+  addText: { color: theme.colors.accentOn, fontWeight: "800" },
   empty: { color: theme.colors.textMuted, textAlign: "center", marginTop: 24 },
   cell: { flex: 1 / 3, aspectRatio: 1, padding: GAP },
   thumb: { flex: 1, borderRadius: 10, backgroundColor: theme.colors.surface },

--- a/travelswap_ai/travelswapai/screens/OffersScreen.js
+++ b/travelswap_ai/travelswapai/screens/OffersScreen.js
@@ -224,7 +224,10 @@ const s = StyleSheet.create({
   segmActive: { backgroundColor: theme.colors.primary, borderColor: "#111827" },
   segmTxt: { fontWeight: "800", color: theme.colors.boardingText },
   segmTxtActive: { color: theme.colors.boardingText },
-  card: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, padding: 12, backgroundColor: "#fff" },
+  card: {
+    borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
+    padding: 14, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
   title: { fontWeight: "800" },
   sub: { color: "#6B7280", marginTop: 4 },
   meta: { color: "#111827", marginTop: 4, fontWeight: "600" },

--- a/travelswap_ai/travelswapai/screens/ProfileScreen.js
+++ b/travelswap_ai/travelswapai/screens/ProfileScreen.js
@@ -528,7 +528,10 @@ const styles = StyleSheet.create({
   sectionTitle: { fontSize: 16, fontWeight: "800", color: theme.colors.boardingText },
 
   // === CARDS LISTA ANNUNCI (stile HomeScreen)
-  listCard: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, padding: 12, backgroundColor: "#fff" },
+  listCard: {
+    borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
+    padding: 14, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
   listCardTitle: { fontWeight: "800", color: theme.colors.boardingText },
   listCardSub: { color: "#6B7280", marginTop: 4 },
   listCardMeta: { color: "#111827", marginTop: 6, fontWeight: "600" },


### PR DESCRIPTION
## Descrizione

Prima tranche del restyling "premium senza stravolgere": direzione scelta dal confronto visivo di 3 varianti palette (indigo raffinato / indigo saturo / **indigo + oro**).

- `theme.js`: nuovi token `accent`/`accentSoft`/`accentOn` (oro + inchiostro indigo abbinato); `primary` raffinato ma ruolo invariato (evita di rompere i ~25 punti dell'app che lo usano già come sfondo chiaro di badge/pill).
- CTA principali (Login, Pubblica annuncio) → oro con ombra dedicata.
- Fix di un bug di contrasto pre-esistente sulla variante `outline` del Button condiviso (testo/bordo quasi invisibili).
- Card di Home/Offerte/Profilo/MatchCard: da bordo piatto grigio a ombra morbida.
- Badge "reciproco" nei match: da blu generico a oro.

⚠️ **Nota**: questa modifica è validata solo per sintassi (nessun errore di build) — non ancora verificata visivamente su device dall'utente. Vedi `docs/IMPROVEMENTS.md` sezione F per i dettagli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_