### PR TITLE
⚠️ Fix critico: accettare offerte è sempre rotto in produzione + Storico transazioni

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -36,8 +36,16 @@ Implementato: `lib/listingImages.js` (upload su Supabase Storage + CRUD `listing
 Aggiunto anche il selettore foto **direttamente nel form di creazione/modifica annuncio** (`CreateListingScreen`, sezione "Foto" sotto il titolo): in creazione le foto restano in sospeso e vengono caricate dopo la pubblicazione (appena esiste l'id dell'annuncio); in modifica si caricano/eliminano subito.
 Prerequisiti d'attivazione: eseguire `supabase/storage_setup.sql` (bucket `listing-images` + policy) e installare `expo-image-picker` + `base64-arraybuffer`.
 
-### C3. Storico transazioni — `transactions`
-Tabella pronta ma nessuna UI. Serve: sezione "I miei scambi/acquisti" nel profilo. Utile per fiducia e ricomprensione dello stato.
+### C3. Storico transazioni — `transactions` — ✅ FATTO
+Implementato: `lib/transactions.js` (lettura con join sull'annuncio), `screens/TransactionsScreen.js` (lista con badge Venduto/Ricevuto), accesso "🧾 I miei scambi" dal Profilo, tradotto it/en/es.
+
+**Scoperta importante**: nessuna funzione scriveva mai in `transactions` — modificata `accept_offer_any()` (unica funzione di accettazione usata dall'app) per registrare 1 riga per un buy, 2 righe per uno swap (una per ciascun annuncio che cambia proprietario), in modo atomico con l'accettazione stessa.
+
+**⚠️ Bug critici preesistenti trovati testando in locale, indipendenti dalla feature**: accettare/rifiutare/cancellare **qualsiasi** offerta falliva sempre in produzione, per due cause distinte:
+1. `_norm()` veniva chiamata su `offers.status` (un ENUM) come se fosse testo — Postgres non fa il cast implicito. Rotto in 4 funzioni/trigger.
+2. L'enum `listing_status` non conteneva `pending`/`reserved`/`swapped`, valori impostati attivamente da `accept_offer_any()`.
+
+Entrambi corretti con migrazioni dedicate, validate con un test end-to-end reale (due utenti simulati, scenario buy e swap) applicato **nell'ordine esatto dei nomi file** di produzione. Vedi `supabase/README.md` — vanno applicate sul progetto Supabase reale.
 
 ---
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -6,8 +6,13 @@ Lo schema del database vive in `migrations/`, in ordine di applicazione:
 |---|---|
 | `20260711160000_init.sql` | Schema completo ricostruito dal backup del progetto originale (enum, 14 tabelle, 6 viste, ~25 funzioni/RPC, trigger, indici, policy RLS) |
 | `20260711160001_security_hardening.sql` | Fix di sicurezza: RLS sulle 4 tabelle che ne erano prive, PNR rimosso da `listings` e dalla vista `v_last_minute`, valori enum `expired`/`deleted` mancanti |
+| `20260711160003_transactions_on_accept.sql` | `accept_offer_any()` registra ora una riga in `transactions` quando un'offerta viene accettata (1 per buy, 2 per swap) — prima nessuna funzione scriveva mai in questa tabella |
+| `20260711160004_fix_offer_status_norm_cast.sql` | ⚠️ **Fix critico**: `_norm()` veniva chiamata su `offers.status` (un ENUM) invece che su testo → **ogni** accettazione/rifiuto/cancellazione di un'offerta falliva sempre in produzione. Corregge 4 funzioni/trigger. |
+| `20260711160005_add_missing_listing_statuses.sql` | ⚠️ **Fix critico**: l'enum `listing_status` non conteneva `pending`/`reserved`/`swapped`, valori impostati da `accept_offer_any()` — bloccava l'accettazione di **qualsiasi** offerta (stesso sintomo del fix precedente, causa diversa) |
 
-Entrambe le migrazioni sono state validate applicandole in sequenza a un PostgreSQL 16 pulito.
+> Le due migrazioni "Fix critico" vanno applicate **subito** sul progetto Supabase reale (non solo nel repo): finché mancano, accettare un'offerta fallisce sempre con un errore Postgres. Scoperte testando in locale la migrazione `transactions_on_accept` prima di consegnarla — non erano mai state esercitate end-to-end.
+
+Tutte le migrazioni sono state validate applicandole in sequenza (nell'ordine reale dei nomi file) a un PostgreSQL 16 pulito, incluso un test end-to-end con due utenti simulati per buy e swap.
 
 ## Ripristino su un nuovo progetto (il vecchio è in pausa non riattivabile)
 

--- a/supabase/migrations/20260711160003_transactions_on_accept.sql
+++ b/supabase/migrations/20260711160003_transactions_on_accept.sql
@@ -1,0 +1,80 @@
+-- ============================================================
+-- Storico transazioni: registra una riga in `transactions` quando
+-- un'offerta viene accettata. Finora nessuna funzione/trigger scriveva
+-- mai in questa tabella (esisteva nello schema ma restava vuota).
+--
+-- Modifica accept_offer_any() (l'unica funzione di accettazione usata
+-- dall'app) aggiungendo l'insert in modo atomico con l'accettazione:
+-- - offerta 'buy'  -> 1 riga  (ttype='sale', price=amount)
+-- - offerta 'swap' -> 2 righe (ttype='swap', una per ciascun annuncio
+--   che cambia proprietario) — la funzione e' SECURITY DEFINER e gia'
+--   aggiorna lo status di ENTRAMBI gli annunci coinvolti (anche quello
+--   dell'utente che non ha chiamato la funzione), quindi puo' scrivere
+--   in sicurezza anche la riga con seller_id diverso dal chiamante.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.accept_offer_any(offer_id_text text) RETURNS public.offers
+    LANGUAGE plpgsql SECURITY DEFINER
+    AS $$
+declare
+  v_offer public.offers;
+  v_owner uuid;
+begin
+  select * into v_offer
+  from public.offers
+  where id::text = offer_id_text
+  for update;
+
+  if not found then
+    raise exception 'Offer not found';
+  end if;
+
+  -- owner del listing destinazione (confronto via testo)
+  select user_id into v_owner
+  from public.listings
+  where id::text = v_offer.to_listing_id::text;
+
+  if v_owner is null or v_owner <> auth.uid() then
+    raise exception 'Not allowed';
+  end if;
+
+  if v_offer.status <> 'pending' then
+    return v_offer;
+  end if;
+
+  -- accetta
+  update public.offers set status = 'accepted' where id = v_offer.id;
+
+  -- rifiuta le altre pendenti verso lo stesso listing
+  update public.offers
+     set status = 'declined'
+   where to_listing_id::text = v_offer.to_listing_id::text
+     and id <> v_offer.id
+     and status = 'pending';
+
+  -- riserva listing destinazione
+  update public.listings
+     set status = 'reserved'
+   where id::text = v_offer.to_listing_id::text;
+
+  -- se SWAP, riserva anche il listing offerto
+  if v_offer.type = 'swap' and v_offer.from_listing_id is not null then
+    update public.listings
+       set status = 'reserved'
+     where id::text = v_offer.from_listing_id::text;
+  end if;
+
+  -- registra la/le transazione/i (mai stata scritta automaticamente finora)
+  if v_offer.type = 'swap' and v_offer.from_listing_id is not null then
+    insert into public.transactions (listing_id, seller_id, buyer_id, ttype, price, status)
+    values
+      (v_offer.to_listing_id,   v_owner,             v_offer.proposer_id, 'swap', null, 'completed'),
+      (v_offer.from_listing_id, v_offer.proposer_id, v_owner,             'swap', null, 'completed');
+  else
+    insert into public.transactions (listing_id, seller_id, buyer_id, ttype, price, status)
+    values (v_offer.to_listing_id, v_owner, v_offer.proposer_id, 'sale', v_offer.amount, 'completed');
+  end if;
+
+  select * into v_offer from public.offers where id = v_offer.id;
+  return v_offer;
+end $$;

--- a/supabase/migrations/20260711160004_fix_offer_status_norm_cast.sql
+++ b/supabase/migrations/20260711160004_fix_offer_status_norm_cast.sql
@@ -1,0 +1,170 @@
+-- ============================================================
+-- Fix critico: _norm(s text) veniva chiamata con offers.status, che è
+-- un ENUM (public.offer_status) e non text. Postgres non lo risolve
+-- implicitamente per il dispatch di funzione ⇒ ERRORE ogni volta.
+--
+-- Impatto reale (scoperto testando in locale la migrazione 20260711160003):
+-- - after_update_offers_propagate: fallisce ad OGNI cambio di stato di
+--   un'offerta ⇒ accept_offer_any / decline_offer_any / updateOffer
+--   (cancella offerta) sono TUTTE rotte in produzione oggi.
+-- - before_insert_offers_enforce: fallisce quando si crea una nuova
+--   offerta di tipo SWAP (verifica del limite "max 2 proposte attive").
+-- - expire_old_accepted_offers, recompute_listing_pending_state: rotte
+--   se mai invocate (manutenzione/cron).
+--
+-- offers.type è invece TEXT (non enum): _norm(new.type)/_norm(o.type)
+-- erano già corretti e non vengono toccati.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.after_update_offers_propagate() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  ns text := _norm(new.status::text);
+begin
+  if ns = 'accepted' then
+    if new.from_listing_id is not null then
+      update public.listings set status = 'pending'
+      where id in (new.from_listing_id, new.to_listing_id)
+        and status in ('active');
+    else
+      -- offerta BUY: almeno il target diventa pending
+      update public.listings set status = 'pending'
+      where id = new.to_listing_id and status = 'active';
+    end if;
+  elsif ns = 'finalized' then
+    -- finalizzazione: imposta stati finali
+    if _norm(new.type) = 'swap' then
+      update public.listings set status = 'swapped' where id in (new.from_listing_id, new.to_listing_id);
+    else
+      update public.listings set status = 'sold' where id = new.to_listing_id;
+      -- se esiste una from_listing, portala a 'sold' solo se business rule lo prevede (qui NO)
+    end if;
+  elsif ns in ('cancelled','declined') then
+    -- se una proposta decade o viene annullata, ricomputa lo stato pending della/e listing coinvolte
+    if new.from_listing_id is not null then
+      perform public.recompute_listing_pending_state(new.from_listing_id);
+    end if;
+    perform public.recompute_listing_pending_state(new.to_listing_id);
+  end if;
+  return null;
+end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.before_insert_offers_enforce() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  st_to text;
+  st_from text;
+  cnt int;
+begin
+  select status into st_to from public.listings where id = new.to_listing_id;
+  if st_to is null then
+    raise exception 'Listing target inesistente';
+  end if;
+  if st_to <> 'active' then
+    raise exception 'Puoi proporre solo verso annunci attivi';
+  end if;
+
+  if new.from_listing_id is not null then
+    select status into st_from from public.listings where id = new.from_listing_id;
+    if st_from is null then
+      raise exception 'La tua listing (from) non esiste';
+    end if;
+    if st_from <> 'active' then
+      raise exception 'La tua listing deve essere attiva per inviare proposte';
+    end if;
+
+    if _norm(new.type) = 'swap' then
+      select count(*) into cnt
+      from public.offers o
+      where o.from_listing_id = new.from_listing_id
+        and _norm(o.type) = 'swap'
+        and _norm(o.status::text) in ('pending','in_review');
+
+      if cnt >= 2 then
+        raise exception 'Hai già 2 proposte attive da questa listing';
+      end if;
+    end if;
+  end if;
+
+  -- normalizza default status
+  if new.status is null then new.status := 'pending'; end if;
+
+  return new;
+end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.expire_old_accepted_offers() RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+declare
+  n int;
+begin
+  update public.offers
+    set status = 'expired'
+  where _norm(status::text) = 'accepted'
+    and now() > (coalesce(updated_at, created_at) + interval '3 days');
+
+  -- ripristina annunci coinvolti
+  perform public.recompute_listing_pending_state(o.from_listing_id)
+    from public.offers o
+    where _norm(o.status::text) = 'expired'
+      and now() > (coalesce(o.updated_at, o.created_at) + interval '3 days')
+      and o.from_listing_id is not null;
+
+  perform public.recompute_listing_pending_state(o.to_listing_id)
+    from public.offers o
+    where _norm(o.status::text) = 'expired'
+      and now() > (coalesce(o.updated_at, o.created_at) + interval '3 days');
+
+  get diagnostics n = row_count;
+  return coalesce(n,0);
+end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.recompute_listing_pending_state(p_listing uuid) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+declare
+  cnt_pending int;
+  has_accepted int;
+  cur_status text;
+begin
+  -- finalizzati/sold/swapped non si toccano
+  select status into cur_status from public.listings where id = p_listing;
+  if cur_status in ('sold','swapped') then
+    return;
+  end if;
+
+  -- offerte accettate (non finalizzate)
+  select count(*) into has_accepted
+  from public.offers o
+  where (o.from_listing_id = p_listing or o.to_listing_id = p_listing)
+    and _norm(o.status::text) = 'accepted';
+
+  if has_accepted > 0 then
+    update public.listings set status = 'pending' where id = p_listing and status <> 'pending';
+    return;
+  end if;
+
+  -- numero di proposte "pendenti" uscenti dalla MIA listing (solo swap, cioè from_listing valorizzata)
+  select count(*) into cnt_pending
+  from public.offers o
+  where o.from_listing_id = p_listing
+    and _norm(o.type) = 'swap'
+    and _norm(o.status::text) in ('pending','in_review');
+
+  if cnt_pending >= 2 then
+    update public.listings set status = 'pending' where id = p_listing and status <> 'pending';
+  else
+    -- torna attivo se non scaduto/finalizzato
+    update public.listings
+      set status = 'active'
+      where id = p_listing
+        and status in ('pending')
+        and (published_at is null or (now() <= published_at + interval '30 days'));
+  end if;
+end;
+$$;

--- a/supabase/migrations/20260711160005_add_missing_listing_statuses.sql
+++ b/supabase/migrations/20260711160005_add_missing_listing_statuses.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- Fix critico: listing_status non conteneva 'pending'/'reserved'/
+-- 'swapped', valori impostati attivamente da accept_offer_any() e dal
+-- trigger after_update_offers_propagate() quando un'offerta viene
+-- accettata. Scoperto testando in locale accept_offer_any end-to-end:
+-- ERROR: invalid input value for enum listing_status: "pending".
+--
+-- Prima di questo fix, accettare QUALSIASI offerta (buy o swap) falliva
+-- sempre con questo errore in produzione.
+--
+-- ('sold' esiste già nell'enum originale; 'expired'/'deleted' erano
+-- già stati aggiunti dall'hardening 20260711160001.)
+-- ============================================================
+
+alter type public.listing_status add value if not exists 'pending';
+alter type public.listing_status add value if not exists 'reserved';
+alter type public.listing_status add value if not exists 'swapped';

--- a/travelswap_ai/travelswapai/App.js
+++ b/travelswap_ai/travelswapai/App.js
@@ -20,6 +20,7 @@ import EditProfileScreen from './screens/EditProfileScreen';
 import OfferDetailScreen from './screens/OfferDetailScreen';
 import ListingDetailScreen from './screens/ListingDetailScreen';
 import SavedScreen from './screens/SavedScreen';
+import TransactionsScreen from './screens/TransactionsScreen';
 import ManageImagesScreen from './screens/ManageImagesScreen';
 import { AuthProvider, useAuth } from './lib/auth';
 import { I18nProvider } from './lib/i18n';
@@ -107,6 +108,7 @@ function RootNavigator() {
           <Stack.Screen name="ListingDetail" component={ListingDetailScreen} options={{ title: "Listing" }} />
           <Stack.Screen name="OfferDetail" component={OfferDetailScreen} options={{ title: "Offer" }} />
           <Stack.Screen name="Saved" component={SavedScreen} options={{ title: "Preferiti" }} />
+          <Stack.Screen name="Transactions" component={TransactionsScreen} options={{ title: "I miei scambi" }} />
           <Stack.Screen name="ManageImages" component={ManageImagesScreen} options={{ title: "Foto annuncio" }} />
         </>
       ) : (

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -63,6 +63,7 @@ export const translations = {
       title: "Profilo",
       editProfile: "Modifica profilo",
       savedListings: "I miei preferiti",
+      myTransactions: "I miei scambi",
       logout: "Esci",
       myListings: "I miei annunci",
       publishListing: "Pubblica annuncio",
@@ -87,6 +88,15 @@ export const translations = {
       deleteErrorMsg: "Impossibile eliminare.",
       emptyText: "Nessuna foto. Tocca “Aggiungi foto” per caricarne.",
       missingListing: "Annuncio non specificato.",
+    },
+
+    transactions: {
+      screenTitle: "I miei scambi",
+      emptyText: "Nessuno scambio ancora.\nQuando compri, vendi o scambi un annuncio, lo troverai qui.",
+      typeSale: "Vendita",
+      typeSwap: "Scambio",
+      directionSold: "Venduto",
+      directionBought: "Ricevuto",
     },
 
     // --- Annunci / Listing ---
@@ -531,6 +541,7 @@ export const translations = {
       title: "Profile",
       editProfile: "Edit profile",
       savedListings: "My favorites",
+      myTransactions: "My transactions",
       logout: "Logout",
       myListings: "My listings",
       publishListing: "Publish listing",
@@ -555,6 +566,15 @@ export const translations = {
       deleteErrorMsg: "Couldn't delete it.",
       emptyText: "No photos yet. Tap “Add photo” to upload some.",
       missingListing: "Listing not specified.",
+    },
+
+    transactions: {
+      screenTitle: "My transactions",
+      emptyText: "No transactions yet.\nWhen you buy, sell, or swap a listing, it'll show up here.",
+      typeSale: "Sale",
+      typeSwap: "Swap",
+      directionSold: "Sold",
+      directionBought: "Received",
     },
 
     listing: {
@@ -986,6 +1006,7 @@ export const translations = {
       title: "Perfil",
       editProfile: "Editar perfil",
       savedListings: "Mis favoritos",
+      myTransactions: "Mis intercambios",
       logout: "Cerrar sesión",
       myListings: "Mis anuncios",
       publishListing: "Publicar anuncio",
@@ -1010,6 +1031,15 @@ export const translations = {
       deleteErrorMsg: "No se pudo eliminar.",
       emptyText: "Aún no hay fotos. Toca “Añadir foto” para subir alguna.",
       missingListing: "Anuncio no especificado.",
+    },
+
+    transactions: {
+      screenTitle: "Mis intercambios",
+      emptyText: "Aún no hay transacciones.\nCuando compres, vendas o intercambies un anuncio, aparecerá aquí.",
+      typeSale: "Venta",
+      typeSwap: "Intercambio",
+      directionSold: "Vendido",
+      directionBought: "Recibido",
     },
 
     listing: {

--- a/travelswap_ai/travelswapai/lib/transactions.js
+++ b/travelswap_ai/travelswapai/lib/transactions.js
@@ -1,0 +1,29 @@
+// lib/transactions.js — storico scambi/acquisti (tabella transactions)
+import { supabase } from "./supabase";
+
+/**
+ * Le mie transazioni (sia come venditore che come acquirente), con i
+ * dati essenziali dell'annuncio coinvolto. Ordinate dalla più recente.
+ * Ogni riga include `direction`: "sold" se ero il venditore, "bought"
+ * se ero l'acquirente (per lo swap, ogni utente vede la propria riga
+ * come "bought" per l'annuncio ricevuto).
+ */
+export async function listMyTransactions() {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("transactions")
+    .select(
+      "id, ttype, price, status, created_at, seller_id, buyer_id, listing:listing_id ( id, title, type, location, image_url )"
+    )
+    .or(`seller_id.eq.${user.id},buyer_id.eq.${user.id}`)
+    .order("created_at", { ascending: false });
+
+  if (error) { console.log("[listMyTransactions]", error.message); return []; }
+
+  return (data || []).map((row) => ({
+    ...row,
+    direction: row.seller_id === user.id ? "sold" : "bought",
+  }));
+}

--- a/travelswap_ai/travelswapai/screens/ProfileScreen.js
+++ b/travelswap_ai/travelswapai/screens/ProfileScreen.js
@@ -332,6 +332,16 @@ export default function ProfileScreen() {
             </TouchableOpacity>
 
             <TouchableOpacity
+              style={[styles.editBtn, { marginTop: 8 }]}
+              onPress={() => {
+                navigation.navigate?.("Transactions");
+                navigation.getParent?.()?.navigate?.("Transactions");
+              }}
+            >
+              <Text style={styles.editBtnText}>🧾 {t("profile.myTransactions", "I miei scambi")}</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
               style={[styles.editBtn, { marginTop: 8, backgroundColor: theme.colors.primary, borderColor: "#111827" }]}
               onPress={handleLogout}
             >

--- a/travelswap_ai/travelswapai/screens/TransactionsScreen.js
+++ b/travelswap_ai/travelswapai/screens/TransactionsScreen.js
@@ -1,0 +1,135 @@
+// screens/TransactionsScreen.js — storico scambi/acquisti dell'utente
+import React, { useCallback, useState } from "react";
+import {
+  View, Text, FlatList, TouchableOpacity, ActivityIndicator,
+  StyleSheet, RefreshControl,
+} from "react-native";
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { listMyTransactions } from "../lib/transactions";
+import { useI18n } from "../lib/i18n";
+import { theme } from "../lib/theme";
+
+function formatDate(iso, locale) {
+  try {
+    return new Date(iso).toLocaleDateString(locale || undefined, {
+      day: "2-digit", month: "short", year: "numeric",
+    });
+  } catch {
+    return iso || "";
+  }
+}
+
+export default function TransactionsScreen() {
+  const { t, locale } = useI18n();
+  const navigation = useNavigation();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setItems(await listMyTransactions());
+    } catch (e) {
+      if (__DEV__) console.log("[Transactions] load error", e?.message || e);
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(useCallback(() => { load(); }, [load]));
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (!items.length) {
+    return (
+      <View style={styles.center}>
+        <Text style={{ fontSize: 44 }}>🧾</Text>
+        <Text style={styles.emptyText}>
+          {t("transactions.emptyText", "Nessuno scambio ancora.\nQuando compri, vendi o scambi un annuncio, lo troverai qui.")}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={items}
+      keyExtractor={(it) => String(it.id)}
+      contentContainerStyle={{ padding: 16 }}
+      refreshControl={<RefreshControl refreshing={loading} onRefresh={load} />}
+      renderItem={({ item }) => {
+        const listing = item.listing || {};
+        const isSwap = item.ttype === "swap";
+        const typeLabel = isSwap ? t("transactions.typeSwap", "Scambio") : t("transactions.typeSale", "Vendita");
+        const directionLabel = item.direction === "sold"
+          ? t("transactions.directionSold", "Venduto")
+          : t("transactions.directionBought", "Ricevuto");
+
+        return (
+          <TouchableOpacity
+            style={styles.card}
+            activeOpacity={0.8}
+            onPress={() => listing.id && navigation.navigate("ListingDetail", { id: listing.id })}
+          >
+            <View style={{ flex: 1, paddingRight: 12 }}>
+              <Text style={styles.title} numberOfLines={2}>
+                {listing.title || t("savedScreen.untitledListing", "Annuncio")}
+              </Text>
+              <Text style={styles.sub}>{typeLabel} · {formatDate(item.created_at, locale)}</Text>
+              {item.price != null ? (
+                <Text style={styles.price}>{item.price} €</Text>
+              ) : null}
+            </View>
+            <View style={[styles.badge, item.direction === "sold" ? styles.badgeSold : styles.badgeBought]}>
+              <Text style={styles.badgeText}>{directionLabel}</Text>
+            </View>
+          </TouchableOpacity>
+        );
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.background,
+    padding: 24,
+  },
+  emptyText: {
+    color: theme.colors.textMuted,
+    marginTop: 10,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    padding: 14,
+    marginBottom: 12,
+    ...theme.shadow.sm,
+  },
+  title: { fontFamily: theme.fonts.headingBold, fontSize: 16, color: theme.colors.text },
+  sub: { marginTop: 4, color: theme.colors.textMuted },
+  price: { marginTop: 6, fontFamily: theme.fonts.headingBold, fontSize: 15, color: theme.colors.text },
+  badge: {
+    paddingHorizontal: 10, paddingVertical: 5, borderRadius: 999,
+    borderWidth: 1,
+  },
+  badgeSold: { backgroundColor: theme.colors.surfaceMuted, borderColor: theme.colors.border },
+  badgeBought: { backgroundColor: theme.colors.accentSoft, borderColor: theme.colors.accent },
+  badgeText: { fontSize: 12, fontWeight: "700", color: theme.colors.text },
+});


### PR DESCRIPTION
## ⚠️ Azione richiesta dopo il merge

Questa PR contiene **due migrazioni che vanno applicate sul progetto Supabase reale**, non solo mergiate qui. Finché non lo fai, **accettare qualsiasi offerta continuerà a fallire** — vedi sotto.

## Cosa contiene

### Storico transazioni (C3 della roadmap)
- `accept_offer_any()` ora registra una riga in `transactions` quando un'offerta viene accettata (1 per buy, 2 per swap — una per ciascun annuncio che cambia proprietario), atomicamente con l'accettazione. Nessuna funzione lo faceva prima: la tabella esisteva nello schema ma restava sempre vuota.
- `lib/transactions.js`, `screens/TransactionsScreen.js`: lista "I miei scambi" con badge Venduto/Ricevuto, accesso dal Profilo, tradotto it/en/es fin dall'inizio.

### 🔴 Due bug critici preesistenti, scoperti testando la migrazione sopra
Prima di consegnare la funzionalità ho testato `accept_offer_any()` end-to-end in locale (mai stata esercitata così prima) — e non funzionava, per due cause indipendenti dalla mia feature:

1. **`_norm()` chiamata su un ENUM invece che su testo.** `offers.status` è `public.offer_status` (enum), ma 4 funzioni/trigger passavano questo valore a `_norm(s text)` — Postgres non fa il cast implicito, quindi **ogni** cambio di stato di un'offerta falliva con un errore. Colpiva `after_update_offers_propagate` (il trigger che scatta ad ogni update di un'offerta — quindi accept/decline/cancel erano **tutte** rotte), `before_insert_offers_enforce` (creazione di una nuova offerta swap), più due funzioni di manutenzione.
2. **L'enum `listing_status` non conteneva `pending`/`reserved`/`swapped`**, valori che `accept_offer_any()` imposta attivamente sugli annunci coinvolti. Stesso identico sintomo del bug #1 (accettare un'offerta falliva sempre), causa completamente diversa — trovato subito dopo aver corretto il primo.

**In pratica: prima di questi due fix, la funzione di accettazione offerte non ha mai funzionato end-to-end**, né per buy né per swap, sul nuovo progetto Supabase.

## Test

Validato con un test reale a due utenti simulati (venditore + proponente), applicando le migrazioni **nell'ordine esatto dei nomi file** che verrà usato in produzione:
- scenario **buy**: 1 riga in `transactions`, seller/buyer/price corretti
- scenario **swap**: 2 righe (una per lato), verificato il verso seller/buyer su entrambe — inclusa la riga per l'utente che NON ha chiamato la funzione, confermando che il bypass RLS dentro `SECURITY DEFINER` funziona come previsto

⚠️ Lato app: validato solo per sintassi, non ancora verificato visivamente su device (come da checklist standard di questa sessione).

## Dopo il merge

1. Apri il **SQL Editor** del tuo progetto Supabase
2. Incolla ed esegui, in ordine: `20260711160003_transactions_on_accept.sql`, `20260711160004_fix_offer_status_norm_cast.sql`, `20260711160005_add_missing_listing_statuses.sql`
3. Testa un ciclo completo di offerta (proponi → accetta) per confermare

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_