### PR TITLE
feat(swap-chains): unifica manutenzione in /api/chains/recompute

### DIFF
--- a/server/src/models/chains.js
+++ b/server/src/models/chains.js
@@ -138,6 +138,17 @@ async function ownersWithPendingChain() {
 export async function findAndProposeChains() {
   if (!supabase) throw new Error("Supabase client not configured");
 
+  // Manutenzione nella stessa chiamata: chi triggera questo endpoint
+  // periodicamente non deve configurare un secondo meccanismo solo per
+  // scadere le catene rimaste in sospeso troppo a lungo (expires_at, 48h).
+  let expiredCount = 0;
+  const { data: expireResult, error: expireErr } = await supabase.rpc("expire_old_chain_proposals");
+  if (expireErr) {
+    console.error("[chains] expire_old_chain_proposals failed:", expireErr.message);
+  } else {
+    expiredCount = expireResult ?? 0;
+  }
+
   const allActive = await listActiveListings({ limit: 1000 });
   const { edges, singleVendoByOwner } = await buildDesireGraph(allActive);
   const cycles = findThreeCycles(edges);
@@ -195,6 +206,7 @@ export async function findAndProposeChains() {
   }
 
   return {
+    expiredChains: expiredCount,
     scannedListings: allActive.length,
     candidateOwners: singleVendoByOwner.size,
     cyclesFound: cycles.length,


### PR DESCRIPTION
## Contesto

Il piano originale prevedeva due meccanismi periodici separati: `POST /api/chains/recompute` (trova nuove catene) e la funzione SQL `expire_old_chain_proposals()` (pulizia catene scadute), da triggerare entrambi. Per semplificare la configurazione lato utente (un solo trigger periodico da impostare invece di due), unisco le due operazioni.

## Cosa fa

`findAndProposeChains()` chiama ora `expire_old_chain_proposals()` (RPC) come primo passo, prima di cercare nuovi cicli — così le catene scadute liberano subito i loro partecipanti per una nuova proposta nello stesso giro, invece di aspettare la prossima esecuzione. Il conteggio (`expiredChains`) è incluso nella risposta JSON dell'endpoint per verifica visiva.

## Validazione

- 40/40 test automatici (`node --test`), nessuna regressione.
- Verificato contro PostgreSQL 16 locale: `expire_old_chain_proposals()` è chiamabile via RPC e scade correttamente una catena di test con `expires_at` nel passato (status passa da `proposed` a `expired`).

## Test plan

- [ ] Configurare un unico trigger periodico (es. cron-job.org) su `POST /api/chains/recompute` con header `X-Cron-Secret`
- [ ] Verificare che la risposta includa `expiredChains` e `proposed`/`cyclesFound` coerenti


---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_