### PR TITLE
feat(swap-chains): motore di ricerca cicli lato server, fase 2

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -57,21 +57,28 @@ Con `expo-notifications`: avvisa l'utente quando arriva una nuova offerta o un n
 ### D2. Chat in-app per le offerte
 Oggi si può fare un'offerta ma non trattare. Una chat leggera per ogni offerta (tabella `messages` da aggiungere) sbloccherebbe la negoziazione e ridurrebbe gli scambi "fuori piattaforma" (che le euristiche antifrode già segnalano come rischio).
 
-### D0. Swap a catena + normalizzazione AI — 🚧 FASE 1 FATTA (schema + funzioni)
+### D0. Swap a catena + normalizzazione AI — 🚧 FASE 2 FATTA (schema + motore di ricerca)
 Analisi di mercato con simulazione sintetica (300 utenti, 10 run): il matching reciproco diretto di oggi intercetta solo ~0,3% degli utenti; catene multi-parte da sole non cambiano nulla (~0,3% anche loro); **solo la combinazione catena + normalizzazione AI (tolleranza data/area) sblocca ~92%**. Deciso con te: catene di **esattamente 3** utenti, chiusura solo quando **tutti e 3 confermano esplicitamente** (nessuna esecuzione automatica).
 
-Implementato (fase 1, validata su Postgres locale con scenario felice/rifiuto/race-condition/permessi):
+**Fase 1** (schema + funzioni, validata su Postgres locale con scenario felice/rifiuto/race-condition/permessi):
 - `chain_proposals`/`chain_participants` (RLS: solo i partecipanti vedono la propria catena).
 - `create_chain_proposal()` — solo `service_role`, valida ciclo chiuso + proprietà + stato `active` di ogni annuncio.
 - `confirm_chain_participant()` — chiude atomicamente solo a 3/3 conferme: annunci → `reserved`, offerte 1:1 pendenti su quegli annunci rifiutate, 3 righe in `transactions` (stesso trattamento di `accept_offer_any()` generalizzato a 3 lati). Se un annuncio non è più `active` al momento della chiusura (venduto altrove nel frattempo), la catena decade senza toccare nulla.
 - `decline_chain_participant()` — un rifiuto fa decadere subito la catena, nessun effetto collaterale.
+- Bug trovati e corretti durante il test locale: ricorsione infinita nella policy RLS di `chain_participants` (self-query) e un `REVOKE ALL ... FROM PUBLIC` che non bastava a bloccare `authenticated` su Supabase (i permessi di default vanno direttamente ai ruoli, non solo a `PUBLIC`).
 
-**Bug trovati e corretti durante il test locale, prima di consegnare**: (1) ricorsione infinita nella policy RLS di `chain_participants` (si auto-interrogava) — risolto con funzione helper `SECURITY DEFINER`; (2) `REVOKE ALL ... FROM PUBLIC` su `create_chain_proposal()` non bastava — su Supabase i permessi di default vanno direttamente ad `anon`/`authenticated`, non solo a `PUBLIC`: senza la correzione, **qualunque utente autenticato avrebbe potuto chiamare la funzione riservata al server**.
+**Fase 2** (motore lato server che *trova* i cicli, `server/src/models/chains.js` + `server/src/ai/chainMatch.js`):
+- Grafo dei desideri: per ogni annuncio CERCO di un utente, cerca tra gli annunci VENDO di altri utenti (stesso tipo) quelli che lo soddisferebbero, poi cerca cicli chiusi di 3 proprietari nel grafo risultante (`findThreeCycles`, funzione pura, **9 + 6 test unitari**, `node --test`).
+- Normalizzazione fuzzy con lo stesso pattern già usato dal matcher 1:1 esistente (`ai/score.js`): **AI primaria** (prompt dedicato, tollera città vicine/varianti testuali e ±3 giorni) **con fallback euristico deterministico** (cluster geografico statico + tolleranza data) se la chiave OpenAI manca o la chiamata fallisce — la ricerca cicli non si blocca mai. La soglia di punteggio (65/100) passa solo quando l'area è compatibile, la sola vicinanza di data non basta.
+- Nuovo endpoint `POST /api/chains/recompute`, protetto da un secret condiviso (`CHAIN_CRON_SECRET`, header `X-Cron-Secret`) e non dal login utente — scansiona gli annunci di *tutti* gli utenti, quindi non va esposto al client. **Fail-closed**: se il secret non è configurato, l'endpoint rifiuta sempre (503) invece di restare aperto per errore.
+- v1: considera solo i proprietari con **esattamente un** annuncio VENDO attivo (evita l'ambiguità di "quale dei suoi annunci starebbe dando" se ne ha più di uno) — limite noto, da rilassare in un secondo momento.
+- ⚠️ Non testato end-to-end contro un vero progetto Supabase/OpenAI in questa sessione (nessuno dei due disponibile nell'ambiente): la logica pura (ricerca cicli, punteggio euristico) è coperta da test automatici in CI; le query Supabase sono scritte solo con pattern già usati altrove nel codebase (niente sintassi nuova non verificabile) proprio per questo motivo.
+- Bug preesistente scoperto per caso durante lo smoke test (non introdotto da questa modifica): `server/src/services/trust/aiTrust.js` fa crashare **l'intero server** all'avvio se manca `OPENAI_API_KEY` (chiama `new OpenAI(...)` senza controllare la chiave, a differenza di `ai/score.js` che lo fa correttamente). Segnalato, non ancora corretto.
 
 **Non ancora fatto** (prossimi passi):
-- Fase 2: motore lato server che *trova* i cicli da proporre (grafo CERCO→VENDO su tutti gli annunci attivi, con normalizzazione fuzzy AI su data/area — i due parametri validati nella simulazione).
 - Fase 3: spiegazione della catena in linguaggio naturale (AI) da mostrare all'utente.
 - Fase 4: UI per vedere/confermare/rifiutare una proposta di catena.
+- Applicare la migrazione fase 1 sul progetto Supabase reale (se non ancora fatto) e configurare `CHAIN_CRON_SECRET` + un trigger periodico (cron esterno o Render) per `/api/chains/recompute` e per `expire_old_chain_proposals()`.
 
 ### D3. Avvisi di ricerca ("price/route alert")
 "Avvisami quando compare un treno Roma→Milano sotto 40€". Sfrutta il motore di matching che c'è già, girato al contrario. Ottima retention.

--- a/server/src/ai/chainMatch.js
+++ b/server/src/ai/chainMatch.js
@@ -1,0 +1,285 @@
+// server/src/ai/chainMatch.js
+// Normalizzazione "fuzzy" per lo swap a catena: dato un annuncio CERCO
+// (cosa un utente vuole) e un lotto di annunci VENDO candidati di altri
+// utenti, stima quanto bene ciascun candidato soddisfa la richiesta,
+// tollerando città vicine e date non identiche — esattamente i due
+// parametri validati nella simulazione di mercato (±3 giorni, stessa
+// area geografica) che facevano la differenza tra ~0% e ~92% di
+// copertura.
+//
+// Stesso pattern del matcher esistente (ai/score.js): AI primaria con
+// fallback euristico deterministico se la chiave manca o la chiamata
+// fallisce, così la ricerca cicli non si blocca mai per un problema
+// di rete/quota OpenAI.
+import OpenAI from "openai";
+
+const client = process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+
+const MODEL = process.env.CHAIN_AI_MODEL || process.env.MATCH_AI_MODEL || "gpt-4o-mini";
+const TEMPERATURE = Number(process.env.CHAIN_AI_TEMP ?? 0);
+const MAX_CANDIDATES_PER_CALL = Number(process.env.CHAIN_AI_BATCH ?? 40);
+const CHAIN_AI_TIMEOUT_MS = Number(process.env.CHAIN_AI_TIMEOUT_MS ?? 15000);
+const CHAIN_SCORE_THRESHOLD = Number(process.env.CHAIN_SCORE_THRESHOLD ?? 65);
+
+// ----------------------------------------------------------------------
+// Fallback deterministico: cluster geografico + tolleranza data.
+// ----------------------------------------------------------------------
+
+// Regioni approssimate: sufficiente per giudicare "abbastanza vicino da
+// valere uno scambio", non un dato geografico preciso.
+const REGION_BY_CITY = {
+  roma: "centro", firenze: "centro", bologna: "centro", perugia: "centro", pisa: "centro",
+  milano: "nord", torino: "nord", venezia: "nord", verona: "nord", genova: "nord",
+  trieste: "nord", bergamo: "nord", brescia: "nord", padova: "nord",
+  napoli: "sud", bari: "sud", palermo: "sud", catania: "sud", cagliari: "sud",
+  salerno: "sud", messina: "sud",
+};
+
+function normCityKey(s) {
+  return String(s || "")
+    .toLowerCase()
+    .normalize("NFD").replace(/[̀-ͯ]/g, "") // rimuove accenti
+    .trim();
+}
+
+function regionOf(cityRaw) {
+  const key = normCityKey(cityRaw);
+  if (!key) return null;
+  if (REGION_BY_CITY[key]) return REGION_BY_CITY[key];
+  // match parziale: "Roma Termini" -> "roma"
+  for (const known of Object.keys(REGION_BY_CITY)) {
+    if (key.includes(known)) return REGION_BY_CITY[known];
+  }
+  return null;
+}
+
+// route_from/route_to sono le colonne strutturate; `location` a volte
+// contiene "CittaA-->CittaB" come stringa legacy (vedi CreateListingScreen).
+function parseArrowLocation(location) {
+  const s = String(location || "");
+  const m = s.split(/-->|→/).map((x) => x.trim()).filter(Boolean);
+  if (m.length >= 2) return { from: m[0], to: m[1] };
+  if (m.length === 1) return { from: m[0], to: null };
+  return { from: null, to: null };
+}
+
+function routeOf(listing) {
+  if (listing?.type === "hotel") {
+    const city = listing.location || null;
+    return { from: city, to: city };
+  }
+  const from = listing?.route_from || parseArrowLocation(listing?.location).from;
+  const to = listing?.route_to || parseArrowLocation(listing?.location).to;
+  return { from, to };
+}
+
+function dateOf(listing) {
+  const raw = listing?.type === "hotel" ? listing?.check_in : listing?.depart_at;
+  if (!raw) return null;
+  const d = new Date(raw);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+function withinDateTolerance(a, b, days) {
+  const da = dateOf(a);
+  const db = dateOf(b);
+  if (!da || !db) return false;
+  const diffDays = Math.abs(da.getTime() - db.getTime()) / (1000 * 60 * 60 * 24);
+  return diffDays <= days;
+}
+
+function sameRegionRoute(want, candidate) {
+  const w = routeOf(want);
+  const c = routeOf(candidate);
+  const rFrom = regionOf(w.from);
+  const rTo = regionOf(w.to);
+  if (!rFrom || !rTo) return false;
+  return rFrom === regionOf(c.from) && rTo === regionOf(c.to);
+}
+
+/**
+ * Fallback deterministico, sempre disponibile (nessuna chiamata esterna).
+ * Score: 30 base, +15 se le date sono vicine (±3gg), +55 se stessa area
+ * geografica — la soglia CHAIN_SCORE_THRESHOLD (65) passa solo quando
+ * l'area coincide, la vicinanza di data da sola non basta.
+ */
+export function heuristicChainScore(wantListing, candidates, { dateToleranceDays = 3 } = {}) {
+  return (candidates || [])
+    .filter(Boolean)
+    .map((c) => {
+      if (!wantListing || c.type !== wantListing.type) {
+        return { id: c.id, score: 0, reason: "tipo diverso" };
+      }
+      const dateOk = withinDateTolerance(wantListing, c, dateToleranceDays);
+      const regionOk = sameRegionRoute(wantListing, c);
+      const score = 30 + (dateOk ? 15 : 0) + (regionOk ? 55 : 0);
+      return {
+        id: c.id,
+        score: Math.min(100, score),
+        reason: `${regionOk ? "stessa area" : "area diversa"}, ${dateOk ? "date vicine" : "date distanti"}`,
+        model: "heuristic",
+      };
+    })
+    .sort((a, b) => b.score - a.score || String(a.id).localeCompare(String(b.id)));
+}
+
+// ----------------------------------------------------------------------
+// AI: normalizzazione semantica (città/date) via LLM.
+// Non richiede la tabella di regioni statica: giudica caso per caso se
+// due città sono "abbastanza vicine" per uno scambio, gestendo anche
+// varianti testuali (es. "Roma Termini" vs "Roma Tiburtina") e città
+// fuori dalla mappa statica del fallback.
+// ----------------------------------------------------------------------
+
+function truncate(s, n) {
+  const str = String(s || "");
+  return str.length > n ? str.slice(0, n) + "…" : str;
+}
+
+function slimListing(l) {
+  const r = routeOf(l);
+  return {
+    id: l.id,
+    type: l.type,
+    from: truncate(r.from, 60),
+    to: truncate(r.to, 60),
+    date: dateOf(l)?.toISOString() ?? null,
+    price: l.price ?? null,
+  };
+}
+
+function buildChainPrompt(wantListing, candidatesBatch) {
+  const want = slimListing(wantListing);
+  const candidates = candidatesBatch.map(slimListing);
+  return `Sei un motore di normalizzazione fuzzy per uno scambio di biglietti/prenotazioni di viaggio.
+Un utente CERCA questo: ${JSON.stringify(want)}
+
+Per ciascun annuncio candidato, stima uno score 0-100 di quanto bene soddisferebbe questa richiesta SE scambiato, tollerando:
+- città vicine/equivalenti per uno spostamento (stessa area metropolitana, stazioni diverse della stessa città, città limitrofe ben collegate) anche se il nome non è identico;
+- differenze di data fino a circa 3 giorni;
+- non tollerare tipo diverso (treno vs hotel) o città in aree completamente diverse d'Italia.
+
+Linee guida punteggio: 30=nessuna corrispondenza, 65=area compatibile ma data lontana o viceversa, 85+=area e data entrambe compatibili.
+
+Rispondi SOLO con:
+{"scores": [{"id": "<uuid>", "score": <int 0-100>, "reason": "<max 100 char, in italiano>"}]}
+Un elemento per OGNI candidato, nessuna omissione.
+
+Candidati: ${JSON.stringify(candidates)}`;
+}
+
+async function callOpenAIChainScore(prompt, timeoutMs) {
+  if (!client) return null;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort("timeout"), timeoutMs);
+  try {
+    const resp = await client.responses.create(
+      {
+        model: MODEL,
+        input: prompt,
+        temperature: TEMPERATURE,
+        text: {
+          format: {
+            type: "json_schema",
+            name: "chain_scores_payload",
+            strict: true,
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              required: ["scores"],
+              properties: {
+                scores: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["id", "score", "reason"],
+                    properties: {
+                      id: { type: "string" },
+                      score: { type: "integer", minimum: 0, maximum: 100 },
+                      reason: { type: "string", maxLength: 120 },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      { signal: ctrl.signal }
+    );
+    clearTimeout(timer);
+
+    let text = "";
+    if (typeof resp?.output_text === "string") text = resp.output_text;
+    else if (Array.isArray(resp?.output)) {
+      const c = resp.output[0]?.content?.[0];
+      if (c?.type === "output_text") text = c.text || "";
+    }
+    if (!text.trim()) return null;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = null;
+    }
+    return Array.isArray(parsed?.scores) ? parsed.scores : null;
+  } catch (e) {
+    clearTimeout(timer);
+    console.error("[chainMatch] OpenAI error:", e?.status, e?.message || e);
+    return null;
+  }
+}
+
+function validateChainScores(raw, knownIds) {
+  if (!Array.isArray(raw)) return null;
+  const ids = new Set(knownIds);
+  const out = [];
+  for (const x of raw) {
+    if (!x || !ids.has(x.id)) continue;
+    let s = Number.isFinite(Number(x.score)) ? Math.round(Number(x.score)) : 0;
+    s = Math.max(0, Math.min(100, s));
+    out.push({
+      id: x.id,
+      score: s,
+      reason: typeof x.reason === "string" ? x.reason.slice(0, 200) : "",
+      model: MODEL,
+    });
+  }
+  return out;
+}
+
+/**
+ * Prova la normalizzazione AI; se non disponibile o fallisce, ricade sul
+ * fallback deterministico (mai null/undefined, sempre un array).
+ */
+export async function scoreChainCandidates(wantListing, candidates) {
+  if (!Array.isArray(candidates) || candidates.length === 0) return [];
+  if (!client) return heuristicChainScore(wantListing, candidates);
+
+  const sorted = candidates.slice().sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  const allIds = sorted.map((c) => c.id);
+  const results = [];
+
+  for (let i = 0; i < sorted.length; i += MAX_CANDIDATES_PER_CALL) {
+    const batch = sorted.slice(i, i + MAX_CANDIDATES_PER_CALL);
+    const prompt = buildChainPrompt(wantListing, batch);
+    const raw = await callOpenAIChainScore(prompt, CHAIN_AI_TIMEOUT_MS);
+    const validated = validateChainScores(raw, batch.map((c) => c.id));
+    if (!validated || !validated.length) {
+      // un batch fallito -> ricadi sull'euristica per l'intero lotto di candidati
+      return heuristicChainScore(wantListing, candidates);
+    }
+    results.push(...validated);
+  }
+
+  const byId = new Map(results.map((r) => [r.id, r]));
+  return allIds
+    .map((id) => byId.get(id) || { id, score: 0, reason: "", model: MODEL })
+    .sort((a, b) => b.score - a.score || String(a.id).localeCompare(String(b.id)));
+}
+
+export const CHAIN_SCORE_PASS_THRESHOLD = CHAIN_SCORE_THRESHOLD;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,6 +8,7 @@ import { trustscoreRouter } from './routes/trustscore.js';
 // Routers esistenti
 import { listingsRouter } from './routes/listing.js';
 import { matchesRouter } from './routes/match.js';
+import { chainsRouter } from './routes/chains.js';
 
 // Parser / ingest / Messenger
 import { parseFacebookText } from './parsers/fbParser.js';
@@ -39,6 +40,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use('/ai', trustscoreRouter);
 app.use('/api/listings', listingsRouter);
 app.use('/api/matches', matchesRouter);
+app.use('/api/chains', chainsRouter);
 app.use('/', translateListingsRouter);
 
 mountParseDescriptionRoute(app, [requireAuth, rateLimitParse]);

--- a/server/src/models/chains.js
+++ b/server/src/models/chains.js
@@ -1,0 +1,190 @@
+// server/src/models/chains.js
+// Motore di ricerca degli swap a catena (fase 2): trova cicli chiusi di
+// esattamente 3 utenti tra gli annunci attivi e li propone via
+// create_chain_proposal() (RPC Postgres, fase 1 — vedi
+// supabase/migrations/20260712120000_swap_chains.sql).
+//
+// v1: un solo annuncio VENDO per utente considerato (se un utente ha più
+// annunci attivi in VENDO, viene escluso dal grafo — evita l'ambiguità
+// di "quale dei suoi annunci starebbe dando" finché non serve altro).
+import { supabase } from "../db.js";
+import { listActiveListings } from "./listings.js";
+import { scoreChainCandidates, CHAIN_SCORE_PASS_THRESHOLD } from "../ai/chainMatch.js";
+
+/**
+ * Trova cicli diretti di lunghezza esatta 3 in un grafo { ownerId: Set<ownerId> }.
+ * Pura e sincrona: nessuna I/O, per essere testabile senza mock di rete/DB.
+ * Ritorna un array di terne [a, b, c] (a->b->c->a), senza duplicati
+ * (stessa terna in rotazioni diverse conta una sola volta).
+ */
+export function findThreeCycles(edges) {
+  const cycles = [];
+  const seen = new Set();
+
+  for (const a of edges.keys()) {
+    const bs = edges.get(a) || new Set();
+    for (const b of bs) {
+      if (b === a) continue;
+      const cs = edges.get(b) || new Set();
+      for (const c of cs) {
+        if (c === a || c === b) continue;
+        const as = edges.get(c) || new Set();
+        if (!as.has(a)) continue;
+
+        const key = [a, b, c].slice().sort().join("|");
+        if (seen.has(key)) continue;
+        seen.add(key);
+        cycles.push([a, b, c]);
+      }
+    }
+  }
+  return cycles;
+}
+
+/**
+ * Raggruppa gli annunci attivi per proprietario, tenendo solo i CERCO e i
+ * VENDO. Esclude i proprietari con 0 o >1 annunci VENDO attivi (v1: un
+ * solo annuncio da dare a testa, per evitare ambiguità su quale annuncio
+ * verrebbe usato nella catena).
+ */
+function groupListings(allActive) {
+  const vendoByOwner = new Map();
+  const cercoByOwner = new Map();
+
+  for (const l of allActive) {
+    if (l.cerco_vendo === "VENDO") {
+      if (!vendoByOwner.has(l.user_id)) vendoByOwner.set(l.user_id, []);
+      vendoByOwner.get(l.user_id).push(l);
+    } else if (l.cerco_vendo === "CERCO") {
+      if (!cercoByOwner.has(l.user_id)) cercoByOwner.set(l.user_id, []);
+      cercoByOwner.get(l.user_id).push(l);
+    }
+  }
+
+  const singleVendoByOwner = new Map();
+  for (const [owner, listings] of vendoByOwner) {
+    if (listings.length === 1) singleVendoByOwner.set(owner, listings[0]);
+  }
+
+  return { singleVendoByOwner, cercoByOwner };
+}
+
+/**
+ * Costruisce il grafo dei desideri: arco owner(A) -> owner(B) se A ha un
+ * annuncio CERCO soddisfatto (score >= soglia) da un annuncio VENDO di B.
+ * Solo proprietari con esattamente 1 annuncio VENDO attivo partecipano
+ * (vedi groupListings).
+ */
+export async function buildDesireGraph(allActive) {
+  const { singleVendoByOwner, cercoByOwner } = groupListings(allActive);
+  const edges = new Map();
+
+  for (const [owner, cercoListings] of cercoByOwner) {
+    const myGive = singleVendoByOwner.get(owner);
+    if (!myGive) continue; // niente da dare -> non può partecipare a una catena
+
+    for (const want of cercoListings) {
+      const candidates = [];
+      for (const [otherOwner, vendo] of singleVendoByOwner) {
+        if (otherOwner === owner) continue;
+        if (vendo.type !== want.type) continue;
+        candidates.push(vendo);
+      }
+      if (!candidates.length) continue;
+
+      const scored = await scoreChainCandidates(want, candidates);
+      for (const s of scored) {
+        if (s.score < CHAIN_SCORE_PASS_THRESHOLD) continue;
+        const candidateOwner = candidates.find((c) => c.id === s.id)?.user_id;
+        if (!candidateOwner) continue;
+        if (!edges.has(owner)) edges.set(owner, new Set());
+        edges.get(owner).add(candidateOwner);
+      }
+    }
+  }
+
+  return { edges, singleVendoByOwner };
+}
+
+/**
+ * Utenti già coinvolti in una catena 'proposed' (per non riproporli finché
+ * quella non si chiude/decade/scade).
+ */
+async function ownersWithPendingChain() {
+  const { data: pendingChains, error: err1 } = await supabase
+    .from("chain_proposals")
+    .select("id")
+    .eq("status", "proposed");
+  if (err1) throw err1;
+
+  const chainIds = (pendingChains || []).map((c) => c.id);
+  if (!chainIds.length) return new Set();
+
+  const { data: participants, error: err2 } = await supabase
+    .from("chain_participants")
+    .select("user_id")
+    .in("chain_id", chainIds);
+  if (err2) throw err2;
+
+  return new Set((participants || []).map((r) => r.user_id));
+}
+
+/**
+ * Entry point: trova cicli di 3 tra gli annunci attivi e propone una
+ * chain_proposal per ognuno (via RPC service-role). Ritorna un riepilogo,
+ * non lancia eccezioni per un singolo ciclo fallito (continua con gli altri).
+ */
+export async function findAndProposeChains() {
+  if (!supabase) throw new Error("Supabase client not configured");
+
+  const allActive = await listActiveListings({ limit: 1000 });
+  const { edges, singleVendoByOwner } = await buildDesireGraph(allActive);
+  const cycles = findThreeCycles(edges);
+
+  const pending = await ownersWithPendingChain();
+  const proposed = [];
+  const skipped = [];
+  const errors = [];
+
+  for (const [a, b, c] of cycles) {
+    if (pending.has(a) || pending.has(b) || pending.has(c)) {
+      skipped.push({ owners: [a, b, c], reason: "owner already in a pending chain" });
+      continue;
+    }
+
+    const listingA = singleVendoByOwner.get(a);
+    const listingB = singleVendoByOwner.get(b);
+    const listingC = singleVendoByOwner.get(c);
+    if (!listingA || !listingB || !listingC) continue;
+
+    const participants = [
+      { user_id: a, give_listing_id: listingA.id, receive_listing_id: listingB.id },
+      { user_id: b, give_listing_id: listingB.id, receive_listing_id: listingC.id },
+      { user_id: c, give_listing_id: listingC.id, receive_listing_id: listingA.id },
+    ];
+
+    const { data, error } = await supabase.rpc("create_chain_proposal", {
+      p_participants: participants,
+    });
+
+    if (error) {
+      errors.push({ owners: [a, b, c], error: error.message });
+      continue;
+    }
+
+    proposed.push({ chainId: data, owners: [a, b, c] });
+    // evita di riusare gli stessi 3 utenti in un altro ciclo trovato in questo stesso giro
+    pending.add(a);
+    pending.add(b);
+    pending.add(c);
+  }
+
+  return {
+    scannedListings: allActive.length,
+    candidateOwners: singleVendoByOwner.size,
+    cyclesFound: cycles.length,
+    proposed,
+    skipped,
+    errors,
+  };
+}

--- a/server/src/routes/chains.js
+++ b/server/src/routes/chains.js
@@ -1,0 +1,33 @@
+// server/src/routes/chains.js
+import express from "express";
+import { findAndProposeChains } from "../models/chains.js";
+
+export const chainsRouter = express.Router();
+
+// Protetto da un secret condiviso, NON dal login utente: questo endpoint
+// scansiona gli annunci di TUTTI gli utenti (serve il client service-role,
+// vedi db.js), quindi non è pensato per essere chiamato dal client mobile
+// ma da un job periodico/admin. Fail-closed: se CHAIN_CRON_SECRET non è
+// configurato, l'endpoint rifiuta sempre — meglio un 503 esplicito che un
+// endpoint di scansione globale accidentalmente pubblico.
+function requireCronSecret(req, res, next) {
+  const configured = process.env.CHAIN_CRON_SECRET;
+  if (!configured) {
+    return res.status(503).json({ error: "CHAIN_CRON_SECRET not configured" });
+  }
+  const provided = req.get("X-Cron-Secret") || "";
+  if (provided !== configured) {
+    return res.status(401).json({ error: "Invalid or missing X-Cron-Secret" });
+  }
+  next();
+}
+
+chainsRouter.post("/recompute", requireCronSecret, async (req, res) => {
+  try {
+    const out = await findAndProposeChains();
+    return res.status(200).json(out);
+  } catch (e) {
+    console.error("[chains/recompute] error:", e);
+    return res.status(500).json({ error: String(e?.message || e) });
+  }
+});

--- a/server/test/chains.test.js
+++ b/server/test/chains.test.js
@@ -1,0 +1,68 @@
+// Test per la ricerca cicli dello swap a catena (fase 2)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findThreeCycles } from '../src/models/chains.js';
+
+function graphFromPairs(pairs) {
+  const edges = new Map();
+  for (const [a, b] of pairs) {
+    if (!edges.has(a)) edges.set(a, new Set());
+    edges.get(a).add(b);
+  }
+  return edges;
+}
+
+test('trova un ciclo chiuso di 3', () => {
+  const edges = graphFromPairs([
+    ['A', 'B'],
+    ['B', 'C'],
+    ['C', 'A'],
+  ]);
+  const cycles = findThreeCycles(edges);
+  assert.equal(cycles.length, 1);
+  assert.deepEqual(cycles[0].slice().sort(), ['A', 'B', 'C']);
+});
+
+test('nessun ciclo se manca un arco di chiusura', () => {
+  const edges = graphFromPairs([
+    ['A', 'B'],
+    ['B', 'C'],
+    // manca C -> A
+  ]);
+  assert.deepEqual(findThreeCycles(edges), []);
+});
+
+test('un ciclo a 2 (reciproco diretto) non conta come ciclo a 3', () => {
+  const edges = graphFromPairs([
+    ['A', 'B'],
+    ['B', 'A'],
+  ]);
+  assert.deepEqual(findThreeCycles(edges), []);
+});
+
+test('deduplica lo stesso ciclo trovato da punti di partenza diversi', () => {
+  const edges = graphFromPairs([
+    ['A', 'B'],
+    ['B', 'C'],
+    ['C', 'A'],
+  ]);
+  // findThreeCycles itera su tutti i nodi come possibile punto di partenza:
+  // A->B->C->A, B->C->A->B, C->A->B->C sono la stessa terna
+  assert.equal(findThreeCycles(edges).length, 1);
+});
+
+test('trova più cicli distinti nello stesso grafo, ignora rumore senza chiusura', () => {
+  const edges = graphFromPairs([
+    ['A', 'B'], ['B', 'C'], ['C', 'A'], // ciclo 1
+    ['X', 'Y'], ['Y', 'Z'], ['Z', 'X'], // ciclo 2
+    ['P', 'Q'], ['Q', 'R'],             // nessuna chiusura
+  ]);
+  const cycles = findThreeCycles(edges).map((c) => c.slice().sort().join(','));
+  assert.equal(cycles.length, 2);
+  assert.ok(cycles.includes('A,B,C'));
+  assert.ok(cycles.includes('X,Y,Z'));
+});
+
+test('grafo vuoto non esplode', () => {
+  assert.deepEqual(findThreeCycles(new Map()), []);
+});

--- a/server/test/heuristicChainScore.test.js
+++ b/server/test/heuristicChainScore.test.js
@@ -1,0 +1,81 @@
+// Test per il fallback deterministico della normalizzazione fuzzy (fase 2)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { heuristicChainScore } from '../src/ai/chainMatch.js';
+
+const want = {
+  id: 'want-1',
+  type: 'train',
+  route_from: 'Roma',
+  route_to: 'Milano',
+  depart_at: '2026-08-01T09:00:00Z',
+};
+
+test('stessa area + date vicine: score alto, passa la soglia', () => {
+  const [top] = heuristicChainScore(want, [
+    { id: 'a', type: 'train', route_from: 'Roma', route_to: 'Milano', depart_at: '2026-08-02T09:00:00Z' },
+  ]);
+  assert.equal(top.score, 100); // 30 + 15 (data) + 55 (area)
+});
+
+test('stessa area ma date lontane: passa comunque la soglia (65)', () => {
+  const [top] = heuristicChainScore(want, [
+    { id: 'a', type: 'train', route_from: 'Roma', route_to: 'Milano', depart_at: '2026-09-15T09:00:00Z' },
+  ]);
+  assert.equal(top.score, 85); // 30 + 55 (area), niente bonus data
+});
+
+test('date vicine ma area diversa: NON passa la soglia (65)', () => {
+  const [top] = heuristicChainScore(want, [
+    { id: 'a', type: 'train', route_from: 'Palermo', route_to: 'Catania', depart_at: '2026-08-02T09:00:00Z' },
+  ]);
+  assert.equal(top.score, 45); // 30 + 15 (data), niente area
+  assert.ok(top.score < 65);
+});
+
+test('tipo diverso: score 0 a prescindere dal resto', () => {
+  const [top] = heuristicChainScore(want, [
+    { id: 'a', type: 'hotel', location: 'Roma', check_in: '2026-08-01' },
+  ]);
+  assert.equal(top.score, 0);
+});
+
+test('città nella stessa area ma non identiche (stazioni diverse) contano comunque', () => {
+  const wantVariant = { ...want, route_from: 'Roma Termini', route_to: 'Milano Centrale' };
+  const [top] = heuristicChainScore(wantVariant, [
+    { id: 'a', type: 'train', route_from: 'Roma Tiburtina', route_to: 'Milano Rogoredo', depart_at: '2026-08-01T09:00:00Z' },
+  ]);
+  assert.equal(top.score, 100);
+});
+
+test('fallback sul parsing di location "CittaA-->CittaB" quando route_from/route_to mancano', () => {
+  const wantLegacy = { id: 'want-2', type: 'train', location: 'Roma-->Milano', depart_at: '2026-08-01T09:00:00Z' };
+  const [top] = heuristicChainScore(wantLegacy, [
+    { id: 'a', type: 'train', location: 'Roma-->Milano', depart_at: '2026-08-01T09:00:00Z' },
+  ]);
+  assert.equal(top.score, 100);
+});
+
+test('hotel: confronta la città in location + check_in', () => {
+  const wantHotel = { id: 'want-3', type: 'hotel', location: 'Firenze', check_in: '2026-08-01' };
+  const [close, far] = heuristicChainScore(wantHotel, [
+    { id: 'a', type: 'hotel', location: 'Firenze centro', check_in: '2026-08-03' },
+    { id: 'b', type: 'hotel', location: 'Bari', check_in: '2026-08-01' },
+  ]).sort((x, y) => x.id.localeCompare(y.id));
+  assert.equal(close.score, 100); // stessa area (Firenze), date vicine
+  assert.equal(far.score, 45);    // area diversa, solo data vicina
+});
+
+test('ordina per score decrescente, tie-break per id', () => {
+  const out = heuristicChainScore(want, [
+    { id: 'z', type: 'train', route_from: 'Palermo', route_to: 'Catania', depart_at: '2026-08-01T09:00:00Z' },
+    { id: 'a', type: 'train', route_from: 'Roma', route_to: 'Milano', depart_at: '2026-08-01T09:00:00Z' },
+    { id: 'b', type: 'train', route_from: 'Roma', route_to: 'Milano', depart_at: '2026-08-01T09:00:00Z' },
+  ]);
+  assert.deepEqual(out.map((r) => r.id), ['a', 'b', 'z']);
+});
+
+test('input vuoto non esplode', () => {
+  assert.deepEqual(heuristicChainScore(want, []), []);
+  assert.deepEqual(heuristicChainScore(want, null), []);
+});


### PR DESCRIPTION
## Contesto

Segue la PR #20 (fase 1: schema DB per gli scambi a catena a 3). Questa è la **fase 2 di 4**: il motore lato server che *trova* i cicli da proporre.

## Cosa fa

- **`server/src/models/chains.js`** — costruisce il grafo dei desideri: per ogni annuncio CERCO di un utente, cerca tra gli annunci VENDO di altri utenti (stesso tipo) quelli che lo soddisferebbero, poi cerca cicli chiusi di 3 proprietari (`findThreeCycles`, funzione pura). Per ogni ciclo trovato, chiama `create_chain_proposal()` (RPC, fase 1) — con un controllo di dedup per non riproporre utenti già in una catena `proposed`.
- **`server/src/ai/chainMatch.js`** — normalizzazione fuzzy, stesso pattern del matcher 1:1 esistente (`ai/score.js`): **AI primaria** (prompt dedicato che tollera città vicine/varianti testuali e ±3 giorni) **con fallback euristico deterministico** (cluster geografico statico + tolleranza data) se la chiave OpenAI manca o la chiamata fallisce — la ricerca cicli non si blocca mai per un problema di rete/quota, esattamente come già succede oggi per il matching 1:1.
- **`POST /api/chains/recompute`** — nuovo endpoint, protetto da un secret condiviso (`CHAIN_CRON_SECRET`, header `X-Cron-Secret`) e **non** dal login utente, perché scansiona gli annunci di *tutti* gli utenti (non va esposto al client mobile). **Fail-closed**: se il secret non è configurato, l'endpoint rifiuta sempre con 503 invece di restare aperto per errore.

**Limite noto v1**: considera solo i proprietari con **esattamente un** annuncio VENDO attivo, per evitare l'ambiguità su "quale dei suoi annunci starebbe dando" se un utente ne ha più di uno attivo contemporaneamente. Documentato in `docs/IMPROVEMENTS.md`, da rilassare in un secondo momento.

## Validazione

- **15 test automatici nuovi** (`node --test`, stessa convenzione del repo) su tutta la logica pura: ricerca cicli (6 test — ciclo trovato, nessun ciclo, un 2-ciclo non conta, dedup, più cicli nello stesso grafo, grafo vuoto) e punteggio euristico di fallback (9 test — area+data compatibili, solo area, solo data non basta, tipo diverso, varianti testuali di città, parsing del formato legacy `CittaA-->CittaB`, hotel via `location`+`check_in`, ordinamento, input vuoto). Tutti passano insieme ai 19 test preesistenti (34/34).
- Smoke test manuale: il server si avvia correttamente con le nuove route montate, `/api/chains/recompute` risponde 503 senza secret configurato, 401 con secret sbagliato, e un 500 con messaggio chiaro (non crash) se Supabase non è configurato.

**⚠️ Non testato end-to-end** contro un vero progetto Supabase o una vera chiamata OpenAI (nessuno dei due disponibile in questo ambiente). Per ridurre il rischio, le query Supabase in `chains.js` usano solo pattern già presenti e collaudati altrove nel codebase (niente sintassi PostgREST nuova/non verificabile — ho scartato una prima versione con un join annidato `!inner` proprio perché non potevo validarla).

**Bug preesistente scoperto per caso durante lo smoke test** (non introdotto da questa PR, segnalato in `docs/IMPROVEMENTS.md`, non corretto qui): `server/src/services/trust/aiTrust.js` fa crashare l'intero server all'avvio se manca `OPENAI_API_KEY`, a differenza di `ai/score.js` (e del mio nuovo `ai/chainMatch.js`) che gestiscono correttamente l'assenza della chiave.

## Test plan

- [ ] Configurare `CHAIN_CRON_SECRET` sull'ambiente server (Render)
- [ ] Chiamare `POST /api/chains/recompute` con qualche annuncio di test reale e verificare che le chain_proposals vengano create correttamente
- [ ] (Dopo la fase 4/UI) verificare che un ciclo trovato sia effettivamente confermabile dai 3 utenti coinvolti


---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_