### PR TITLE
fix(swap-chains): chiarezza visiva del giro + feedback su chiusura catena

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -88,11 +88,17 @@ Analisi di mercato con simulazione sintetica (300 utenti, 10 run): il matching r
 - Tradotta interamente in it/en/es dall'inizio (16 chiavi nuove in `chains.*` + 1 in `profile.chainProposals`, parità verificata).
 - ⚠️ Come le fasi precedenti, non testata su dispositivo reale (nessun modo di eseguire l'app in questo ambiente) — solo controllo sintattico e verifica di parità i18n.
 
+✅ **Testata end-to-end con dati reali dall'utente** (3 account di test, un ciclo Roma→Milano / Torino→Roma / Napoli→Bari creato via SQL Editor): il trigger periodico ha trovato il ciclo, creato la proposta, e la schermata l'ha mostrata correttamente nel Profilo. Prima vera conferma su un progetto Supabase reale, non solo in locale.
+
+**Migliorie fatte dopo il primo test utente** (la spiegazione era poco chiara, e a scambio completato la card spariva senza nessun feedback):
+- Aggiunta una versione visiva del giro nella card: frecce tra i 3 passaggi + un'icona "torna al primo" per chiudere visivamente il cerchio, e il verbo esplicito "dà" invece del solo trattino.
+- Aggiunto un popup di conferma quando lo scambio si chiude con successo (🎉), e uno separato se decade per un annuncio non più disponibile nel frattempo — prima in entrambi i casi la card spariva silenziosamente, senza che l'utente sapesse cosa fosse successo.
+- 7 chiavi i18n nuove, parità verificata.
+
 **Non ancora fatto / prossimi passi**:
 - La spiegazione è generata solo in italiano per ora (come le altre feature AI esistenti, non localizzate) — da rivedere se serve multilingua.
 - Nessun badge/notifica quando arriva una nuova proposta — l'utente deve aprire la schermata per scoprirla (va bene per un primo test, da migliorare se il volume cresce).
-- **Da fare sul progetto Supabase reale**: applicare le migrazioni `20260712120000_swap_chains.sql` e `20260712180000_chain_explanation.sql`.
-- **Da fare sul server (Render)**: configurare `CHAIN_CRON_SECRET` + verificare `OPENAI_API_KEY`, e impostare un trigger periodico (cron esterno o Render) per `POST /api/chains/recompute` e per la funzione SQL `expire_old_chain_proposals()` — per ora nessuno dei due parte da solo.
+- **Fatto sul progetto Supabase reale**: migrazioni applicate, `CHAIN_CRON_SECRET`/`OPENAI_API_KEY` configurati su Render, trigger periodico attivo su cron-job.org.
 
 ### D3. Avvisi di ricerca ("price/route alert")
 "Avvisami quando compare un treno Roma→Milano sotto 40€". Sfrutta il motore di matching che c'è già, girato al contrario. Ottima retention.

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -117,6 +117,13 @@ export const translations = {
       emptyText: "Nessuna proposta di scambio a 3 al momento.\nQuando ne troviamo una che ti riguarda, la vedrai qui.",
       unknownListing: "Annuncio non disponibile",
       unknownCity: "città sconosciuta",
+      gives: "dà",
+      legsCaption: "Ecco il giro:",
+      backToStart: "torna al primo — il giro si chiude",
+      completedTitle: "🎉 Scambio completato!",
+      completedMsg: "Tutti e 3 avete confermato: lo scambio è avvenuto. Lo trovi anche in \"I miei scambi\".",
+      canceledTitle: "Scambio non riuscito",
+      canceledMsg: "Nel frattempo uno degli annunci coinvolti non è più disponibile. Nessuno ha perso nulla.",
     },
 
     editProfileScreen: {
@@ -753,6 +760,13 @@ export const translations = {
       emptyText: "No 3-way swap proposals right now.\nWhen we find one that involves you, it'll show up here.",
       unknownListing: "Listing unavailable",
       unknownCity: "unknown city",
+      gives: "gives",
+      legsCaption: "Here's the loop:",
+      backToStart: "back to the first one — the loop closes",
+      completedTitle: "🎉 Swap completed!",
+      completedMsg: "All 3 of you confirmed: the swap went through. You'll also find it under \"My transactions\".",
+      canceledTitle: "Swap didn't go through",
+      canceledMsg: "One of the listings involved is no longer available. Nobody lost anything.",
     },
 
     editProfileScreen: {
@@ -1357,6 +1371,13 @@ export const translations = {
       emptyText: "No hay propuestas de intercambio a 3 por ahora.\nCuando encontremos una que te involucre, aparecerá aquí.",
       unknownListing: "Anuncio no disponible",
       unknownCity: "ciudad desconocida",
+      gives: "da",
+      legsCaption: "Así es el ciclo:",
+      backToStart: "vuelve al primero — el ciclo se cierra",
+      completedTitle: "🎉 ¡Intercambio completado!",
+      completedMsg: "Los 3 habéis confirmado: el intercambio se ha realizado. También lo encontrarás en \"Mis intercambios\".",
+      canceledTitle: "El intercambio no se completó",
+      canceledMsg: "Mientras tanto, uno de los anuncios implicados ya no está disponible. Nadie ha perdido nada.",
     },
 
     editProfileScreen: {

--- a/travelswap_ai/travelswapai/screens/ChainProposalsScreen.js
+++ b/travelswap_ai/travelswapai/screens/ChainProposalsScreen.js
@@ -53,20 +53,33 @@ function ChainCard({ chain, onConfirm, onDecline, busyId, t, locale }) {
         {chain.explanation || t("chains.noExplanation", "Abbiamo trovato uno scambio a 3 che ti riguarda.")}
       </Text>
 
+      <Text style={styles.legsCaption}>{t("chains.legsCaption", "Ecco il giro:")}</Text>
       <View style={styles.legs}>
-        {chain.participants.map((p) => (
-          <View key={p.position} style={styles.leg}>
-            <Ionicons
-              name={p.confirmed ? "checkmark-circle" : "time-outline"}
-              size={16}
-              color={p.confirmed ? theme.colors.success : theme.colors.textMuted}
-            />
-            <Text style={styles.legText}>
-              {p.isMe ? t("chains.you", "Tu") : t("chains.otherUser", "Un altro utente")}
-              {" — "}
-              {describeListing(p.listing, t, locale)}
-            </Text>
-          </View>
+        {chain.participants.map((p, idx) => (
+          <React.Fragment key={p.position}>
+            <View style={styles.leg}>
+              <Ionicons
+                name={p.confirmed ? "checkmark-circle" : "time-outline"}
+                size={16}
+                color={p.confirmed ? theme.colors.success : theme.colors.textMuted}
+              />
+              <Text style={styles.legText}>
+                {p.isMe ? t("chains.you", "Tu") : t("chains.otherUser", "Un altro utente")}
+                {" "}{t("chains.gives", "dà")}{": "}
+                {describeListing(p.listing, t, locale)}
+              </Text>
+            </View>
+            {idx < chain.participants.length - 1 ? (
+              <View style={styles.legArrow}>
+                <Ionicons name="arrow-down-outline" size={16} color={theme.colors.textMuted} />
+              </View>
+            ) : (
+              <View style={styles.legArrow}>
+                <Ionicons name="repeat-outline" size={16} color={theme.colors.textMuted} />
+                <Text style={styles.legArrowText}>{t("chains.backToStart", "torna al primo — il giro si chiude")}</Text>
+              </View>
+            )}
+          </React.Fragment>
         ))}
       </View>
 
@@ -124,8 +137,19 @@ export default function ChainProposalsScreen() {
   const handleConfirm = useCallback(async (chainId) => {
     setBusyId(chainId);
     try {
-      await confirmChain(chainId);
+      const result = await confirmChain(chainId);
       await load();
+      if (result?.status === "completed") {
+        Alert.alert(
+          t("chains.completedTitle", "🎉 Scambio completato!"),
+          t("chains.completedMsg", "Tutti e 3 avete confermato: lo scambio è avvenuto. Lo trovi anche in \"I miei scambi\".")
+        );
+      } else if (result?.status === "canceled") {
+        Alert.alert(
+          t("chains.canceledTitle", "Scambio non riuscito"),
+          t("chains.canceledMsg", "Nel frattempo uno degli annunci coinvolti non è più disponibile. Nessuno ha perso nulla.")
+        );
+      }
     } catch (e) {
       Alert.alert(t("common.error", "Errore"), e?.message || t("chains.confirmError", "Impossibile confermare lo scambio."));
     } finally {
@@ -240,9 +264,12 @@ const styles = StyleSheet.create({
   badgeText: { fontSize: 12, fontWeight: "800", color: theme.colors.accentOn },
   progressText: { fontSize: 12, color: theme.colors.textMuted, fontWeight: "600" },
   explanation: { color: theme.colors.text, lineHeight: 20, marginBottom: 12 },
-  legs: { gap: 8, marginBottom: 14 },
-  leg: { flexDirection: "row", alignItems: "center", gap: 8 },
+  legsCaption: { fontSize: 12, fontWeight: "700", color: theme.colors.textMuted, marginBottom: 6 },
+  legs: { marginBottom: 14 },
+  leg: { flexDirection: "row", alignItems: "center", gap: 8, paddingVertical: 2 },
   legText: { color: theme.colors.text, flexShrink: 1 },
+  legArrow: { flexDirection: "row", alignItems: "center", gap: 6, paddingLeft: 3, paddingVertical: 2 },
+  legArrowText: { fontSize: 11, color: theme.colors.textMuted, fontStyle: "italic" },
   actionsRow: { flexDirection: "row", gap: 10 },
   waitingRow: { alignItems: "center", gap: 6 },
   waitingText: { color: theme.colors.textMuted, textAlign: "center" },


### PR DESCRIPTION
## Contesto

Feedback diretto dopo il **primo test end-to-end reale** della feature (3 account di test, ciclo Roma→Milano/Torino→Roma/Napoli→Bari creato via SQL Editor su Supabase, trovato correttamente dal trigger periodico su cron-job.org e mostrato nell'app). Prima vera conferma su un progetto Supabase reale — finora tutto era stato validato solo in locale.

Due problemi segnalati:
1. La spiegazione testuale da sola era poco chiara.
2. A scambio concluso (tutti e 3 confermato), la card spariva dalla lista senza nessun feedback — l'utente non sapeva se fosse andato a buon fine o cosa fosse successo.

## Cosa fa

- **Versione visiva del giro**: frecce (↓) tra i 3 passaggi della catena + un'icona "torna al primo" per chiudere il cerchio visivamente, e il verbo esplicito "dà" al posto del solo trattino tra "Tu"/"Un altro utente" e l'annuncio.
- **Popup di chiusura**: 🎉 quando lo scambio si conclude con successo dopo l'ultima conferma; popup separato e distinto se invece decade perché nel frattempo un annuncio non è più disponibile (stesso bug di "sparisce senza spiegazione", ma per un caso diverso — non ancora notato dall'utente ma stesso difetto strutturale, corretto insieme).

## Validazione

- Sintassi verificata con `esbuild`.
- 7 chiavi i18n nuove (`gives`, `legsCaption`, `backToStart`, `completedTitle`/`Msg`, `canceledTitle`/`Msg`), parità verificata su it/en/es.
- Icone Ionicons nuove (`arrow-down-outline`, `repeat-outline`) verificate contro il pacchetto reale prima di usarle.
- **Non testata su dispositivo** in questo giro (nessun modo di eseguire l'app in questo ambiente) — la logica di `result?.status === "completed"/"canceled"` si basa sul valore di ritorno di `confirm_chain_participant()` (che ritorna `public.chain_proposals`, un singolo record), comportamento standard PostgREST/Supabase-js ma non verificabile end-to-end qui.

## Test plan

- [ ] Con l'ambiente di test già pronto dell'utente (3 account, catena esistente): rifare un giro di conferme e verificare che il popup 🎉 compaia sull'ultima conferma
- [ ] Verificare visivamente che le frecce tra i passaggi rendano il "giro" più chiaro


---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_