### PR TITLE
Unifica le icone su Ionicons, rimuove lucide-react-native

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -73,7 +73,9 @@ Direzione scelta dopo confronto visivo di 3 varianti (indigo raffinato / indigo 
 
 - ✅ **Terza tranche**: estesa l'ombra morbida ai contenitori-card rimanenti (`OfferFlow`, `OfferDetailScreen`, `MatchingScreen` — lasciati intenzionalmente piatti input/chip/skeleton loader, che non sono card). Trovato e sistemato un altro CTA ad alto impatto: il **FAB "Ricalcola AI"** in Matching passa da lavanda chiaro a oro con ombra dorata, stesso trattamento del pulsante "Pubblica". Aggiunto anche il badge "selezionato" (`cardSelected` in OfferFlow) in oro. Font esteso ai titoli di `OfferFlow`, `OfferDetailScreen`, `MatchingScreen`.
 
-Non ancora fatto (prossimi passi naturali): unificazione delle 3 librerie di icone su una sola (rimandata: non verificabile offline se le icone lucide→Ionicons esistono davvero, rischio di icona mancante silenziosa), estensione font ai titoli rimanenti (Profilo, form creazione annuncio).
+- ✅ **Unificazione icone**: verificato scaricando il pacchetto reale da npm (non più "non verificabile offline") che Ionicons ha `train-outline`/`bed-outline` — sostituiti i 2 usi di `lucide-react-native` (Home, Profilo) e rimossa la dipendenza dal `package.json`. Icone ora tutte su `@expo/vector-icons` (Ionicons + AntDesign).
+
+Non ancora fatto (prossimo passo naturale): estensione font ai titoli rimanenti (Profilo, form creazione annuncio).
 
 ---
 

--- a/travelswap_ai/travelswapai/package.json
+++ b/travelswap_ai/travelswapai/package.json
@@ -32,7 +32,6 @@
     "expo-status-bar": "~3.0.8",
     "expo-web-browser": "~15.0.7",
     "fast-text-encoding": "*",
-    "lucide-react-native": "^0.544.0",
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",

--- a/travelswap_ai/travelswapai/screens/HomeScreen.js
+++ b/travelswap_ai/travelswapai/screens/HomeScreen.js
@@ -8,7 +8,7 @@ import { useI18n } from "../lib/i18n";
 import { theme } from "../lib/theme";
 import TrustScoreBadge from "../components/TrustScoreBadge";
 import SaveButton from "../components/SaveButton";
-import { Train, BedDouble } from "lucide-react-native";
+import { Ionicons } from "@expo/vector-icons";
 
 // --- Helper: rimuove eventuali prezzi dal titolo
 function stripPriceFromTitle(s) {
@@ -129,9 +129,9 @@ export default function HomeScreen() {
         <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
           <View style={{ flexDirection: "row", alignItems: "center", flexShrink: 1 }}>
             {typeLc === "train" ? (
-              <Train size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
+              <Ionicons name="train-outline" size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
             ) : typeLc === "hotel" ? (
-              <BedDouble size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
+              <Ionicons name="bed-outline" size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
             ) : null}
             <Text style={styles.cardTitle} numberOfLines={1}>
               {stripPriceFromTitle(item.title) || tt("listing.untitled", "Senza titolo")}

--- a/travelswap_ai/travelswapai/screens/ProfileScreen.js
+++ b/travelswap_ai/travelswapai/screens/ProfileScreen.js
@@ -24,7 +24,7 @@ import { useAuth } from "../lib/auth";
 import { theme } from "../lib/theme";
 import { supabase } from "../lib/supabase.js";
 import TrustScoreBadge from '../components/TrustScoreBadge';
-import { Train, BedDouble } from "lucide-react-native";
+import { Ionicons } from "@expo/vector-icons";
 
 // --- Helper: rimuove eventuali prezzi dal titolo (come in HomeScreen)
 function stripPriceFromTitle(s) {
@@ -215,9 +215,9 @@ export default function ProfileScreen() {
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
         <View style={{ flexDirection: "row", alignItems: "center", flexShrink: 1 }}>
           {String(item.type).toLowerCase() === "train" ? (
-            <Train size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
+            <Ionicons name="train-outline" size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
           ) : String(item.type).toLowerCase() === "hotel" ? (
-            <BedDouble size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
+            <Ionicons name="bed-outline" size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
           ) : null}
           <Text style={styles.listCardTitle} numberOfLines={1}>
             {stripPriceFromTitle(item.title) || t("listing.untitled", "Senza titolo")}


### PR DESCRIPTION
## Descrizione

Chiude l'ultimo punto della roadmap di restyling: l'app usava 3 librerie di icone diverse (Ionicons, AntDesign, lucide-react-native) per soli 2 utilizzi di lucide.

Nella tranche precedente avevo rimandato questo cambio perché non potevo verificare offline se `train-outline`/`bed-outline` esistessero davvero in Ionicons — un'icona mancante sarebbe un bug silenzioso difficile da notare senza device. Questa volta ho **scaricato il pacchetto reale `@expo/vector-icons` da npm** ed estratto la glyph map di Ionicons: entrambe le icone esistono.

- `HomeScreen.js`, `ProfileScreen.js`: le icone tipo-annuncio (treno/hotel) passano da `lucide-react-native` a `Ionicons` (stessa dimensione/colore — `train-outline`/`bed-outline` al posto di `Train`/`BedDouble`, nessun cambio visivo atteso).
- Rimossa la dipendenza `lucide-react-native` dal `package.json` (zero usi rimasti nel progetto).

Icone ora tutte su `@expo/vector-icons` (Ionicons + AntDesign).

⚠️ Validato solo per sintassi, non ancora verificato visivamente su device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_