### PR TITLE
UX 2/2: nuova architettura a 4 tab (Esplora / Vendi / Attività / Profilo)

### DIFF
--- a/travelswap_ai/travelswapai/App.js
+++ b/travelswap_ai/travelswapai/App.js
@@ -24,6 +24,7 @@ import TransactionsScreen from './screens/TransactionsScreen';
 import ManageImagesScreen from './screens/ManageImagesScreen';
 import ChainProposalsScreen from './screens/ChainProposalsScreen';
 import SavedSearchesScreen from './screens/SavedSearchesScreen';
+import MatchingScreen from './screens/MatchingScreen';
 import PreferencesOnboardingScreen from './screens/PreferencesOnboardingScreen';
 import { AuthProvider, useAuth } from './lib/auth';
 import { useNeedsPreferencesOnboarding } from './lib/preferences';
@@ -125,6 +126,7 @@ function RootNavigator() {
           <Stack.Screen name="ManageImages" component={ManageImagesScreen} options={{ title: "Foto annuncio" }} />
           <Stack.Screen name="ChainProposals" component={ChainProposalsScreen} options={{ title: "Scambi a 3" }} />
           <Stack.Screen name="SavedSearches" component={SavedSearchesScreen} options={{ title: "Avvisi di ricerca" }} />
+          <Stack.Screen name="Matching" component={MatchingScreen} options={{ title: "Suggeriti dall'AI" }} />
         </>
       ) : (
         <>

--- a/travelswap_ai/travelswapai/lib/ActivityContext.js
+++ b/travelswap_ai/travelswapai/lib/ActivityContext.js
@@ -1,0 +1,43 @@
+// lib/ActivityContext.js — stato condiviso della casella Attività, così il
+// numeretto rosso sul tab e la schermata leggono la stessa fonte e si
+// aggiornano insieme (è la risposta al "non vedevo la proposta a 3":
+// le cose da fare si contano sul tab, non restano nascoste).
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { loadActivity } from "./activity";
+
+const EMPTY = { toDo: [], waiting: [], found: [], history: [] };
+
+const ActivityContext = createContext({
+  summary: EMPTY,
+  toDoCount: 0,
+  loading: true,
+  refresh: () => {},
+});
+
+export function ActivityProvider({ children }) {
+  const [summary, setSummary] = useState(EMPTY);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await loadActivity();
+      setSummary({ toDo: s.toDo, waiting: s.waiting, found: s.found, history: s.history });
+    } catch (e) {
+      if (__DEV__) console.log("[Activity] refresh error", e?.message || e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  return (
+    <ActivityContext.Provider
+      value={{ summary, toDoCount: summary.toDo.length, loading, refresh }}
+    >
+      {children}
+    </ActivityContext.Provider>
+  );
+}
+
+export const useActivity = () => useContext(ActivityContext);

--- a/travelswap_ai/travelswapai/lib/activity.js
+++ b/travelswap_ai/travelswapai/lib/activity.js
@@ -1,0 +1,57 @@
+// lib/activity.js — aggrega tutto ciò che "ti succede" in un unico posto
+// (la casella Attività). Ogni fonte è best-effort: se una fallisce, le
+// altre restano, così un errore di rete non svuota l'intera schermata.
+import { listIncomingOffersAny, listOutgoingOffersAny } from "./offers";
+import { listMyChainProposals } from "./chains";
+import { listMyMatches } from "./savedSearches";
+import { listMyTransactions } from "./transactions";
+
+function isPending(status) {
+  return String(status || "").toLowerCase() === "pending";
+}
+
+/**
+ * Ritorna le quattro sezioni della casella Attività:
+ *  - toDo:    richiede una tua azione (proposte ricevute, catene da confermare)
+ *  - waiting: in attesa degli altri (proposte inviate, catene già confermate)
+ *  - found:   annunci trovati dai tuoi avvisi di ricerca
+ *  - history: scambi/vendite conclusi
+ */
+export async function loadActivity() {
+  const [incoming, outgoing, chains, matches, tx] = await Promise.all([
+    listIncomingOffersAny().catch(() => []),
+    listOutgoingOffersAny().catch(() => []),
+    listMyChainProposals().catch(() => []),
+    listMyMatches().catch(() => []),
+    listMyTransactions().catch(() => []),
+  ]);
+
+  const toDo = [];
+  incoming.filter((o) => isPending(o.status)).forEach((o) =>
+    toDo.push({ kind: "offer_in", id: "oi_" + o.id, sort: o.created_at, data: o })
+  );
+  chains.filter((c) => !c.myConfirmed).forEach((c) =>
+    toDo.push({ kind: "chain", id: "ch_" + c.id, sort: c.created_at, data: c })
+  );
+
+  const waiting = [];
+  outgoing.filter((o) => isPending(o.status)).forEach((o) =>
+    waiting.push({ kind: "offer_out", id: "oo_" + o.id, sort: o.created_at, data: o })
+  );
+  chains.filter((c) => c.myConfirmed).forEach((c) =>
+    waiting.push({ kind: "chain_waiting", id: "cw_" + c.id, sort: c.created_at, data: c })
+  );
+
+  const found = matches.map((m) => ({
+    kind: "match", id: "m_" + m.id, sort: m.matched_at, data: m,
+  }));
+
+  const history = tx.map((t) => ({
+    kind: "tx", id: "t_" + t.id, sort: t.created_at, data: t,
+  }));
+
+  const byNewest = (a, b) => new Date(b.sort || 0) - new Date(a.sort || 0);
+  [toDo, waiting, found, history].forEach((arr) => arr.sort(byNewest));
+
+  return { toDo, waiting, found, history, toDoCount: toDo.length };
+}

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -38,6 +38,35 @@ export const translations = {
       create: "Crea",
       messages: "Messaggi",
       profile: "Il mio profilo",
+      explore: "Esplora",
+      sell: "Vendi",
+      activity: "Attività",
+    },
+
+    esplora: {
+      title: "Esplora",
+      searchPlaceholder: "Cerca tratta o città…",
+      forYouTitle: "Per te",
+      seeAll: "Vedi tutti",
+      alertsA11y: "I miei avvisi di ricerca",
+    },
+
+    activity: {
+      sectionToDo: "Da fare",
+      sectionToDoHint: "Aspettano una tua risposta.",
+      sectionWaiting: "In attesa",
+      sectionFound: "Trovati per te",
+      sectionFoundHint: "Annunci nuovi che soddisfano i tuoi avvisi.",
+      sectionHistory: "Storico",
+      offerReceived: "Proposta ricevuta",
+      offerSent: "Proposta inviata",
+      chainToConfirm: "Uno scambio a 3 aspetta la tua conferma",
+      chainWaiting: "Hai confermato — in attesa degli altri",
+      matchFound: "Trovato per un tuo avviso",
+      review: "Vedi e conferma",
+      pending: "In attesa",
+      emptyTitle: "Ancora niente da mostrare",
+      empty: "Qui trovi tutto ciò che ti riguarda: proposte ricevute e inviate, scambi a 3 da confermare, annunci trovati dai tuoi avvisi e lo storico.",
     },
 
     // --- Titoli usati in MainTabs ---
@@ -703,6 +732,35 @@ export const translations = {
       create: "Create",
       messages: "Messages",
       profile: "My Profile",
+      explore: "Explore",
+      sell: "Sell",
+      activity: "Activity",
+    },
+
+    esplora: {
+      title: "Explore",
+      searchPlaceholder: "Search route or city…",
+      forYouTitle: "For you",
+      seeAll: "See all",
+      alertsA11y: "My search alerts",
+    },
+
+    activity: {
+      sectionToDo: "To do",
+      sectionToDoHint: "These are waiting for your reply.",
+      sectionWaiting: "Waiting",
+      sectionFound: "Found for you",
+      sectionFoundHint: "New listings that match your alerts.",
+      sectionHistory: "History",
+      offerReceived: "Proposal received",
+      offerSent: "Proposal sent",
+      chainToConfirm: "A 3-way swap is waiting for your confirmation",
+      chainWaiting: "You've confirmed — waiting for the others",
+      matchFound: "Found for one of your alerts",
+      review: "Review and confirm",
+      pending: "Pending",
+      emptyTitle: "Nothing to show yet",
+      empty: "This is where everything about you lives: proposals received and sent, 3-way swaps to confirm, listings found by your alerts, and your history.",
     },
 
     listings: {
@@ -1350,6 +1408,35 @@ export const translations = {
       create: "Crear",
       messages: "Mensajes",
       profile: "Perfil",
+      explore: "Explorar",
+      sell: "Vender",
+      activity: "Actividad",
+    },
+
+    esplora: {
+      title: "Explorar",
+      searchPlaceholder: "Busca ruta o ciudad…",
+      forYouTitle: "Para ti",
+      seeAll: "Ver todos",
+      alertsA11y: "Mis avisos de búsqueda",
+    },
+
+    activity: {
+      sectionToDo: "Por hacer",
+      sectionToDoHint: "Esperan tu respuesta.",
+      sectionWaiting: "En espera",
+      sectionFound: "Encontrados para ti",
+      sectionFoundHint: "Anuncios nuevos que cumplen tus avisos.",
+      sectionHistory: "Historial",
+      offerReceived: "Propuesta recibida",
+      offerSent: "Propuesta enviada",
+      chainToConfirm: "Un intercambio a 3 espera tu confirmación",
+      chainWaiting: "Has confirmado — esperando a los demás",
+      matchFound: "Encontrado para uno de tus avisos",
+      review: "Ver y confirmar",
+      pending: "En espera",
+      emptyTitle: "Todavía no hay nada que mostrar",
+      empty: "Aquí encuentras todo lo que te concierne: propuestas recibidas y enviadas, intercambios a 3 por confirmar, anuncios encontrados por tus avisos y el historial.",
     },
 
     listings: {

--- a/travelswap_ai/travelswapai/screens/AttivitaScreen.js
+++ b/travelswap_ai/travelswapai/screens/AttivitaScreen.js
@@ -1,0 +1,281 @@
+// screens/AttivitaScreen.js — la casella "Attività": un unico posto per
+// tutto ciò che ti riguarda. Quattro sezioni: cose da fare (proposte
+// ricevute, catene da confermare), in attesa degli altri, annunci
+// trovati dai tuoi avvisi, e lo storico degli scambi.
+import React, { useCallback, useState } from "react";
+import {
+  View, Text, ScrollView, TouchableOpacity, ActivityIndicator,
+  StyleSheet, RefreshControl, Alert,
+} from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import { Ionicons } from "@expo/vector-icons";
+import { useActivity } from "../lib/ActivityContext";
+import { acceptOffer, declineOffer, cancelOffer } from "../lib/offers";
+import { markMatchSeen } from "../lib/savedSearches";
+import { useI18n } from "../lib/i18n";
+import { theme } from "../lib/theme";
+
+function formatDate(iso, locale) {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleDateString(locale || undefined, { day: "2-digit", month: "short" });
+  } catch {
+    return "";
+  }
+}
+
+function describeListing(listing, t, locale) {
+  if (!listing) return t("chains.unknownListing", "Annuncio non disponibile");
+  if (listing.type === "hotel") {
+    const city = listing.location || t("chains.unknownCity", "città sconosciuta");
+    const d = formatDate(listing.check_in, locale);
+    return d ? `${city} · ${d}` : city;
+  }
+  const from = listing.route_from || "?";
+  const to = listing.route_to || "?";
+  const d = formatDate(listing.depart_at, locale);
+  return d ? `${from} → ${to} · ${d}` : `${from} → ${to}`;
+}
+
+function Section({ title, hint, count, children }) {
+  return (
+    <View style={styles.section}>
+      <View style={styles.sectionHead}>
+        <Text style={styles.sectionTitle}>{title}</Text>
+        {count > 0 ? <View style={styles.countPill}><Text style={styles.countPillText}>{count}</Text></View> : null}
+      </View>
+      {hint ? <Text style={styles.sectionHint}>{hint}</Text> : null}
+      {children}
+    </View>
+  );
+}
+
+export default function AttivitaScreen({ navigation }) {
+  const { t, locale } = useI18n();
+  const { summary, loading, refresh } = useActivity();
+  const [busyId, setBusyId] = useState(null);
+
+  useFocusEffect(useCallback(() => { refresh(); }, [refresh]));
+
+  const onAccept = useCallback(async (offerId) => {
+    setBusyId(offerId);
+    try { await acceptOffer(offerId); await refresh(); Alert.alert(t("common.ok", "OK"), t("offers.accepted", "Proposta accettata")); }
+    catch (e) { Alert.alert(t("common.error", "Errore"), e?.message || String(e)); }
+    finally { setBusyId(null); }
+  }, [refresh, t]);
+
+  const onDecline = useCallback(async (offerId) => {
+    setBusyId(offerId);
+    try { await declineOffer(offerId); await refresh(); }
+    catch (e) { Alert.alert(t("common.error", "Errore"), e?.message || String(e)); }
+    finally { setBusyId(null); }
+  }, [refresh, t]);
+
+  const onCancel = useCallback(async (offerId) => {
+    setBusyId(offerId);
+    try { await cancelOffer(offerId); await refresh(); }
+    catch (e) { Alert.alert(t("common.error", "Errore"), e?.message || String(e)); }
+    finally { setBusyId(null); }
+  }, [refresh, t]);
+
+  const goChain = useCallback(() => {
+    navigation?.navigate?.("ChainProposals");
+    navigation?.getParent?.()?.navigate?.("ChainProposals");
+  }, [navigation]);
+
+  const goListing = useCallback((listingId, matchId) => {
+    if (matchId) markMatchSeen(matchId).catch(() => {});
+    if (!listingId) return;
+    navigation?.navigate?.("ListingDetail", { id: listingId });
+    navigation?.getParent?.()?.navigate?.("ListingDetail", { id: listingId });
+  }, [navigation]);
+
+  const offerKindLabel = (o) =>
+    o.type === "buy" ? t("offers.buy", "Acquisto") : t("offers.swap", "Scambio");
+
+  const renderToDo = (it) => {
+    if (it.kind === "offer_in") {
+      const o = it.data;
+      const busy = busyId === o.id;
+      return (
+        <View key={it.id} style={styles.card}>
+          <Text style={styles.cardKicker}>{t("activity.offerReceived", "Proposta ricevuta")} · {offerKindLabel(o)}</Text>
+          <Text style={styles.cardTitle} numberOfLines={2}>{o.to_listing?.title || t("offerFlow.listing", "Annuncio")}</Text>
+          {o.amount != null ? <Text style={styles.cardMeta}>{Number(o.amount).toFixed(2)} {o.currency || "EUR"}</Text> : null}
+          {o.message ? <Text style={styles.cardMsg}>{o.message}</Text> : null}
+          <View style={styles.actionRow}>
+            <TouchableOpacity style={[styles.btn, styles.btnAccept, busy && styles.btnDisabled]} disabled={busy} onPress={() => onAccept(o.id)}>
+              <Text style={styles.btnAcceptTxt}>{busy ? "…" : t("offers.accept", "Accetta")}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.btn, styles.btnDecline, busy && styles.btnDisabled]} disabled={busy} onPress={() => onDecline(o.id)}>
+              <Text style={styles.btnDeclineTxt}>{busy ? "…" : t("offers.decline", "Rifiuta")}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      );
+    }
+    // chain to confirm
+    const c = it.data;
+    return (
+      <TouchableOpacity key={it.id} style={styles.card} onPress={goChain} activeOpacity={0.85}>
+        <Text style={styles.cardKicker}>🔗 {t("chains.badge", "Scambio a 3")}</Text>
+        <Text style={styles.cardTitle}>{t("activity.chainToConfirm", "Uno scambio a 3 aspetta la tua conferma")}</Text>
+        <Text style={styles.cardMeta}>{t("chains.confirmedCount", "{count} di 3 hanno confermato", { count: c.confirmedCount || 0 })}</Text>
+        <View style={styles.linkRow}>
+          <Text style={styles.linkText}>{t("activity.review", "Vedi e conferma")}</Text>
+          <Ionicons name="chevron-forward" size={16} color={theme.colors.accent} />
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderWaiting = (it) => {
+    if (it.kind === "offer_out") {
+      const o = it.data;
+      const busy = busyId === o.id;
+      return (
+        <View key={it.id} style={styles.card}>
+          <Text style={styles.cardKicker}>{t("activity.offerSent", "Proposta inviata")} · {offerKindLabel(o)}</Text>
+          <Text style={styles.cardTitle} numberOfLines={2}>{o.to_listing?.title || t("offerFlow.listing", "Annuncio")}</Text>
+          <View style={styles.actionRow}>
+            <View style={styles.statusChip}><Text style={styles.statusChipText}>{t("activity.pending", "In attesa")}</Text></View>
+            <TouchableOpacity style={[styles.btn, styles.btnDecline, busy && styles.btnDisabled]} disabled={busy} onPress={() => onCancel(o.id)}>
+              <Text style={styles.btnDeclineTxt}>{busy ? "…" : t("offers.cancel", "Cancella")}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      );
+    }
+    const c = it.data;
+    return (
+      <TouchableOpacity key={it.id} style={styles.card} onPress={goChain} activeOpacity={0.85}>
+        <Text style={styles.cardKicker}>🔗 {t("chains.badge", "Scambio a 3")}</Text>
+        <Text style={styles.cardTitle}>{t("activity.chainWaiting", "Hai confermato — in attesa degli altri")}</Text>
+        <Text style={styles.cardMeta}>{t("chains.confirmedCount", "{count} di 3 hanno confermato", { count: c.confirmedCount || 0 })}</Text>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderFound = (it) => {
+    const m = it.data;
+    return (
+      <TouchableOpacity key={it.id} style={styles.card} onPress={() => goListing(m.listing_id, !m.seen ? m.id : null)} activeOpacity={0.85}>
+        <View style={styles.rowBetween}>
+          <Text style={styles.cardKicker}>🔔 {t("activity.matchFound", "Trovato per un tuo avviso")}</Text>
+          {!m.seen ? <View style={styles.newDot} /> : null}
+        </View>
+        <Text style={styles.cardTitle}>{describeListing(m.listing, t, locale)}</Text>
+        {m.listing?.price != null ? <Text style={styles.cardMeta}>{Number(m.listing.price)}€</Text> : null}
+      </TouchableOpacity>
+    );
+  };
+
+  const renderHistory = (it) => {
+    const tx = it.data;
+    const listing = tx.listing || {};
+    const dir = tx.direction === "sold"
+      ? t("transactions.directionSold", "Venduto")
+      : t("transactions.directionBought", "Ricevuto");
+    const typeLabel = tx.ttype === "swap" ? t("transactions.typeSwap", "Scambio") : t("transactions.typeSale", "Vendita");
+    return (
+      <TouchableOpacity key={it.id} style={styles.card} onPress={() => goListing(listing.id)} activeOpacity={0.85}>
+        <Text style={styles.cardKicker}>🧾 {typeLabel} · {dir}</Text>
+        <Text style={styles.cardTitle} numberOfLines={2}>{listing.title || t("savedScreen.untitledListing", "Annuncio")}</Text>
+        <Text style={styles.cardMeta}>{formatDate(tx.created_at, locale)}{tx.price != null ? ` · ${tx.price} €` : ""}</Text>
+      </TouchableOpacity>
+    );
+  };
+
+  const total = summary.toDo.length + summary.waiting.length + summary.found.length + summary.history.length;
+
+  if (loading && total === 0) {
+    return <View style={styles.center}><ActivityIndicator /></View>;
+  }
+
+  if (total === 0) {
+    return (
+      <ScrollView
+        contentContainerStyle={styles.emptyWrap}
+        refreshControl={<RefreshControl refreshing={loading} onRefresh={refresh} />}
+      >
+        <Text style={{ fontSize: 44 }}>🔔</Text>
+        <Text style={styles.emptyTitle}>{t("activity.emptyTitle", "Ancora niente da mostrare")}</Text>
+        <Text style={styles.emptyText}>
+          {t("activity.empty", "Qui trovi tutto ciò che ti riguarda: proposte ricevute e inviate, scambi a 3 da confermare, annunci trovati dai tuoi avvisi e lo storico.")}
+        </Text>
+      </ScrollView>
+    );
+  }
+
+  return (
+    <ScrollView
+      contentContainerStyle={{ padding: 16 }}
+      refreshControl={<RefreshControl refreshing={loading} onRefresh={refresh} />}
+    >
+      {summary.toDo.length ? (
+        <Section title={t("activity.sectionToDo", "Da fare")} count={summary.toDo.length}
+          hint={t("activity.sectionToDoHint", "Aspettano una tua risposta.")}>
+          {summary.toDo.map(renderToDo)}
+        </Section>
+      ) : null}
+
+      {summary.waiting.length ? (
+        <Section title={t("activity.sectionWaiting", "In attesa")}>
+          {summary.waiting.map(renderWaiting)}
+        </Section>
+      ) : null}
+
+      {summary.found.length ? (
+        <Section title={t("activity.sectionFound", "Trovati per te")}
+          hint={t("activity.sectionFoundHint", "Annunci nuovi che soddisfano i tuoi avvisi.")}>
+          {summary.found.map(renderFound)}
+        </Section>
+      ) : null}
+
+      {summary.history.length ? (
+        <Section title={t("activity.sectionHistory", "Storico")}>
+          {summary.history.map(renderHistory)}
+        </Section>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: theme.colors.background },
+  emptyWrap: { flexGrow: 1, alignItems: "center", justifyContent: "center", padding: 28, backgroundColor: theme.colors.background },
+  emptyTitle: { fontSize: 17, fontWeight: "800", color: theme.colors.text, marginTop: 10 },
+  emptyText: { color: theme.colors.textMuted, textAlign: "center", marginTop: 8, lineHeight: 20 },
+
+  section: { marginBottom: 22 },
+  sectionHead: { flexDirection: "row", alignItems: "center", gap: 8 },
+  sectionTitle: { fontSize: 16, fontWeight: "800", color: theme.colors.text },
+  sectionHint: { color: theme.colors.textMuted, fontSize: 13, marginTop: 2, marginBottom: 10 },
+  countPill: { backgroundColor: theme.colors.danger, borderRadius: 999, minWidth: 20, height: 20, paddingHorizontal: 6, alignItems: "center", justifyContent: "center" },
+  countPillText: { color: "#fff", fontSize: 12, fontWeight: "800" },
+
+  card: {
+    backgroundColor: theme.colors.surface, borderRadius: theme.radius.lg,
+    borderWidth: 1, borderColor: theme.colors.border, padding: 14, marginBottom: 10,
+    ...theme.shadow.sm,
+  },
+  cardKicker: { fontSize: 12, fontWeight: "700", color: theme.colors.textMuted, marginBottom: 4 },
+  cardTitle: { fontSize: 15, fontWeight: "800", color: theme.colors.text },
+  cardMeta: { color: theme.colors.textMuted, marginTop: 4 },
+  cardMsg: { color: theme.colors.text, marginTop: 8 },
+  rowBetween: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  newDot: { width: 8, height: 8, borderRadius: 4, backgroundColor: theme.colors.accent },
+
+  actionRow: { flexDirection: "row", gap: 10, marginTop: 12, alignItems: "center" },
+  btn: { flex: 1, paddingVertical: 10, borderRadius: 10, alignItems: "center" },
+  btnAccept: { backgroundColor: "#DCFCE7" },
+  btnAcceptTxt: { color: "#166534", fontWeight: "800" },
+  btnDecline: { backgroundColor: "#FEE2E2" },
+  btnDeclineTxt: { color: "#991B1B", fontWeight: "800" },
+  btnDisabled: { opacity: 0.6 },
+  statusChip: { flex: 1, backgroundColor: theme.colors.surfaceMuted, borderRadius: 999, paddingVertical: 8, alignItems: "center" },
+  statusChipText: { fontWeight: "700", color: theme.colors.textMuted },
+
+  linkRow: { flexDirection: "row", alignItems: "center", gap: 4, marginTop: 10 },
+  linkText: { color: theme.colors.accent, fontWeight: "800" },
+});

--- a/travelswap_ai/travelswapai/screens/HomeScreen.js
+++ b/travelswap_ai/travelswapai/screens/HomeScreen.js
@@ -1,14 +1,39 @@
 // screens/HomeScreen.js — Annunci pubblici (senza tab "Voli")
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { View, Text, StyleSheet, FlatList, TouchableOpacity, ActivityIndicator } from "react-native";
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, ActivityIndicator, TextInput, ScrollView } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { listPublicListings, getCurrentUser } from "../lib/db";
+import { getUserSnapshot } from "../lib/backendApi";
 import OfferCTAs from "../components/OfferCTA";
 import { useI18n } from "../lib/i18n";
 import { theme } from "../lib/theme";
 import TrustScoreBadge from "../components/TrustScoreBadge";
 import SaveButton from "../components/SaveButton";
 import { Ionicons } from "@expo/vector-icons";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// Estrae i migliori suggerimenti AI dallo snapshot backend, in modo
+// tollerante alla forma della risposta (come fa MatchingScreen). Best
+// effort: se manca o è malformato, la striscia "Per te" resta nascosta.
+function extractPicks(snap) {
+  const items = Array.isArray(snap) ? snap : (snap?.items || snap?.rows || snap?.data || []);
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((raw) => {
+      const listingId = raw.listingId ?? raw.listing_id ?? raw.toId ?? raw.to_id ?? raw.id;
+      return {
+        listingId,
+        title: raw.title ?? raw.name ?? "—",
+        location: raw.location ?? raw.city ?? raw.destination ?? "",
+        type: raw.type ?? raw.listing_type ?? "",
+        score: Number(raw.score ?? raw.score_pct ?? 0) || 0,
+      };
+    })
+    .filter((p) => typeof p.listingId === "string" && UUID_RE.test(p.listingId))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 6);
+}
 
 // --- Helper: rimuove eventuali prezzi dal titolo
 function stripPriceFromTitle(s) {
@@ -28,6 +53,8 @@ export default function HomeScreen() {
   const [error, setError] = useState(null);
   const [tab, setTab] = useState("all"); // "all" | "hotel" | "train"
   const [me, setMe] = useState(null);
+  const [query, setQuery] = useState("");
+  const [picks, setPicks] = useState([]);
 
   // helper i18n con fallback + interpolation
   const tt = (key, fallback, vars) => {
@@ -58,6 +85,12 @@ export default function HomeScreen() {
       ]);
       setMe(u);
       setItems(Array.isArray(data) ? data : []);
+      // Suggerimenti AI: best effort, non bloccano la lista se falliscono
+      if (u?.id) {
+        getUserSnapshot(u.id)
+          .then((snap) => setPicks(extractPicks(snap)))
+          .catch(() => setPicks([]));
+      }
     } catch (e) {
       setError(e?.message || String(e));
     } finally {
@@ -68,14 +101,32 @@ export default function HomeScreen() {
   useEffect(() => { load(); }, [load]);
 
   useEffect(() => {
-    navigation.setOptions?.({ title: tt("listingsTitle", "Annunci") });
+    navigation.setOptions?.({
+      title: tt("esplora.title", "Esplora"),
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={() => navigation.navigate("SavedSearches")}
+          style={{ paddingHorizontal: 14, paddingVertical: 6 }}
+          accessibilityRole="button"
+          accessibilityLabel={tt("esplora.alertsA11y", "I miei avvisi di ricerca")}
+        >
+          <Ionicons name="notifications-outline" size={22} color={theme.colors.boardingText} />
+        </TouchableOpacity>
+      ),
+    });
   }, [navigation, t, locale]);
 
   const filtered = useMemo(() => {
-    if (tab === "all") return items;
-    const ttype = tab.toLowerCase();
-    return items.filter((x) => String(x.type || "").toLowerCase() === ttype);
-  }, [items, tab]);
+    const q = query.trim().toLowerCase();
+    return items.filter((x) => {
+      if (tab !== "all" && String(x.type || "").toLowerCase() !== tab.toLowerCase()) return false;
+      if (!q) return true;
+      const hay = [x.title, x.location, x.route_from, x.route_to]
+        .map((s) => String(s || "").toLowerCase())
+        .join(" ");
+      return hay.includes(q);
+    });
+  }, [items, tab, query]);
 
   const renderTabs = () => (
     <View style={styles.tabs}>
@@ -174,6 +225,47 @@ export default function HomeScreen() {
     );
   };
 
+  // Striscia "Per te": i migliori suggerimenti dell'AI, in cima alla lista.
+  // Tiene l'AI in vetrina anche senza un tab dedicato, e porta alla
+  // schermata completa con "Vedi tutti".
+  const renderPerTe = () => {
+    if (!picks.length) return null;
+    return (
+      <View style={styles.perTeWrap}>
+        <View style={styles.perTeHead}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+            <Ionicons name="sparkles" size={15} color={theme.colors.accent} />
+            <Text style={styles.perTeTitle}>{tt("esplora.forYouTitle", "Per te")}</Text>
+            <View style={styles.aiTag}><Text style={styles.aiTagText}>{tt("matching.aiTag", "AI")}</Text></View>
+          </View>
+          <TouchableOpacity onPress={() => navigation.navigate("Matching")}>
+            <Text style={styles.seeAll}>{tt("esplora.seeAll", "Vedi tutti")}</Text>
+          </TouchableOpacity>
+        </View>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 10, paddingRight: 16 }}>
+          {picks.map((p) => {
+            const isTrain = String(p.type || "").toLowerCase() === "train";
+            return (
+              <TouchableOpacity
+                key={p.listingId}
+                style={styles.pickCard}
+                activeOpacity={0.85}
+                onPress={() => navigation.navigate("ListingDetail", { id: p.listingId })}
+              >
+                <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+                  <Ionicons name={isTrain ? "train-outline" : "bed-outline"} size={15} color={theme.colors.boardingText} />
+                  <Text style={styles.pickScore}>{Math.round(p.score)}</Text>
+                </View>
+                <Text style={styles.pickTitle} numberOfLines={2}>{stripPriceFromTitle(p.title) || tt("listing.untitled", "Senza titolo")}</Text>
+                {p.location ? <Text style={styles.pickSub} numberOfLines={1}>{p.location}</Text> : null}
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      </View>
+    );
+  };
+
   if (loading) {
     return (
       <View style={styles.center}>
@@ -196,13 +288,33 @@ export default function HomeScreen() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{tt("listingsTitle", "Annunci")}</Text>
+      <Text style={styles.title}>{tt("esplora.title", "Esplora")}</Text>
+
+      <View style={styles.searchWrap}>
+        <Ionicons name="search" size={18} color={theme.colors.textMuted} />
+        <TextInput
+          style={styles.searchInput}
+          value={query}
+          onChangeText={setQuery}
+          placeholder={tt("esplora.searchPlaceholder", "Cerca tratta o città…")}
+          placeholderTextColor={theme.colors.textMuted}
+          returnKeyType="search"
+          autoCorrect={false}
+        />
+        {query ? (
+          <TouchableOpacity onPress={() => setQuery("")} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+            <Ionicons name="close-circle" size={18} color={theme.colors.textMuted} />
+          </TouchableOpacity>
+        ) : null}
+      </View>
+
       {renderTabs()}
 
       <FlatList
         data={filtered}
         keyExtractor={(it) => String(it.id)}
         renderItem={renderItem}
+        ListHeaderComponent={query ? null : renderPerTe}
         ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
         ListEmptyComponent={
           <View style={styles.emptyWrap}>
@@ -245,4 +357,32 @@ const styles = StyleSheet.create({
   emptyWrap: { paddingVertical: 32, alignItems: "center", paddingHorizontal: 16 },
   emptyText: { color: theme.colors.textMuted, textAlign: "center", fontWeight: "700" },
   emptySub: { color: theme.colors.textMuted, textAlign: "center", marginTop: 6 },
+
+  searchWrap: {
+    flexDirection: "row", alignItems: "center", gap: 8,
+    marginHorizontal: 16, marginBottom: 12,
+    paddingHorizontal: 12, height: 44,
+    borderRadius: theme.radius.pill,
+    borderWidth: 1, borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
+  },
+  searchInput: { flex: 1, color: theme.colors.text, fontSize: 15, paddingVertical: 0 },
+
+  perTeWrap: { marginBottom: 16 },
+  perTeHead: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 10 },
+  perTeTitle: { fontSize: 15, fontWeight: "800", color: theme.colors.text },
+  seeAll: { color: theme.colors.accent, fontWeight: "800", fontSize: 13 },
+  aiTag: {
+    backgroundColor: theme.colors.accentSoft, borderWidth: 1, borderColor: theme.colors.accent,
+    borderRadius: 999, paddingHorizontal: 6, paddingVertical: 1,
+  },
+  aiTagText: { fontSize: 10, fontWeight: "800", color: theme.colors.accentOn, letterSpacing: 0.4 },
+  pickCard: {
+    width: 150, padding: 12, borderRadius: theme.radius.lg,
+    borderWidth: 1, borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface, ...theme.shadow.sm,
+  },
+  pickScore: { fontSize: 13, fontWeight: "800", color: theme.colors.accent },
+  pickTitle: { marginTop: 8, fontWeight: "800", color: theme.colors.boardingText, minHeight: 36 },
+  pickSub: { marginTop: 4, color: theme.colors.textMuted, fontSize: 12 },
 });

--- a/travelswap_ai/travelswapai/screens/MainTabs.js
+++ b/travelswap_ai/travelswapai/screens/MainTabs.js
@@ -1,21 +1,50 @@
 import React from "react";
-import { View } from "react-native";
+import { View, Text, TouchableOpacity, StyleSheet, Platform } from "react-native";
 import { theme } from "../lib/theme";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { Ionicons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
 import HeaderLogo from "../components/HeaderLogo";
 
 import HomeScreen from "./HomeScreen";
-import OffersScreen from "./OffersScreen";
-import MatchingScreen from "./MatchingScreen";
+import AttivitaScreen from "./AttivitaScreen";
 import ProfileScreen from "./ProfileScreen";
 import { useI18n } from "../lib/i18n";
+import { ActivityProvider, useActivity } from "../lib/ActivityContext";
 
 const Tab = createBottomTabNavigator();
-const TAB_BAR_HEIGHT = 68;
+const TAB_BAR_HEIGHT = 70;
 
-export default function MainTabs() {
+// Il tab centrale "Vendi" non apre una pagina propria: è una scorciatoia
+// verso la creazione annuncio (l'azione che fa vivere il marketplace, oggi
+// nascosta nel profilo). Lo schermo è fittizio, il tabPress è annullato.
+function Noop() {
+  return null;
+}
+
+function VendiButton() {
+  const navigation = useNavigation();
   const { t } = useI18n();
+  return (
+    <TouchableOpacity
+      style={styles.vendiWrap}
+      activeOpacity={0.9}
+      onPress={() => navigation.navigate("CreateListing")}
+      accessibilityRole="button"
+      accessibilityLabel={t("tabs.sell", "Vendi")}
+    >
+      <View style={styles.vendiDisc}>
+        <Ionicons name="add" size={30} color={theme.colors.accentOn} />
+      </View>
+      <Text style={styles.vendiLabel}>{t("tabs.sell", "Vendi")}</Text>
+    </TouchableOpacity>
+  );
+}
+
+function MainTabsInner() {
+  const { t } = useI18n();
+  const { toDoCount } = useActivity();
+
   return (
     <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
       <Tab.Navigator
@@ -25,38 +54,35 @@ export default function MainTabs() {
           headerTintColor: theme.colors.boardingText,
           tabBarActiveTintColor: theme.colors.boardingText,
           tabBarInactiveTintColor: theme.colors.textMuted,
-          tabBarStyle: { height: TAB_BAR_HEIGHT },
+          tabBarStyle: { height: TAB_BAR_HEIGHT, paddingTop: 4, borderTopColor: theme.colors.border },
           tabBarLabelStyle: { paddingBottom: 6, fontWeight: "700" },
-          
         }}
       >
         <Tab.Screen
           name="Home"
           component={HomeScreen}
           options={{
-            tabBarLabel: t("listingsTitle", "Annunci"),
+            tabBarLabel: t("tabs.explore", "Esplora"),
             tabBarIcon: ({ color, size, focused }) => (
-              <Ionicons name={focused ? "home" : "home-outline"} color={color} size={size} />
+              <Ionicons name={focused ? "compass" : "compass-outline"} color={color} size={size} />
             ),
           }}
         />
         <Tab.Screen
-          name="Offers"
-          component={OffersScreen}
-          options={{
-            tabBarLabel: t("offers.title", "Offerte"),
-            tabBarIcon: ({ color, size, focused }) => (
-              <Ionicons name={focused ? "pricetags" : "pricetags-outline"} color={color} size={size} />
-            ),
-          }}
+          name="Vendi"
+          component={Noop}
+          options={{ tabBarButton: () => <VendiButton /> }}
+          listeners={{ tabPress: (e) => e.preventDefault() }}
         />
         <Tab.Screen
-          name="Matching"
-          component={MatchingScreen}
+          name="Attivita"
+          component={AttivitaScreen}
           options={{
-            tabBarLabel: t("matching.tabLabel", "Per te"),
+            tabBarLabel: t("tabs.activity", "Attività"),
+            tabBarBadge: toDoCount > 0 ? toDoCount : undefined,
+            tabBarBadgeStyle: { backgroundColor: theme.colors.danger },
             tabBarIcon: ({ color, size, focused }) => (
-              <Ionicons name={focused ? "sparkles" : "sparkles-outline"} color={color} size={size} />
+              <Ionicons name={focused ? "notifications" : "notifications-outline"} color={color} size={size} />
             ),
           }}
         />
@@ -74,3 +100,40 @@ export default function MainTabs() {
     </View>
   );
 }
+
+export default function MainTabs() {
+  // Provider attorno ai tab: il conteggio "da fare" alimenta sia il
+  // numeretto rosso sul tab Attività sia la schermata, dalla stessa fonte.
+  return (
+    <ActivityProvider>
+      <MainTabsInner />
+    </ActivityProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  vendiWrap: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "flex-start",
+    paddingTop: 4,
+  },
+  vendiDisc: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    backgroundColor: theme.colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+    ...Platform.select({
+      ios: { shadowColor: theme.colors.accent, shadowOpacity: 0.5, shadowRadius: 8, shadowOffset: { width: 0, height: 4 } },
+      android: { elevation: 6 },
+    }),
+  },
+  vendiLabel: {
+    marginTop: 3,
+    fontSize: 11,
+    fontWeight: "800",
+    color: theme.colors.boardingText,
+  },
+});

--- a/travelswap_ai/travelswapai/screens/MatchingScreen.js
+++ b/travelswap_ai/travelswapai/screens/MatchingScreen.js
@@ -23,7 +23,6 @@ import {
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
-import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import * as Haptics from "expo-haptics";
 import { useI18n } from "../lib/i18n";
 import { recomputeAIAndSnapshot } from "../lib/backendApi";
@@ -266,7 +265,9 @@ function MatchRow({ item, onPress, isNew, expanded, onToggleInfo, generatedAt, o
 export default function MatchingScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
-  const tabBarHeight = useBottomTabBarHeight(); // calcolato qui (mai nei renderItem)
+  // Ora è una schermata Stack (aperta da "Vedi tutti"), non un tab:
+  // niente barra dei tab sotto, quindi nessuna altezza da compensare.
+  const tabBarHeight = 0;
   const { t, lang } = useI18n();
 const [showPerfectOnly, setShowPerfectOnly] = useState(false);
 const [sortByNewness, setSortByNewness] = useState(false);

--- a/travelswap_ai/travelswapai/screens/ProfileScreen.js
+++ b/travelswap_ai/travelswapai/screens/ProfileScreen.js
@@ -332,37 +332,7 @@ export default function ProfileScreen() {
             </TouchableOpacity>
 
             <TouchableOpacity
-              style={[styles.editBtn, { marginTop: 8 }]}
-              onPress={() => {
-                navigation.navigate?.("Transactions");
-                navigation.getParent?.()?.navigate?.("Transactions");
-              }}
-            >
-              <Text style={styles.editBtnText}>🧾 {t("profile.myTransactions", "I miei scambi")}</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.editBtn, { marginTop: 8 }]}
-              onPress={() => {
-                navigation.navigate?.("ChainProposals");
-                navigation.getParent?.()?.navigate?.("ChainProposals");
-              }}
-            >
-              <Text style={styles.editBtnText}>🔗 {t("profile.chainProposals", "Proposte di scambio a 3")}</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.editBtn, { marginTop: 8 }]}
-              onPress={() => {
-                navigation.navigate?.("SavedSearches");
-                navigation.getParent?.()?.navigate?.("SavedSearches");
-              }}
-            >
-              <Text style={styles.editBtnText}>🔔 {t("profile.savedSearches", "Avvisi di ricerca")}</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.editBtn, { marginTop: 8, backgroundColor: theme.colors.primary, borderColor: "#111827" }]}
+              style={[styles.editBtn, { marginTop: 8, backgroundColor: theme.colors.primary, borderColor: theme.colors.text }]}
               onPress={handleLogout}
             >
               <Text style={[styles.editBtnText, { color: theme.colors.boardingText }]}>{t("profile.logout", "Esci")}</Text>


### PR DESCRIPTION
Secondo e ultimo passo della **Proposta A** approvata. Riorganizza l'app attorno alle quattro intenzioni reali di chi la apre, invece che per componenti. **Nessuna schermata buttata** — cambiano solo le porte d'ingresso.

## La nuova tab bar
| | Tab | Cosa risolve |
|---|---|---|
| 🧭 | **Esplora** (era "Annunci") | barra di ricerca vera (tratta/città) + striscia **"Per te"** con i migliori suggerimenti AI in cima (badge "AI", "Vedi tutti" → schermata completa) + 🔔 campanella avvisi in alto |
| ➕ | **Vendi** | pulsante centrale in oro che apre la creazione annuncio — l'azione che fa vivere il marketplace, prima nascosta nel profilo (problema #2) |
| 🔔 | **Attività** | casella unica per tutto ciò che ti succede: **Da fare** (proposte ricevute + catene da confermare), **In attesa**, **Trovati per te** (avvisi), **Storico**. Con **numeretto rosso** sul tab quando c'è qualcosa da fare — la risposta strutturale al *"non vedevo la proposta a 3"* (problema #3) |
| 👤 | **Profilo** | alleggerito: identità + i miei annunci + preferiti + esci. Scambi a 3 / Avvisi / I miei scambi ora vivono in Attività |

Il tab **"Matching" sparisce dalla barra**: la schermata resta, raggiungibile da *"Per te → Vedi tutti"*.

## Come si integrano le tue 3 richieste
- **Frase semplice sui punteggi** e **restyle oro completo**: già arrivati in PR #28 (mergiata).
- **Più enfasi sull'AI**: la striscia "Per te" tiene i suggerimenti dell'AI in vetrina in cima alla home, anche senza un tab dedicato, con badge "AI" su ogni card.

## Verifica
- [x] `esbuild` su tutti i 9 file (modificati + nuovi): sintassi OK.
- [x] Parità i18n it/en/es completa: **521/521/521 chiavi**.
- [x] **Bug trovato e corretto in review**: `MatchingScreen` usava `useBottomTabBarHeight()`, che va in crash fuori dal contesto dei tab — ora che è una Stack screen l'ho rimosso (nessuna barra tab sotto da compensare).
- [x] Verificato che nessun'altra schermata navighi verso i tab rimossi (Offerte/Matching per nome): nessun riferimento pendente.
- [ ] **Non provata su dispositivo reale** — nessun accesso Android/Apple in questo ambiente. Questa PR tocca la navigazione (la parte più delicata): consiglio di provarla appena puoi con `git pull` e, se qualcosa non torna, è isolata in una PR separata e reversibile. Verificate sintassi, parità i18n e coerenza dei percorsi di navigazione.

Fonti aggregate in Attività riusano funzioni già esistenti e testate (offerte, catene, avvisi, transazioni); ogni fonte è *best-effort* (se una fallisce, le altre restano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_