### PR TITLE
Font Plus Jakarta Sans per i titoli (non ancora testato su device)

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -69,7 +69,9 @@ Direzione scelta dopo confronto visivo di 3 varianti (indigo raffinato / indigo 
 - `MatchCard`: badge "💫 reciproco" passato da un blu generico all'oro (è un momento "premium" della UI, i match forti).
 - Card di Home/Offerte/Profilo: da bordo piatto grigio a ombra morbida coerente col tema (stesso ~1 riga di stile per file).
 
-Non ancora fatto (prossimi passi naturali): font custom (Sora/Plus Jakarta Sans — richiede installare `expo-font`, rimandato per non sommare un altro giro di installazione dopo quello di `expo-image-picker`), estensione dell'ombra morbida alle card rimanenti, unificazione delle 3 librerie di icone su una sola.
+- ✅ **Font custom**: caricato **Plus Jakarta Sans** (pesi 600/700/800) via `expo-font` + `@expo-google-fonts/plus-jakarta-sans`, con gate di caricamento in `App.js`. Applicato ai 4 "hero moment" più visibili: wordmark `HeaderLogo`, titoli onboarding, headline "Benvenuto" del login, titolo annuncio nel dettaglio. Il resto del testo (corpo, label, bottoni) resta sul font di sistema — coppia display+body deliberata, non un rifacimento totale.
+
+Non ancora fatto (prossimi passi naturali): estensione dell'ombra morbida alle card rimanenti, unificazione delle 3 librerie di icone su una sola, estensione del font ai titoli di sezione rimanenti.
 
 ---
 

--- a/travelswap_ai/travelswapai/App.js
+++ b/travelswap_ai/travelswapai/App.js
@@ -24,6 +24,7 @@ import ManageImagesScreen from './screens/ManageImagesScreen';
 import { AuthProvider, useAuth } from './lib/auth';
 import { I18nProvider } from './lib/i18n';
 import Constants from "expo-constants";
+import { useFonts, PlusJakartaSans_600SemiBold, PlusJakartaSans_700Bold, PlusJakartaSans_800ExtraBold } from '@expo-google-fonts/plus-jakarta-sans';
 
 const Stack = createNativeStackNavigator();
 
@@ -122,6 +123,23 @@ function RootNavigator() {
 
 export default function App() {
   console.log("[WHOAMI] owner =", Constants.expoConfig?.owner, "slug =", Constants.expoConfig?.slug, "name =", Constants.expoConfig?.name);
+
+  // Font dei titoli (Plus Jakarta Sans): caricato una volta all'avvio,
+  // il testo di sistema resta invariato per tutto il resto dell'app.
+  const [fontsLoaded] = useFonts({
+    PlusJakartaSans_600SemiBold,
+    PlusJakartaSans_700Bold,
+    PlusJakartaSans_800ExtraBold,
+  });
+
+  if (!fontsLoaded) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: theme.colors.background }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
   return (
     <ErrorBoundary>
       <AuthProvider>

--- a/travelswap_ai/travelswapai/components/HeaderLogo.js
+++ b/travelswap_ai/travelswapai/components/HeaderLogo.js
@@ -99,7 +99,7 @@ export default function HeaderLogo() {
 
         {/* Testo con shimmer overlay */}
         <View style={{ position: "relative", overflow: "hidden" }}>
-          <Text style={{ fontWeight: "800", fontSize: 16, color: theme.colors.boardingText }}>
+          <Text style={{ fontFamily: theme.fonts.headingExtraBold, fontSize: 16, color: theme.colors.boardingText }}>
             TravelSwapAI
           </Text>
           {/* Luccichio diagonale che scorre sopra il testo */}

--- a/travelswap_ai/travelswapai/lib/theme.js
+++ b/travelswap_ai/travelswapai/lib/theme.js
@@ -33,6 +33,14 @@ export const theme = {
     boardingText: "#1B2159",
     boardingBgPressed: "#DFDAF3",
   },
+  // Font dei titoli (Plus Jakarta Sans, caricato in App.js). Il testo
+  // corrente resta sul font di sistema: il display face si usa solo
+  // per i titoli, con misura.
+  fonts: {
+    headingSemibold: "PlusJakartaSans_600SemiBold",
+    headingBold: "PlusJakartaSans_700Bold",
+    headingExtraBold: "PlusJakartaSans_800ExtraBold",
+  },
   radius: { sm: 10, md: 14, lg: 18, xl: 24, pill: 999 },
   spacing: { xs: 6, sm: 10, md: 14, lg: 18, xl: 24, xxl: 32 },
   shadow: {
@@ -41,8 +49,10 @@ export const theme = {
     lg: { shadowColor: "#0F172A", shadowOffset: { width: 0, height: 14 }, shadowOpacity: 0.14, shadowRadius: 28, elevation: 10 },
   },
   typography: {
-    title: { fontSize: 26, fontWeight: "800", letterSpacing: -0.3 },
-    sectionTitle: { fontSize: 17, fontWeight: "800", letterSpacing: -0.2 },
+    // fontWeight non va impostato insieme a un fontFamily custom: il peso
+    // è già "cotto" nel file del font caricato (vedi fonts.heading*).
+    title: { fontFamily: "PlusJakartaSans_800ExtraBold", fontSize: 26, letterSpacing: -0.3 },
+    sectionTitle: { fontFamily: "PlusJakartaSans_700Bold", fontSize: 17, letterSpacing: -0.2 },
     subtitle: { fontSize: 16, fontWeight: "600", color: "#6B6F92" },
     body: { fontSize: 16, color: "#1B2159" },
     small: { fontSize: 12, color: "#6B6F92" },

--- a/travelswap_ai/travelswapai/package.json
+++ b/travelswap_ai/travelswapai/package.json
@@ -8,6 +8,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
@@ -22,6 +23,7 @@
     "expo-barcode-scanner": "^13.0.1",
     "expo-camera": "~17.0.7",
     "expo-constants": "~18.0.8",
+    "expo-font": "~14.0.7",
     "expo-haptics": "~15.0.7",
     "expo-image-picker": "~17.0.9",
     "expo-linear-gradient": "~15.0.7",

--- a/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
+++ b/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
@@ -502,7 +502,7 @@ const styles = StyleSheet.create({
   ribbon: { backgroundColor: "#22C55E", paddingHorizontal: 12, paddingVertical: 4, borderRadius: 8,
     shadowColor: "#000", shadowOpacity: 0.08, shadowRadius: 6, elevation: 2 },
   ribbonText: { color: "#fff", fontWeight: "800", letterSpacing: 0.5, fontSize: 12 },
-  title: { fontSize: 22, fontWeight: "800" },
+  title: { fontFamily: theme.fonts.headingExtraBold, fontSize: 22 },
   subtitle: { marginTop: 6 },
   price: { fontSize: 22, fontWeight: "800" },
   card: { marginTop: 16, borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 16, padding: 14,

--- a/travelswap_ai/travelswapai/screens/LoginScreen.js
+++ b/travelswap_ai/travelswapai/screens/LoginScreen.js
@@ -178,7 +178,7 @@ export default function LoginScreen({ navigation }) {
   return (
     <View style={{ flex: 1, padding: 20, backgroundColor: theme.colors.background }}>
       <View style={{ alignItems: "center", marginTop: 40, marginBottom: 24 }}>
-        <Text style={{ fontSize: 28, fontWeight: "800", color: theme.colors.text }}>
+        <Text style={{ fontFamily: theme.fonts.headingExtraBold, fontSize: 28, color: theme.colors.text }}>
           Benvenuto 👋
         </Text>
         <Text style={{ marginTop: 6, color: theme.colors.muted }}>

--- a/travelswap_ai/travelswapai/screens/OnboardingScreen.js
+++ b/travelswap_ai/travelswapai/screens/OnboardingScreen.js
@@ -181,7 +181,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 0 },
     elevation: 0,
   },
-  title: { fontSize: 24, fontWeight: "800", textAlign: "center", color: theme.colors.text },
+  title: { fontFamily: theme.fonts.headingExtraBold, fontSize: 24, textAlign: "center", color: theme.colors.text },
   text: { fontSize: 16, color: theme.colors.textMuted, textAlign: "center", marginTop: 8 },
   // dots
   dotsRow: { flexDirection: "row", justifyContent: "center", alignItems: "center", marginTop: 18, gap: 8 },


### PR DESCRIPTION
## Descrizione

Secondo passo del restyling "Swap Gold": font caratteristico solo per i titoli (coppia display+body deliberata, il corpo del testo resta sul font di sistema).

- `App.js`: `useFonts` + gate di caricamento (spinner finché Plus Jakarta Sans 600/700/800 non è pronto) prima di montare la navigazione.
- `theme.js`: nuovi token `fonts.headingSemibold/Bold/ExtraBold`; applicati anche a `typography.title`/`sectionTitle`.
- Applicato ai 4 momenti più visibili: wordmark `HeaderLogo` (in cima a ogni schermata), titoli onboarding, headline "Benvenuto" del login, titolo annuncio nel dettaglio.
- Nuove dipendenze: `expo-font`, `@expo-google-fonts/plus-jakarta-sans`.

⚠️ **Richiede un'installazione**: dopo il merge, nel Codespace serve `npm install` (o `npx expo install`) per scaricare le due nuove dipendenze prima di avviare l'app — stesso procedimento fatto per `expo-image-picker`.

⚠️ Validato solo per sintassi, non ancora verificato visivamente su device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_