### PR TITLE
feat(onboarding): raccolta preferenze di viaggio dopo la registrazione (D4)

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -103,8 +103,14 @@ Analisi di mercato con simulazione sintetica (300 utenti, 10 run): il matching r
 ### D3. Avvisi di ricerca ("price/route alert")
 "Avvisami quando compare un treno Roma→Milano sotto 40€". Sfrutta il motore di matching che c'è già, girato al contrario. Ottima retention.
 
-### D4. Onboarding con preferenze
-Raccogliere tratte/città preferite in onboarding per alimentare da subito il matching AI e i preferiti — oggi le `prefs` del profilo esistono ma non vengono popolate in modo guidato.
+### D4. Onboarding con preferenze — ✅ FATTO
+Implementato: `screens/PreferencesOnboardingScreen.js` + `lib/preferences.js`. Mostrata **una sola volta per account**, subito dopo la registrazione (o al primo login se non era mai stata vista) — non ad ogni avvio: il segnale è `profiles.prefs.onboarded`, assente finché l'utente non salva o salta. Renderizzata fuori dallo Stack Navigator (nessuna nuova route da gestire), come passaggio intermedio tra login e `MainTabs`.
+
+Raccoglie esattamente i 3 campi già letti dal matcher euristico esistente (`server/src/ai/score.js`: `prefs.types`/`prefs.maxPrice`/`prefs.location`) — **zero modifiche al backend/DB**, la colonna `profiles.prefs` (jsonb) esisteva già mai popolata in modo guidato. "Salta per ora" scrive comunque `{onboarded:true}` per non ripresentare il prompt ad ogni avvio, senza impostare preferenze funzionali (comportamento del matching invariato per chi salta).
+
+Tradotto interamente in it/en/es dall'inizio (12 chiavi nuove in `prefsOnboarding.*`, parità verificata).
+
+⚠️ Non testato su dispositivo reale in questa sessione (nessun modo di eseguire l'app qui) — solo controllo sintattico e verifica i18n.
 
 ---
 

--- a/travelswap_ai/travelswapai/App.js
+++ b/travelswap_ai/travelswapai/App.js
@@ -23,7 +23,9 @@ import SavedScreen from './screens/SavedScreen';
 import TransactionsScreen from './screens/TransactionsScreen';
 import ManageImagesScreen from './screens/ManageImagesScreen';
 import ChainProposalsScreen from './screens/ChainProposalsScreen';
+import PreferencesOnboardingScreen from './screens/PreferencesOnboardingScreen';
 import { AuthProvider, useAuth } from './lib/auth';
+import { useNeedsPreferencesOnboarding } from './lib/preferences';
 import { I18nProvider } from './lib/i18n';
 import Constants from "expo-constants";
 import { useFonts, PlusJakartaSans_600SemiBold, PlusJakartaSans_700Bold, PlusJakartaSans_800ExtraBold } from '@expo-google-fonts/plus-jakarta-sans';
@@ -72,13 +74,22 @@ const linking = {
 
 function RootNavigator() {
   const { session, loading } = useAuth();
+  const { loading: prefsLoading, needsOnboarding, markDone } = useNeedsPreferencesOnboarding(session);
 
-  if (loading) {
+  if (loading || (session && prefsLoading)) {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
         <ActivityIndicator />
       </View>
     );
+  }
+
+  // Preferenze subito dopo la registrazione (D4): una volta sola per
+  // account (profiles.prefs.onboarded), non ad ogni avvio. Renderizzata
+  // fuori dal Navigator: niente route da gestire, solo un passaggio
+  // intermedio prima di entrare nell'app vera e propria.
+  if (session && needsOnboarding) {
+    return <PreferencesOnboardingScreen onDone={markDone} />;
   }
 
   return (

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -126,6 +126,21 @@ export const translations = {
       canceledMsg: "Nel frattempo uno degli annunci coinvolti non è più disponibile. Nessuno ha perso nulla.",
     },
 
+    prefsOnboarding: {
+      title: "Le tue preferenze di viaggio",
+      subtitle: "Aiutaci a trovarti gli scambi giusti — puoi cambiarle quando vuoi dal profilo.",
+      typeLabel: "Cosa ti interessa di più?",
+      typeTrain: "Treno",
+      typeHotel: "Hotel",
+      maxPriceLabel: "Budget massimo indicativo (€)",
+      maxPricePlaceholder: "Es. 100",
+      locationLabel: "Città o zona preferita",
+      locationPlaceholder: "Es. Milano",
+      save: "Salva preferenze",
+      skip: "Salta per ora",
+      saveError: "Impossibile salvare le preferenze.",
+    },
+
     editProfileScreen: {
       fullNameLabel: "Nome e cognome",
       fullNamePlaceholder: "Il tuo nome",
@@ -769,6 +784,21 @@ export const translations = {
       canceledMsg: "One of the listings involved is no longer available. Nobody lost anything.",
     },
 
+    prefsOnboarding: {
+      title: "Your travel preferences",
+      subtitle: "Help us find the right swaps for you — you can change these anytime from your profile.",
+      typeLabel: "What are you most interested in?",
+      typeTrain: "Train",
+      typeHotel: "Hotel",
+      maxPriceLabel: "Rough maximum budget (€)",
+      maxPricePlaceholder: "E.g. 100",
+      locationLabel: "Preferred city or area",
+      locationPlaceholder: "E.g. Milan",
+      save: "Save preferences",
+      skip: "Skip for now",
+      saveError: "Unable to save preferences.",
+    },
+
     editProfileScreen: {
       fullNameLabel: "Full name",
       fullNamePlaceholder: "Your name",
@@ -1378,6 +1408,21 @@ export const translations = {
       completedMsg: "Los 3 habéis confirmado: el intercambio se ha realizado. También lo encontrarás en \"Mis intercambios\".",
       canceledTitle: "El intercambio no se completó",
       canceledMsg: "Mientras tanto, uno de los anuncios implicados ya no está disponible. Nadie ha perdido nada.",
+    },
+
+    prefsOnboarding: {
+      title: "Tus preferencias de viaje",
+      subtitle: "Ayúdanos a encontrarte los intercambios adecuados — puedes cambiarlas cuando quieras desde el perfil.",
+      typeLabel: "¿Qué te interesa más?",
+      typeTrain: "Tren",
+      typeHotel: "Hotel",
+      maxPriceLabel: "Presupuesto máximo indicativo (€)",
+      maxPricePlaceholder: "Ej. 100",
+      locationLabel: "Ciudad o zona preferida",
+      locationPlaceholder: "Ej. Milán",
+      save: "Guardar preferencias",
+      skip: "Saltar por ahora",
+      saveError: "No se pudieron guardar las preferencias.",
     },
 
     editProfileScreen: {

--- a/travelswap_ai/travelswapai/lib/preferences.js
+++ b/travelswap_ai/travelswapai/lib/preferences.js
@@ -1,0 +1,72 @@
+// lib/preferences.js — onboarding con preferenze (D4)
+// Riusa la colonna profiles.prefs già esistente e già letta dal matcher
+// euristico lato server (server/src/ai/score.js: prefs.types/maxPrice/
+// location) — nessuna modifica DB necessaria, solo la UI per popolarla.
+import { useCallback, useEffect, useState } from "react";
+import { supabase } from "./supabase";
+
+export async function getMyPrefs() {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("prefs")
+    .eq("id", user.id)
+    .maybeSingle();
+  if (error) {
+    console.log("[getMyPrefs]", error.message);
+    return null;
+  }
+  return data?.prefs ?? {};
+}
+
+export async function saveMyPrefs(prefs) {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Non autenticato");
+  const { error } = await supabase
+    .from("profiles")
+    .upsert({ id: user.id, prefs: { ...prefs, onboarded: true } }, { onConflict: "id" });
+  if (error) throw error;
+}
+
+export async function skipPrefsOnboarding() {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
+  const { error } = await supabase
+    .from("profiles")
+    .upsert({ id: user.id, prefs: { onboarded: true } }, { onConflict: "id" });
+  if (error) console.log("[skipPrefsOnboarding]", error.message);
+}
+
+/**
+ * true finché l'utente loggato non ha mai salvato né saltato le
+ * preferenze (prefs.onboarded assente) — una volta sola per account,
+ * non ad ogni avvio.
+ */
+export function useNeedsPreferencesOnboarding(session) {
+  const [loading, setLoading] = useState(true);
+  const [needsOnboarding, setNeedsOnboarding] = useState(false);
+
+  const check = useCallback(async () => {
+    if (!session) {
+      setLoading(false);
+      setNeedsOnboarding(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const prefs = await getMyPrefs();
+      setNeedsOnboarding(!!prefs && !prefs.onboarded);
+    } catch {
+      setNeedsOnboarding(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.user?.id]);
+
+  useEffect(() => { check(); }, [check]);
+
+  const markDone = useCallback(() => setNeedsOnboarding(false), []);
+
+  return { loading, needsOnboarding, markDone };
+}

--- a/travelswap_ai/travelswapai/screens/PreferencesOnboardingScreen.js
+++ b/travelswap_ai/travelswapai/screens/PreferencesOnboardingScreen.js
@@ -1,0 +1,166 @@
+// screens/PreferencesOnboardingScreen.js — D4: preferenze subito dopo la
+// registrazione, per alimentare da subito il matching AI (server/src/ai/
+// score.js legge prefs.types/maxPrice/location per il fallback euristico,
+// e l'AI vera li usa come contesto).
+import React, { useState } from "react";
+import {
+  View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, Alert, ScrollView,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { theme } from "../lib/theme";
+import { useI18n } from "../lib/i18n";
+import { saveMyPrefs, skipPrefsOnboarding } from "../lib/preferences";
+import Input from "../components/ui/Input";
+import Button from "../components/ui/Button";
+
+const TYPE_OPTIONS = [
+  { key: "train", icon: "train-outline", labelKey: "prefsOnboarding.typeTrain", fallback: "Treno" },
+  { key: "hotel", icon: "bed-outline", labelKey: "prefsOnboarding.typeHotel", fallback: "Hotel" },
+];
+
+export default function PreferencesOnboardingScreen({ onDone }) {
+  const { t } = useI18n();
+  const [types, setTypes] = useState([]);
+  const [maxPrice, setMaxPrice] = useState("");
+  const [location, setLocation] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [skipping, setSkipping] = useState(false);
+
+  const toggleType = (key) => {
+    setTypes((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]));
+  };
+
+  const onSave = async () => {
+    setSaving(true);
+    try {
+      const priceNum = Number(String(maxPrice).replace(",", "."));
+      await saveMyPrefs({
+        types,
+        maxPrice: Number.isFinite(priceNum) && priceNum > 0 ? priceNum : undefined,
+        location: location.trim() || undefined,
+      });
+      onDone?.();
+    } catch (e) {
+      Alert.alert(t("common.error", "Errore"), e?.message || t("prefsOnboarding.saveError", "Impossibile salvare le preferenze."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onSkip = async () => {
+    setSkipping(true);
+    try {
+      await skipPrefsOnboarding();
+      onDone?.();
+    } catch {
+      // anche in errore, non blocchiamo l'utente sull'onboarding
+      onDone?.();
+    } finally {
+      setSkipping(false);
+    }
+  };
+
+  const busy = saving || skipping;
+
+  return (
+    <SafeAreaView style={styles.root}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>{t("prefsOnboarding.title", "Le tue preferenze di viaggio")}</Text>
+        <Text style={styles.subtitle}>
+          {t("prefsOnboarding.subtitle", "Aiutaci a trovarti gli scambi giusti — puoi cambiarle quando vuoi dal profilo.")}
+        </Text>
+
+        <Text style={styles.sectionLabel}>{t("prefsOnboarding.typeLabel", "Cosa ti interessa di più?")}</Text>
+        <View style={styles.typeRow}>
+          {TYPE_OPTIONS.map((opt) => {
+            const selected = types.includes(opt.key);
+            return (
+              <TouchableOpacity
+                key={opt.key}
+                onPress={() => toggleType(opt.key)}
+                style={[styles.typeChip, selected && styles.typeChipSelected]}
+                accessibilityRole="button"
+                accessibilityState={{ selected }}
+              >
+                <Ionicons
+                  name={opt.icon}
+                  size={20}
+                  color={selected ? theme.colors.accentOn : theme.colors.textMuted}
+                />
+                <Text style={[styles.typeChipText, selected && styles.typeChipTextSelected]}>
+                  {t(opt.labelKey, opt.fallback)}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <Input
+          label={t("prefsOnboarding.maxPriceLabel", "Budget massimo indicativo (€)")}
+          value={maxPrice}
+          onChangeText={setMaxPrice}
+          placeholder={t("prefsOnboarding.maxPricePlaceholder", "Es. 100")}
+          keyboardType="numeric"
+        />
+
+        <Input
+          label={t("prefsOnboarding.locationLabel", "Città o zona preferita")}
+          value={location}
+          onChangeText={setLocation}
+          placeholder={t("prefsOnboarding.locationPlaceholder", "Es. Milano")}
+        />
+
+        <Button
+          title={t("prefsOnboarding.save", "Salva preferenze")}
+          onPress={onSave}
+          loading={saving}
+          disabled={busy}
+          style={{ marginTop: 8 }}
+        />
+
+        <TouchableOpacity onPress={onSkip} disabled={busy} style={styles.skipBtn}>
+          {skipping ? (
+            <ActivityIndicator color={theme.colors.textMuted} />
+          ) : (
+            <Text style={styles.skipText}>{t("prefsOnboarding.skip", "Salta per ora")}</Text>
+          )}
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: theme.colors.background },
+  content: { padding: 24, paddingTop: 32 },
+  title: {
+    fontFamily: theme.fonts.headingExtraBold,
+    fontSize: 24,
+    color: theme.colors.text,
+    marginBottom: 8,
+  },
+  subtitle: { color: theme.colors.textMuted, lineHeight: 20, marginBottom: 24 },
+  sectionLabel: { fontWeight: "700", color: theme.colors.text, marginBottom: 10 },
+  typeRow: { flexDirection: "row", gap: 10, marginBottom: 20 },
+  typeChip: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 14,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
+  },
+  typeChipSelected: {
+    backgroundColor: theme.colors.accentSoft,
+    borderColor: theme.colors.accent,
+  },
+  typeChipText: { fontWeight: "700", color: theme.colors.textMuted },
+  typeChipTextSelected: { color: theme.colors.accentOn },
+  skipBtn: { alignItems: "center", marginTop: 16, padding: 8 },
+  skipText: { color: theme.colors.textMuted, fontWeight: "600" },
+});


### PR DESCRIPTION
## Contesto

Primo dei due item scelti dopo lo swap a catena: D4 (onboarding con preferenze), poi D3 (avvisi di ricerca), poi una valutazione complessiva dell'interfaccia.

## Cosa fa

- **`screens/PreferencesOnboardingScreen.js`** — chiede tipo preferito (treno/hotel, multi-selezione), budget massimo indicativo e città/zona preferita. Mostrata **una sola volta per account**, subito dopo la registrazione (o al primo login se non l'aveva mai vista) — non ad ogni avvio.
- **`lib/preferences.js`** — legge/scrive `profiles.prefs`. Il segnale "va mostrata?" è `prefs.onboarded` assente; "Salta per ora" lo imposta comunque a `true` per non ripresentare il prompt, senza però impostare preferenze funzionali (comportamento del matching invariato per chi salta).
- In `App.js`, la schermata è renderizzata **fuori dallo Stack Navigator** come passaggio intermedio tra sessione autenticata e `MainTabs` — nessuna nuova route da gestire, si "smonta" da sola (`onDone` → `markDone()`) quando l'utente salva o salta.

**Zero modifiche a DB/backend**: i 3 campi raccolti (`types`/`maxPrice`/`location`) sono esattamente quelli già letti dal matcher euristico esistente (`server/src/ai/score.js`) — la colonna `profiles.prefs` (jsonb) esisteva già dallo schema originale ma non veniva mai popolata in modo guidato dall'utente.

## Validazione

- Sintassi verificata con `esbuild` su tutti i file toccati.
- Tradotta interamente in it/en/es dall'inizio (12 chiavi nuove in `prefsOnboarding.*`), parità verificata.
- Audit i18n esteso a tutto l'app (369 chiavi reali controllate, 0 problemi residui) — stessa metodologia usata più volte in questa sessione dopo aver trovato bug reali con questo pattern.
- Icone Ionicons riusate (`train-outline`, `bed-outline`) già verificate contro il pacchetto reale in un giro precedente.

**⚠️ Non testata su dispositivo reale** in questo giro — nessun modo di eseguire l'app in questo ambiente.

## Test plan

- [ ] Registrare un nuovo utente di test e verificare che la schermata preferenze appaia subito dopo, prima dei tab principali
- [ ] Salvare le preferenze e verificare che `profiles.prefs` sul progetto Supabase reale contenga `types`/`maxPrice`/`location`/`onboarded:true`
- [ ] Rifare login con lo stesso utente e verificare che la schermata NON ricompaia
- [ ] Provare anche "Salta per ora" e verificare lo stesso comportamento (non ricompare, ma senza preferenze impostate)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_