### PR TITLE
Terza tranche restyling: card rimanenti, FAB Ricalcola AI, titoli (non testato su device)

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -71,7 +71,9 @@ Direzione scelta dopo confronto visivo di 3 varianti (indigo raffinato / indigo 
 
 - ✅ **Font custom**: caricato **Plus Jakarta Sans** (pesi 600/700/800) via `expo-font` + `@expo-google-fonts/plus-jakarta-sans`, con gate di caricamento in `App.js`. Applicato ai 4 "hero moment" più visibili: wordmark `HeaderLogo`, titoli onboarding, headline "Benvenuto" del login, titolo annuncio nel dettaglio. Il resto del testo (corpo, label, bottoni) resta sul font di sistema — coppia display+body deliberata, non un rifacimento totale.
 
-Non ancora fatto (prossimi passi naturali): estensione dell'ombra morbida alle card rimanenti, unificazione delle 3 librerie di icone su una sola, estensione del font ai titoli di sezione rimanenti.
+- ✅ **Terza tranche**: estesa l'ombra morbida ai contenitori-card rimanenti (`OfferFlow`, `OfferDetailScreen`, `MatchingScreen` — lasciati intenzionalmente piatti input/chip/skeleton loader, che non sono card). Trovato e sistemato un altro CTA ad alto impatto: il **FAB "Ricalcola AI"** in Matching passa da lavanda chiaro a oro con ombra dorata, stesso trattamento del pulsante "Pubblica". Aggiunto anche il badge "selezionato" (`cardSelected` in OfferFlow) in oro. Font esteso ai titoli di `OfferFlow`, `OfferDetailScreen`, `MatchingScreen`.
+
+Non ancora fatto (prossimi passi naturali): unificazione delle 3 librerie di icone su una sola (rimandata: non verificabile offline se le icone lucide→Ionicons esistono davvero, rischio di icona mancante silenziosa), estensione font ai titoli rimanenti (Profilo, form creazione annuncio).
 
 ---
 

--- a/travelswap_ai/travelswapai/screens/MatchingScreen.js
+++ b/travelswap_ai/travelswapai/screens/MatchingScreen.js
@@ -747,7 +747,7 @@ refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         accessibilityLabel="Ricalcola AI"
         style={[styles.fab, { bottom: (tabBarHeight || 0) + (insets.bottom || 0) + 18 }]}
       >
-        {recomputing ? <ActivityIndicator color="#fff" /> : <Ionicons name="flash" size={26} color={theme.colors.boardingText} />}
+        {recomputing ? <ActivityIndicator color={theme.colors.accentOn} /> : <Ionicons name="flash" size={26} color={theme.colors.accentOn} />}
       </TouchableOpacity>
     </SafeAreaView>
   );
@@ -794,14 +794,15 @@ const styles = StyleSheet.create({
 
   /* Sezioni */
   section: {
-    backgroundColor: "#fff",
-    borderRadius: 16,
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
-    borderColor: "#E5E7EB",
-    padding: 12,
+    borderColor: theme.colors.border,
+    padding: 14,
+    ...theme.shadow.sm,
   },
   sectionHeader: { marginBottom: 8 },
-  sectionTitle: { fontSize: 16, fontWeight: "800", color: theme.colors.boardingText },
+  sectionTitle: { fontFamily: theme.fonts.headingBold, fontSize: 16, color: theme.colors.boardingText },
   sectionSubtitle: { color: "#6B7280", marginTop: 4 },
 
   /* Riga */
@@ -873,11 +874,11 @@ const styles = StyleSheet.create({
     width: 62,
     height: 62,
     borderRadius: 31,
-    backgroundColor:  theme.colors.primary,
+    backgroundColor: theme.colors.accent,
     alignItems: "center",
     justifyContent: "center",
     ...Platform.select({
-      ios: { shadowColor: "#000", shadowOpacity: 0.55, shadowRadius: 12, shadowOffset: { width: 0, height: 8 } },
+      ios: { shadowColor: theme.colors.accent, shadowOpacity: 0.55, shadowRadius: 12, shadowOffset: { width: 0, height: 8 } },
       android: { elevation: 8 },
     }),
   },

--- a/travelswap_ai/travelswapai/screens/OfferDetailScreen.js
+++ b/travelswap_ai/travelswapai/screens/OfferDetailScreen.js
@@ -269,8 +269,11 @@ export default function OfferDetailScreen() {
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff" },
   center: { flex: 1, alignItems: "center", justifyContent: "center" },
-  title: { fontSize: 20, fontWeight: "800", marginBottom: 12 },
-  box: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, padding: 12 },
+  title: { fontFamily: theme.fonts.headingExtraBold, fontSize: 20, marginBottom: 12 },
+  box: {
+    borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
+    padding: 14, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
   boxTitle: { fontWeight: "800" },
   boxMeta: { color: "#6B7280", marginTop: 4 },
   badge: { color: "#374151", fontWeight: "700" },
@@ -278,7 +281,10 @@ const s = StyleSheet.create({
   /* CTA sotto il box annuncio */
   ctaRow: { flexDirection: "row", gap: 10, marginTop: 12 },
 
-  card: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, padding: 12, marginBottom: 10, backgroundColor: "#fff" },
+  card: {
+    borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
+    padding: 14, marginBottom: 10, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
   cardTitle: { fontWeight: "800" },
   cardSub: { color: "#6B7280", marginTop: 4 },
   cardMeta: { color: "#111827", marginTop: 4, fontWeight: "600" },

--- a/travelswap_ai/travelswapai/screens/OfferFlow.js
+++ b/travelswap_ai/travelswapai/screens/OfferFlow.js
@@ -231,8 +231,11 @@ export default function OfferFlow() {
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff", padding: 16 },
   center: { flex: 1, alignItems: "center", justifyContent: "center" },
-  title: { fontSize: 20, fontWeight: "800", marginBottom: 16 },
-  target: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, padding: 12, marginBottom: 12 },
+  title: { fontFamily: theme.fonts.headingExtraBold, fontSize: 20, marginBottom: 16 },
+  target: {
+    borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
+    padding: 14, marginBottom: 12, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
   tTitle: { fontWeight: "800" },
   tMeta: { color: "#6B7280", marginTop: 4 },
   label: { fontWeight: "700", marginTop: 8, marginBottom: 6 },
@@ -242,8 +245,11 @@ const s = StyleSheet.create({
   btnOutline: { borderWidth: 1, borderColor: "#E5E7EB", paddingVertical: 12, borderRadius: 12, alignItems: "center", paddingHorizontal: 14 },
   btnOutlineTxt: { color: "#111827", fontWeight: "700" },
   btnDisabled: { opacity: 0.5 },
-  card: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, padding: 12, marginBottom: 10 },
-  cardSelected: { borderColor: "#111827", backgroundColor: "#F3F4F6" },
+  card: {
+    borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
+    padding: 14, marginBottom: 10, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
+  cardSelected: { borderColor: theme.colors.accent, backgroundColor: theme.colors.accentSoft },
   cardTitle: { fontWeight: "800" },
   cardMeta: { color: "#6B7280", marginTop: 4 },
   pendingBox: { borderWidth: 1, borderColor: "#F59E0B", backgroundColor: "#FFFBEB", borderRadius: 12, padding: 12, marginTop: 8 },


### PR DESCRIPTION
## Descrizione

Terza tranche del restyling "Swap Gold", continuando gli stessi token già introdotti nelle PR #11/#12.

- **Card rimanenti** (`OfferFlow`, `OfferDetailScreen`, `MatchingScreen`): contenitori-card veri passati da bordo piatto grigio a ombra morbida. Lasciati intenzionalmente invariati input, chip e skeleton loader in quei file — non sono "card" e non devono avere ombra.
- **FAB "Ricalcola AI"** (Matching): era nello stesso stato in cui era il vecchio pulsante primario prima del fix (sfondo lavanda chiaro + icona scura) — portato a oro con ombra dorata, coerente col pulsante "Pubblica".
- **`cardSelected`** in OfferFlow (l'annuncio scelto per lo scambio): da bordo nero/sfondo grigio generico a oro.
- Font Plus Jakarta Sans esteso ai titoli dei tre screen.

Volutamente **non** toccata l'unificazione delle librerie di icone (Ionicons/AntDesign/lucide): non posso verificare offline se i nomi dei glifi lucide→Ionicons esistono davvero, e un'icona mancante sarebbe un bug silenzioso difficile da notare senza device.

⚠️ Validato solo per sintassi, non ancora verificato visivamente su device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_