### PR TITLE
Restyle Swap Gold completo sulle schermate secondarie (punto 8 QC)

### DIFF
--- a/travelswap_ai/travelswapai/components/DateField.js
+++ b/travelswap_ai/travelswapai/components/DateField.js
@@ -45,7 +45,7 @@ export default function DateField({ label, value, onChange, required, error, dis
           value={value}
           onChangeText={onChange}
           placeholder="YYYY-MM-DD"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor={theme.colors.textMuted}
           style={[styles.input, error && styles.inputError]}
           autoCapitalize="none"
           autoCorrect={false}
@@ -63,8 +63,8 @@ export default function DateField({ label, value, onChange, required, error, dis
 
       <TouchableOpacity onPress={!disabled ? () => setShowPicker(true) : undefined} activeOpacity={0.8}>
         <View style={[styles.input, styles.inputRow, error && styles.inputError]}>
-          <Text style={{ color: value ? "#111827" : "#9CA3AF" }}>{value || "YYYY-MM-DD"}</Text>
-          <Text style={{ color: "#6B7280" }}>📅</Text>
+          <Text style={{ color: value ? theme.colors.text : theme.colors.textMuted }}>{value || "YYYY-MM-DD"}</Text>
+          <Text style={{ color: theme.colors.textMuted }}>📅</Text>
         </View>
       </TouchableOpacity>
       {!!error && <Text style={styles.errorText}>{error}</Text>}
@@ -103,20 +103,20 @@ export default function DateField({ label, value, onChange, required, error, dis
 }
 
 const styles = StyleSheet.create({
-  label: { fontWeight: "700", color: "#111827", marginTop: 8, marginBottom: 6 },
+  label: { fontWeight: "700", color: theme.colors.text, marginTop: 8, marginBottom: 6 },
   input: {
     borderWidth: 1,
-    borderColor: "#E5E7EB",
-    backgroundColor: "#fff",
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
     borderRadius: 12,
     paddingHorizontal: 12,
     paddingVertical: 12,
-    color: "#111827",
+    color: theme.colors.text,
   },
   inputRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
   inputError: { borderColor: "#FCA5A5", backgroundColor: "#FEF2F2" },
-  errorText: { color: "#B91C1C", marginTop: 4 },
-  smallBtn: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 10, backgroundColor: "#111827" },
+  errorText: { color: theme.colors.danger, marginTop: 4 },
+  smallBtn: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 10, backgroundColor: theme.colors.text },
   smallBtnText: { color: "#fff", fontWeight: "800" },
-  inputDisabled: { backgroundColor: "#F3F4F6", color: "#6B7280" },
+  inputDisabled: { backgroundColor: theme.colors.surfaceMuted, color: theme.colors.textMuted },
 });

--- a/travelswap_ai/travelswapai/components/DateTimeField.js
+++ b/travelswap_ai/travelswapai/components/DateTimeField.js
@@ -52,7 +52,7 @@ export default function DateTimeField({ label, value, onChange, required, error,
           value={value ? value.replace("T", " ") : ""}
           onChangeText={(txt) => onChange(txt.replace(" ", "T"))}
           placeholder="YYYY-MM-DD HH:mm"
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor={theme.colors.textMuted}
           style={[styles.input, error && styles.inputError]}
           autoCapitalize="none"
           autoCorrect={false}
@@ -70,8 +70,8 @@ export default function DateTimeField({ label, value, onChange, required, error,
 
       <TouchableOpacity onPress={() => setShowDate(true)} activeOpacity={0.8}>
         <View style={[styles.input, styles.inputRow, error && styles.inputError]}>
-          <Text style={{ color: value ? "#111827" : "#9CA3AF" }}>{display}</Text>
-          <Text style={{ color: "#6B7280" }}>🕒</Text>
+          <Text style={{ color: value ? theme.colors.text : theme.colors.textMuted }}>{display}</Text>
+          <Text style={{ color: theme.colors.textMuted }}>🕒</Text>
         </View>
       </TouchableOpacity>
       {!!error && <Text style={styles.errorText}>{error}</Text>}
@@ -146,20 +146,20 @@ export default function DateTimeField({ label, value, onChange, required, error,
 }
 
 const styles = StyleSheet.create({
-  label: { fontWeight: "700", color: "#111827", marginTop: 8, marginBottom: 6 },
+  label: { fontWeight: "700", color: theme.colors.text, marginTop: 8, marginBottom: 6 },
   input: {
     borderWidth: 1,
-    borderColor: "#E5E7EB",
-    backgroundColor: "#fff",
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
     borderRadius: 12,
     paddingHorizontal: 12,
     paddingVertical: 12,
-    color: "#111827",
+    color: theme.colors.text,
   },
   inputRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
   inputError: { borderColor: "#FCA5A5", backgroundColor: "#FEF2F2" },
-  errorText: { color: "#B91C1C", marginTop: 4 },
-  smallBtn: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 10, backgroundColor: "#111827" },
+  errorText: { color: theme.colors.danger, marginTop: 4 },
+  smallBtn: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 10, backgroundColor: theme.colors.text },
   smallBtnText: { color: "#fff", fontWeight: "800" },
-  inputDisabled: { backgroundColor: "#F3F4F6", color: "#6B7280" },
+  inputDisabled: { backgroundColor: theme.colors.surfaceMuted, color: theme.colors.textMuted },
 });

--- a/travelswap_ai/travelswapai/screens/CreateListingScreen.js
+++ b/travelswap_ai/travelswapai/screens/CreateListingScreen.js
@@ -1254,7 +1254,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
           onChangeText={(v) => update({ description: v })}
           placeholder={t("createListing.descriptionPlaceholder", "Dettagli utili per chi è interessato…")}
           style={[styles.input, styles.multiline, styles.inputSurface]}
-          placeholderTextColor="#9CA3AF"
+          placeholderTextColor={theme.colors.textMuted}
           multiline
           numberOfLines={4}
           textAlignVertical="top"
@@ -1384,7 +1384,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
                         : t("createListing.titlePlaceholderTrain", "Es. Milano → Roma (FR 9520)")
                     }
                     style={[styles.input, !editableFields.title && styles.inputDisabled, errors.title && styles.inputError]}
-                    placeholderTextColor="#9CA3AF"
+                    placeholderTextColor={theme.colors.textMuted}
                   />
                   {!!errors.title && <Text style={styles.errorText}>{errors.title}</Text>}
 
@@ -1447,7 +1447,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
                         onChangeText={(v) => update({ location: v })}
                         placeholder={t("createListing.locationPlaceholderTrain", "Es. Milano Centrale → Roma Termini")}
                         style={[styles.input, !editableFields.location && styles.inputDisabled, errors.location && styles.inputError]}
-                        placeholderTextColor="#9CA3AF"
+                        placeholderTextColor={theme.colors.textMuted}
                       />
                       {!!errors.location && <Text style={styles.errorText}>{errors.location}</Text>}
                     </>
@@ -1461,7 +1461,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
                         editable={!hotelLocLocked}
                         selectTextOnFocus={!hotelLocLocked && editableFields.location}
                         style={[styles.input, hotelLocLocked && styles.inputDisabled, errors.location && styles.inputError]}
-                        placeholderTextColor="#9CA3AF"
+                        placeholderTextColor={theme.colors.textMuted}
                       />
                       {!!errors.location && <Text style={styles.errorText}>{errors.location}</Text>}
                     </>
@@ -1572,7 +1572,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
                         placeholder={t("createListing.train.pnrPlaceholder", "Es. ABCDEF")}
                         style={styles.input}
                         autoCapitalize="characters"
-                        placeholderTextColor="#9CA3AF"
+                        placeholderTextColor={theme.colors.textMuted}
                       />
                       <Text style={styles.note}>🔒 {t("createListing.train.pnrPrivacy", "Il PNR non sarà visibile nell’annuncio.")}</Text>
                     </View>
@@ -1586,7 +1586,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
                     placeholder={t("createListing.pricePlaceholder", "Es. 120")}
                     keyboardType="decimal-pad"
                     style={[styles.input, errors.price && styles.inputError]}
-                    placeholderTextColor="#9CA3AF"
+                    placeholderTextColor={theme.colors.textMuted}
                   />
                   {!!errors.price && <Text style={styles.errorText}>{errors.price}</Text>}
 
@@ -1597,7 +1597,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
                       <Text style={styles.infoLink}> Info</Text>
                     </TouchableOpacity>
                     <TouchableOpacity onPress={analyzePriceAI} disabled={priceLoading} style={[styles.smallAIButton, priceLoading && {opacity:0.7}]}> 
-                      {priceLoading ? <ActivityIndicator color="#fff" /> : <Text style={styles.smallAIButtonText}>Analisi prezzo con AI</Text>}
+                      {priceLoading ? <ActivityIndicator color={theme.colors.accentOn} /> : <Text style={styles.smallAIButtonText}>Analisi prezzo con AI</Text>}
                     </TouchableOpacity>
                   </View>
                   {priceInfoOpen && (
@@ -1647,11 +1647,11 @@ if ((patch.type || form.type) === "train" && routeStr) {
           <View style={styles.footer}>
             {slideIndex > 0 ? (
               <TouchableOpacity onPress={onBackPress} style={[styles.footerBtn, styles.footerGhost]}>
-                <Text style={[styles.footerText, { color: "#111827" }]}>{t("common.back", "Indietro")}</Text>
+                <Text style={[styles.footerText, { color: theme.colors.text }]}>{t("common.back", "Indietro")}</Text>
               </TouchableOpacity>
             ) : (
               <TouchableOpacity onPress={onSaveDraft} disabled={saving || mode === "edit"} style={[styles.footerBtn, styles.footerGhost, (saving || mode === "edit") && { opacity: 0.6 }]}>
-                {saving ? <ActivityIndicator /> : <Text style={[styles.footerText, { color: "#111827" }]}>{mode === "edit" ? t("editListing.draftDisabled","Bozza disattivata") : t("createListing.saveDraft","Salva bozza")}</Text>}
+                {saving ? <ActivityIndicator /> : <Text style={[styles.footerText, { color: theme.colors.text }]}>{mode === "edit" ? t("editListing.draftDisabled","Bozza disattivata") : t("createListing.saveDraft","Salva bozza")}</Text>}
               </TouchableOpacity>
             )}
 
@@ -1689,7 +1689,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
               placeholder={t("createListing.train.pnrPlaceholder", "Es. ABCDEF")}
               autoCapitalize="characters"
               style={styles.input}
-              placeholderTextColor="#9CA3AF"
+              placeholderTextColor={theme.colors.textMuted}
             />
             <TouchableOpacity onPress={handlePNRImport} style={[styles.sheetBtn, styles.sheetBtnGhost]}>
               {importBusy ? <ActivityIndicator /> : <Text style={styles.sheetBtnText}>{t("createListing.importFromPnr", "Importa da PNR")}</Text>}
@@ -1718,7 +1718,7 @@ if ((patch.type || form.type) === "train" && routeStr) {
 
             <View style={{ flexDirection: "row", gap: 10 }}>
               <TouchableOpacity onPress={() => setQrVisible(false)} style={[styles.footerBtn, styles.footerGhost, { flex: 1 }]}>
-                <Text style={[styles.footerText, { color: "#111827" }]}>{t("common.cancel", "Annulla")}</Text>
+                <Text style={[styles.footerText, { color: theme.colors.text }]}>{t("common.cancel", "Annulla")}</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 onPress={() => onQrScanned({ data: "Ryanair FR1234 MXP-FCO 10/09/2025 08:10 09:20 PNR ABCDEF €49" })}
@@ -1755,27 +1755,27 @@ if ((patch.type || form.type) === "train" && routeStr) {
 const styles = StyleSheet.create({
     labelRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
     iconBtn: { padding: 6, marginLeft: 8 },
-    inputDisabled: { backgroundColor: "#F3F4F6", color: "#6B7280" },
+    inputDisabled: { backgroundColor: theme.colors.surfaceMuted, color: theme.colors.textMuted },
     fieldContainer: { position: "relative" },
     disabledOverlay: { position: "absolute", top: 0, left: 0, right: 0, bottom: 0 },
   // --- top ---
-  topPanel: { backgroundColor: "#F4F7FB", paddingHorizontal: 16, paddingTop: 8, paddingBottom: 8, borderBottomWidth: 1, borderBottomColor: "#E5E7EB" },
+  topPanel: { backgroundColor: theme.colors.surfaceMuted, paddingHorizontal: 16, paddingTop: 8, paddingBottom: 8, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   topHeaderRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 8 },
   topTitle: { fontSize: 20, fontWeight: "900", color: theme.colors.boardingText },
 
   pillsRow: { flexDirection: "row", gap: 12, paddingTop: 8, paddingBottom: 6 },
   pill: { paddingHorizontal: 14, paddingVertical: 10, borderRadius: 18, borderWidth: 1 },
-  pillLight: { backgroundColor: "#F3F4F6", borderColor: "#E5E7EB" },
-  pillDark: { backgroundColor: "#0F172A", borderColor: "#0F172A" },
-  pillText: { fontWeight: "800", color: "#111827" },
+  pillLight: { backgroundColor: theme.colors.surfaceMuted, borderColor: theme.colors.border },
+  pillDark: { backgroundColor: theme.colors.text, borderColor: theme.colors.text },
+  pillText: { fontWeight: "800", color: theme.colors.text },
   pillTextDark: { color: "#fff" },
 
-  inputSurface: { backgroundColor: "#FBFDFF" },
+  inputSurface: { backgroundColor: theme.colors.surface },
 
   // Micro log + progress
   microWrap: { marginTop: 6, marginBottom: 4 },
-  microLine: { fontSize: 12, color: "#374151", marginBottom: 2 },
-  progressBar: { height: 8, borderRadius: 6, backgroundColor: "#E5E7EB", overflow: "hidden", marginTop: 6 },
+  microLine: { fontSize: 12, color: theme.colors.textMuted, marginBottom: 2 },
+  progressBar: { height: 8, borderRadius: 6, backgroundColor: theme.colors.border, overflow: "hidden", marginTop: 6 },
   progressFill: { height: "100%", backgroundColor: theme.colors.boardingText },
 
   // --- slider ---
@@ -1791,11 +1791,11 @@ const styles = StyleSheet.create({
     marginBottom: FOOTER_H - 20 // spazio sopra i pulsanti
   },
   slideCard: {
-    backgroundColor: "#fff",
+    backgroundColor: theme.colors.surface,
     borderRadius: 20,
     padding: 16,
     borderWidth: 1,
-    borderColor: "#E5E7EB",
+    borderColor: theme.colors.border,
     shadowColor: "#0F172A",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.06,
@@ -1810,21 +1810,21 @@ const styles = StyleSheet.create({
   col: { flex: 1, minWidth: 0 },
 
   // common
-  card: { backgroundColor: "#fff", borderRadius: 20, padding: 16, borderWidth: 1, borderColor: "#E5E7EB", shadowColor: "#0F172A", shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.06, shadowRadius: 12, elevation: 4 },
-  subCard: { backgroundColor: "#F9FAFB", borderRadius: 12, padding: 12, borderWidth: 1, borderColor: "#E5E7EB", marginBottom: 12 },
+  card: { backgroundColor: theme.colors.surface, borderRadius: 20, padding: 16, borderWidth: 1, borderColor: theme.colors.border, shadowColor: "#0F172A", shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.06, shadowRadius: 12, elevation: 4 },
+  subCard: { backgroundColor: theme.colors.surfaceMuted, borderRadius: 12, padding: 12, borderWidth: 1, borderColor: theme.colors.border, marginBottom: 12 },
   subCardTitle: { fontSize: 16, fontWeight: "800", color: theme.colors.boardingText, marginBottom: 6 },
   titleRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 8 },
   cardTitle: { fontSize: 16, fontWeight: "800", color: theme.colors.boardingText },
 
   label: { fontWeight: "700", color: theme.colors.boardingText, marginTop: 8, marginBottom: 6 },
   labelInline: { fontWeight: "700", color: theme.colors.boardingText },
-  input: { borderWidth: 1, borderColor: "#E5E7EB", backgroundColor: "#fff", borderRadius: 12, paddingHorizontal: 12, paddingVertical: 12, color: "#111827" },
+  input: { borderWidth: 1, borderColor: theme.colors.border, backgroundColor: theme.colors.surface, borderRadius: 12, paddingHorizontal: 12, paddingVertical: 12, color: theme.colors.text },
   inputError: { borderColor: "#FCA5A5", backgroundColor: "#FEF2F2" },
-  errorText: { color: "#B91C1C", marginTop: 4 },
-  note: { fontSize: 12, lineHeight: 16, color: "#6B7280", marginTop: 6 },
+  errorText: { color: theme.colors.danger, marginTop: 4 },
+  note: { fontSize: 12, lineHeight: 16, color: theme.colors.textMuted, marginTop: 6 },
   photoAddBtn: {
     width: 72, height: 72, borderRadius: 10, borderWidth: 1, borderStyle: "dashed",
-    borderColor: "#9CA3AF", alignItems: "center", justifyContent: "center",
+    borderColor: theme.colors.textMuted, alignItems: "center", justifyContent: "center",
   },
   photoRemoveBtn: {
     position: "absolute", top: -6, right: -6, width: 22, height: 22, borderRadius: 11,
@@ -1833,17 +1833,17 @@ const styles = StyleSheet.create({
   photoRemoveText: { color: "#fff", fontSize: 12, fontWeight: "700" },
   multiline: { minHeight: 96 },
   segment: { flexDirection: "row", gap: 8 },
-  segBtn: { paddingHorizontal: 14, paddingVertical: 10, borderRadius: 12, borderWidth: 1, borderColor: "#E5E7EB", backgroundColor: "#F3F4F6" },
-  segBtnActive: { backgroundColor: theme.colors.primary, borderColor: "#111827" },
+  segBtn: { paddingHorizontal: 14, paddingVertical: 10, borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border, backgroundColor: theme.colors.surfaceMuted },
+  segBtnActive: { backgroundColor: theme.colors.primary, borderColor: theme.colors.text },
   segText: { color: theme.colors.boardingText, fontWeight: "800" },
   segTextActive: { color: theme.colors.boardingText },
   smallBtn: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 10, backgroundColor: theme.colors.boardingText },
   smallBtnText: { color: theme.colors.boardingText, fontWeight: "800" },
   switchRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  noteSmall: { color: "#6B7280", marginTop: 6 },
-  previewPlaceholder: { height: 160, borderRadius: 12, borderWidth: 1, borderColor: "#E5E7EB", backgroundColor: "#F9FAFB", alignItems: "center", justifyContent: "center", marginTop: 10 },
-  previewText: { color: "#6B7280", textAlign: "center", paddingHorizontal: 12 },
-  previewImage: { width: "100%", height: 200, borderRadius: 12, backgroundColor: "#E5E7EB", marginTop: 10 },
+  noteSmall: { color: theme.colors.textMuted, marginTop: 6 },
+  previewPlaceholder: { height: 160, borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border, backgroundColor: theme.colors.surfaceMuted, alignItems: "center", justifyContent: "center", marginTop: 10 },
+  previewText: { color: theme.colors.textMuted, textAlign: "center", paddingHorizontal: 12 },
+  previewImage: { width: "100%", height: 200, borderRadius: 12, backgroundColor: theme.colors.border, marginTop: 10 },
 
   footer: {
     position: "absolute", left: 0, right: 0, bottom: 0,
@@ -1859,31 +1859,31 @@ const styles = StyleSheet.create({
     elevation: 4
   },
   footerGhost: {
-    backgroundColor: "#F3F4F6", borderWidth: 1, borderColor: "#E5E7EB",
+    backgroundColor: theme.colors.surfaceMuted, borderWidth: 1, borderColor: theme.colors.border,
     shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 6, shadowOffset: {width:0, height:3},
     elevation: 2
   },
   footerText: { fontWeight: "800", color: theme.colors.boardingText },
 
   sheetBackdrop: { flex: 1, backgroundColor: "#00000066", alignItems: "center", justifyContent: "flex-end" },
-  sheetCard: { width: "100%", backgroundColor: "#fff", borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 16, borderTopWidth: 1, borderColor: "#E5E7EB" },
+  sheetCard: { width: "100%", backgroundColor: theme.colors.surface, borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 16, borderTopWidth: 1, borderColor: theme.colors.border },
   sheetTitle: { fontSize: 16, fontWeight: "800", color: theme.colors.boardingText },
   sheetText: { color: theme.colors.boardingText, marginTop: 4 },
   sheetBtn: { marginTop: 10, paddingVertical: 12, borderRadius: 12, alignItems: "center", justifyContent: "center" },
   sheetBtnPrimary: { backgroundColor: theme.colors.boardingText },
-  sheetBtnGhost: { backgroundColor: "#F3F4F6", borderWidth: 1, borderColor: "#E5E7EB" },
+  sheetBtnGhost: { backgroundColor: theme.colors.surfaceMuted, borderWidth: 1, borderColor: theme.colors.border },
   sheetBtnText: { fontWeight: "800", color: theme.colors.boardingText },
   sheetClose: { alignSelf: "center", marginTop: 10 },
-  sheetCloseText: { color: "#6B7280" },
+  sheetCloseText: { color: theme.colors.textMuted },
   qrOverlay: { flex: 1, backgroundColor: "#000000CC", alignItems: "center", justifyContent: "center", padding: 16 },
   qrFrame: { width: "100%", maxWidth: 480, backgroundColor: theme.colors.primary, borderRadius: 16, padding: 12, gap: 12 },
   qrTitle: { fontWeight: "800", color: theme.colors.primary, alignSelf: "center" },
-  qrCameraWrap: { height: 300, borderRadius: 12, overflow: "hidden", borderWidth: 1, borderColor: "#E5E7EB" },
+  qrCameraWrap: { height: 300, borderRadius: 12, overflow: "hidden", borderWidth: 1, borderColor: theme.colors.border },
 
   // --- new for price info + AI button
   infoRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginTop: 10 },
   infoButton: { flexDirection: "row", alignItems: "center", paddingVertical: 6, paddingRight: 10 },
   infoLink: { fontWeight: "700", color: theme.colors.boardingText },
-  smallAIButton: { paddingHorizontal: 12, paddingVertical: 10, borderRadius: 12, backgroundColor: theme.colors.boardingText },
-  smallAIButtonText: { color: "#fff", fontWeight: "800" },
+  smallAIButton: { paddingHorizontal: 12, paddingVertical: 10, borderRadius: 12, backgroundColor: theme.colors.accent },
+  smallAIButtonText: { color: theme.colors.accentOn, fontWeight: "800" },
 });

--- a/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
+++ b/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
@@ -126,7 +126,7 @@ useEffect(() => {
          accessibilityLabel={tt("common.back", "Indietro")}
        >
          {props.canGoBack !== false && (props.backImage ? props.backImage({ tintColor: props.tintColor }) : null)}
-         <Text style={{ marginLeft: 6, color: props.tintColor ?? "#007AFF", fontWeight: "600" }}>
+         <Text style={{ marginLeft: 6, color: props.tintColor ?? theme.colors.boardingText, fontWeight: "600" }}>
            {tt("common.back", "Indietro")}
          </Text>
        </TouchableOpacity>
@@ -280,7 +280,7 @@ useEffect(() => {
   const operator  = listing?.operator  ?? listing?.carrier  ?? null;
 
   return (
-    <View style={{ flex: 1, backgroundColor: "#F8FAFC" }}>
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
       <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 140 }}
         refreshControl={<RefreshControl refreshing={recomputing} onRefresh={() => setRecomputing(false)} />}>
         {images.length > 0 ? (
@@ -317,7 +317,7 @@ useEffect(() => {
               {/* (toggle spostato nella sezione descrizione) */}
             </View>
 
-            <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: "#E5E7EB", marginTop: 12, marginBottom: 12 }} />
+            <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: theme.colors.border, marginTop: 12, marginBottom: 12 }} />
 
             <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
               <View style={{ flexShrink: 1 }}>
@@ -456,7 +456,7 @@ useEffect(() => {
 /* ========= Micro UI ========= */
 
 function Hairline({ mt = 10, mb = 10 }) {
-  return <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: "#E5E7EB", marginTop: mt, marginBottom: mb }} />;
+  return <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: theme.colors.border, marginTop: mt, marginBottom: mb }} />;
 }
 function SectionCard({ title, children, textColor }) {
   return (
@@ -495,7 +495,7 @@ function ExpandableText({ children, numberOfLines = 4, textColor }) {
 /* ========= Styles ========= */
 
 const styles = StyleSheet.create({
-  headerCard: { borderRadius: 20, backgroundColor: "#FFFFFF", borderWidth: 1, borderColor: "#E5E7EB",
+  headerCard: { borderRadius: 20, backgroundColor: theme.colors.surface, borderWidth: 1, borderColor: theme.colors.border,
     shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 12, elevation: 3, overflow: "hidden", position: "relative" },
   headerGradient: { padding: 16 },
   ribbonWrap: { position: "absolute", top: 10, left: -6, zIndex: 10, transform: [{ rotate: "-10deg" }] },
@@ -505,18 +505,18 @@ const styles = StyleSheet.create({
   title: { fontFamily: theme.fonts.headingExtraBold, fontSize: 22 },
   subtitle: { marginTop: 6 },
   price: { fontSize: 22, fontWeight: "800" },
-  card: { marginTop: 16, borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 16, padding: 14,
-    backgroundColor: "#FFFFFF", shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 10, elevation: 3 },
+  card: { marginTop: 16, borderWidth: 1, borderColor: theme.colors.border, borderRadius: 16, padding: 14,
+    backgroundColor: theme.colors.surface, shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 10, elevation: 3 },
   cardTitle: { fontSize: 16, fontWeight: "800" },
-  chip: { flexDirection: "row", alignItems: "center", backgroundColor: "#F8FAFC", borderWidth: 1,
-    borderColor: "#E5E7EB", paddingHorizontal: 12, paddingVertical: 8, borderRadius: 999, marginRight: 8, marginBottom: 8 },
-  imageWrap: { borderRadius: 20, overflow: "hidden", backgroundColor: "#E5E7EB" },
+  chip: { flexDirection: "row", alignItems: "center", backgroundColor: theme.colors.background, borderWidth: 1,
+    borderColor: theme.colors.border, paddingHorizontal: 12, paddingVertical: 8, borderRadius: 999, marginRight: 8, marginBottom: 8 },
+  imageWrap: { borderRadius: 20, overflow: "hidden", backgroundColor: theme.colors.surfaceMuted },
   image: { width: "100%", aspectRatio: 16 / 9 },
-  footer: { position: "absolute", left: 0, right: 0, bottom: 0, padding: 12, backgroundColor: "#FFFFFF",
-    borderTopWidth: 1, borderTopColor: "#E5E7EB", shadowColor: "#000", shadowOpacity: 0.08, shadowRadius: 10, elevation: 8 },
+  footer: { position: "absolute", left: 0, right: 0, bottom: 0, padding: 12, backgroundColor: theme.colors.surface,
+    borderTopWidth: 1, borderTopColor: theme.colors.border, shadowColor: "#000", shadowOpacity: 0.08, shadowRadius: 10, elevation: 8 },
 
-  toggleBtn: { paddingHorizontal: 10, paddingVertical: 8, borderRadius: 10, borderWidth: 1, borderColor: "#E5E7EB", backgroundColor: "#F8FAFC" },
-  toggleText: { fontWeight: "700", color: "#111827" },
-  caption: { marginTop: 6, color: "#6B7280", fontSize: 12 },
+  toggleBtn: { paddingHorizontal: 10, paddingVertical: 8, borderRadius: 10, borderWidth: 1, borderColor: theme.colors.border, backgroundColor: theme.colors.background },
+  toggleText: { fontWeight: "700", color: theme.colors.text },
+  caption: { marginTop: 6, color: theme.colors.textMuted, fontSize: 12 },
   descHeaderRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
 });

--- a/travelswap_ai/travelswapai/screens/MatchingScreen.js
+++ b/travelswap_ai/travelswapai/screens/MatchingScreen.js
@@ -179,7 +179,7 @@ function MatchRow({ item, onPress, isNew, expanded, onToggleInfo, generatedAt, o
   
   return (
     <View style={styles.row}>
-      <View style={[styles.avatar, { backgroundColor: "#E5E7EB" }]} />
+      <View style={[styles.avatar, { backgroundColor: theme.colors.surfaceMuted }]} />
       <View style={{ flex: 1, marginLeft: 10 }}>
         <View style={{ flexDirection: "row", alignItems: "center" }}>
           <Text style={styles.title} numberOfLines={1}>{item.title}</Text>
@@ -223,7 +223,7 @@ function MatchRow({ item, onPress, isNew, expanded, onToggleInfo, generatedAt, o
         </TouchableOpacity>
 
         <TouchableOpacity onPress={onPressChevron} style={{ paddingTop: 6 }}>
-          <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
+          <Ionicons name="chevron-forward" size={18} color={theme.colors.textMuted} />
         </TouchableOpacity>
       </View>
     </View>
@@ -734,8 +734,8 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: "#E5E7EB",
-    backgroundColor: "#F9FAFB",
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surfaceMuted,
   },
   legendToggleText: { fontWeight: "700", color: theme.colors.boardingText },
 
@@ -750,21 +750,21 @@ const styles = StyleSheet.create({
   },
   sectionHeader: { marginBottom: 8 },
   sectionTitle: { fontFamily: theme.fonts.headingBold, fontSize: 16, color: theme.colors.boardingText },
-  sectionSubtitle: { color: "#6B7280", marginTop: 4 },
+  sectionSubtitle: { color: theme.colors.textMuted, marginTop: 4 },
 
   /* Riga */
   row: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: "#FFFFFF",
+    backgroundColor: theme.colors.surface,
     borderWidth: 1,
-    borderColor: "#F3F4F6",
+    borderColor: theme.colors.border,
     borderRadius: 12,
     padding: 10,
   },
   avatar: { width: 48, height: 48, borderRadius: 10 },
   title: { fontWeight: "800", color: theme.colors.boardingText, marginRight: 8 },
-  meta: { color: "#6B7280", marginTop: 2 },
+  meta: { color: theme.colors.textMuted, marginTop: 2 },
 
   /* colonna destra */
   rightCol: { alignItems: "flex-end", justifyContent: "center", gap: 8 },
@@ -799,20 +799,20 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 6,
     borderRadius: 999,
-    backgroundColor: "#F3F4F6",
+    backgroundColor: theme.colors.surfaceMuted,
     borderWidth: 1,
-    borderColor: "#E5E7EB",
+    borderColor: theme.colors.border,
   },
   infoChipTxt: { color: theme.colors.boardingText, fontWeight: "700", fontSize: 12 },
 
   /* Spiegazione */
-  explBox: { marginTop: 8, borderWidth: 1, borderColor: "#E5E7EB", backgroundColor: "#F9FAFB", borderRadius: 10, padding: 10 },
-  explText: { color: "#374151", lineHeight: 18 },
+  explBox: { marginTop: 8, borderWidth: 1, borderColor: theme.colors.border, backgroundColor: theme.colors.surfaceMuted, borderRadius: 10, padding: 10 },
+  explText: { color: theme.colors.text, lineHeight: 18 },
   explFooter: { flexDirection: "row", justifyContent: "space-between", marginTop: 6 },
-  explSmall: { fontSize: 12, color: "#6B7280" },
+  explSmall: { fontSize: 12, color: theme.colors.textMuted },
 
   /* Skeleton */
-  skel: { backgroundColor: "#E5E7EB" },
+  skel: { backgroundColor: theme.colors.border },
 
   /* Pulsante "Aggiorna suggerimenti" (pill con etichetta) */
   fab: {

--- a/travelswap_ai/travelswapai/screens/OfferDetailScreen.js
+++ b/travelswap_ai/travelswapai/screens/OfferDetailScreen.js
@@ -52,7 +52,7 @@ export default function OfferDetailScreen() {
   if (!effectiveId) {
     return (
       <View style={s.center}>
-        <Text style={{ color: "#6B7280" }}>{t("offerDetail.notFound", "Annuncio non trovato.")}</Text>
+        <Text style={{ color: theme.colors.textMuted }}>{t("offerDetail.notFound", "Annuncio non trovato.")}</Text>
       </View>
     );
   }
@@ -135,7 +135,7 @@ export default function OfferDetailScreen() {
   if (error) {
     return (
       <View style={s.center}>
-        <Text style={{ color: "#B91C1C", marginBottom: 8 }}>{error}</Text>
+        <Text style={{ color: theme.colors.danger, marginBottom: 8 }}>{error}</Text>
         <TouchableOpacity style={s.btn} onPress={load}>
           <Text style={s.btnTxt}>{t("common.retry", "Riprova")}</Text>
         </TouchableOpacity>
@@ -183,11 +183,11 @@ export default function OfferDetailScreen() {
                     listingId: effectiveId,
                   })
                 }
-                style={[s.btn, { backgroundColor: "#F3F4F6", borderWidth: 1, borderColor: "#E5E7EB" }]}
+                style={[s.btn, { backgroundColor: theme.colors.surfaceMuted, borderWidth: 1, borderColor: theme.colors.border }]}
                 accessibilityRole="button"
                 accessibilityLabel={t("detail.actions.proposeBuy", "Proponi acquisto")}
               >
-                <Text style={[s.btnTxt, { color: theme.colors.primary }]}>
+                <Text style={[s.btnTxt, { color: theme.colors.text }]}>
                   {t("detail.actions.proposeBuy", "Proponi acquisto")}
                 </Text>
               </TouchableOpacity>
@@ -255,7 +255,7 @@ export default function OfferDetailScreen() {
 
       {visibleOffers.length === 0 && (
         <View style={{ alignItems: "center", paddingVertical: 24 }}>
-          <Text style={{ color: "#6B7280" }}>
+          <Text style={{ color: theme.colors.textMuted }}>
             {showOnlyThisProposal && proposalId
               ? t("offers.noneOne", "Nessuna proposta trovata per l’ID selezionato")
               : t("offers.none", "Nessuna proposta")}
@@ -267,7 +267,7 @@ export default function OfferDetailScreen() {
 }
 
 const s = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#fff" },
+  container: { flex: 1, backgroundColor: theme.colors.background },
   center: { flex: 1, alignItems: "center", justifyContent: "center" },
   title: { fontFamily: theme.fonts.headingExtraBold, fontSize: 20, marginBottom: 12 },
   box: {
@@ -275,8 +275,8 @@ const s = StyleSheet.create({
     padding: 14, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
   },
   boxTitle: { fontWeight: "800" },
-  boxMeta: { color: "#6B7280", marginTop: 4 },
-  badge: { color: "#374151", fontWeight: "700" },
+  boxMeta: { color: theme.colors.textMuted, marginTop: 4 },
+  badge: { color: theme.colors.textMuted, fontWeight: "700" },
 
   /* CTA sotto il box annuncio */
   ctaRow: { flexDirection: "row", gap: 10, marginTop: 12 },
@@ -286,14 +286,14 @@ const s = StyleSheet.create({
     padding: 14, marginBottom: 10, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
   },
   cardTitle: { fontWeight: "800" },
-  cardSub: { color: "#6B7280", marginTop: 4 },
-  cardMeta: { color: "#111827", marginTop: 4, fontWeight: "600" },
+  cardSub: { color: theme.colors.textMuted, marginTop: 4 },
+  cardMeta: { color: theme.colors.text, marginTop: 4, fontWeight: "600" },
 
   row: { flexDirection: "row", gap: 10, alignItems: "center", marginTop: 10 },
 
   /* Bottoni */
-  btn: { backgroundColor: "#111827", paddingVertical: 10, paddingHorizontal: 16, borderRadius: 10, alignItems: "center" },
-  btnTxt: { color: "#fff", fontWeight: "800" },
+  btn: { backgroundColor: theme.colors.accent, paddingVertical: 10, paddingHorizontal: 16, borderRadius: 10, alignItems: "center" },
+  btnTxt: { color: theme.colors.accentOn, fontWeight: "800" },
   btnSm: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 10, alignItems: "center" },
   btnDisabled: { opacity: 0.6 },
   accept: { backgroundColor: "#DCFCE7" },
@@ -301,6 +301,6 @@ const s = StyleSheet.create({
   decline: { backgroundColor: "#FEE2E2" },
   declineTxt: { color: "#991B1B", fontWeight: "800" },
 
-  badgeWrap: { paddingVertical: 6, paddingHorizontal: 10, backgroundColor: "#F3F4F6", borderRadius: 999 },
-  badgeTxt: { fontWeight: "700", color: "#374151" },
+  badgeWrap: { paddingVertical: 6, paddingHorizontal: 10, backgroundColor: theme.colors.surfaceMuted, borderRadius: 999 },
+  badgeTxt: { fontWeight: "700", color: theme.colors.textMuted },
 });

--- a/travelswap_ai/travelswapai/screens/OfferFlow.js
+++ b/travelswap_ai/travelswapai/screens/OfferFlow.js
@@ -132,7 +132,7 @@ export default function OfferFlow() {
   if (error) {
     return (
       <View style={s.center}>
-        <Text style={{ color: "#B91C1C", marginBottom: 12 }}>{error}</Text>
+        <Text style={{ color: theme.colors.danger, marginBottom: 12 }}>{error}</Text>
         <TouchableOpacity style={s.btn} onPress={load}><Text style={s.btnTxt}>{t("common.retry", "Riprova")}</Text></TouchableOpacity>
       </View>
     );
@@ -206,7 +206,7 @@ export default function OfferFlow() {
                     <Text style={s.cardMeta}>{item.type} • {item.location || item.route_from || "-"}</Text>
                   </TouchableOpacity>
                 )}
-                ListEmptyComponent={<Text style={{ color: "#6B7280" }}>{t("offerFlow.noActiveListings", "Non hai annunci attivi.")}</Text>}
+                ListEmptyComponent={<Text style={{ color: theme.colors.textMuted }}>{t("offerFlow.noActiveListings", "Non hai annunci attivi.")}</Text>}
                 style={{ maxHeight: 240 }}
               />
               <Text style={[s.label, { marginTop: 16 }]}>{t("offerFlow.messageOptional", "Messaggio (opzionale)")}</Text>
@@ -234,7 +234,7 @@ export default function OfferFlow() {
 }
 
 const s = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#fff", padding: 16 },
+  container: { flex: 1, backgroundColor: theme.colors.background, padding: 16 },
   center: { flex: 1, alignItems: "center", justifyContent: "center" },
   title: { fontFamily: theme.fonts.headingExtraBold, fontSize: 20, marginBottom: 16 },
   target: {
@@ -242,13 +242,13 @@ const s = StyleSheet.create({
     padding: 14, marginBottom: 12, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
   },
   tTitle: { fontWeight: "800" },
-  tMeta: { color: "#6B7280", marginTop: 4 },
+  tMeta: { color: theme.colors.textMuted, marginTop: 4 },
   label: { fontWeight: "700", marginTop: 8, marginBottom: 6 },
-  input: { borderWidth: 1, borderColor: "#E5E7EB", borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10 },
-  btn: { backgroundColor: "#111827", paddingVertical: 12, borderRadius: 12, alignItems: "center" },
-  btnTxt: { color: "#fff", fontWeight: "700" },
-  btnOutline: { borderWidth: 1, borderColor: "#E5E7EB", paddingVertical: 12, borderRadius: 12, alignItems: "center", paddingHorizontal: 14 },
-  btnOutlineTxt: { color: "#111827", fontWeight: "700" },
+  input: { borderWidth: 1, borderColor: theme.colors.border, borderRadius: 12, paddingHorizontal: 12, paddingVertical: 10 },
+  btn: { backgroundColor: theme.colors.accent, paddingVertical: 12, borderRadius: 12, alignItems: "center" },
+  btnTxt: { color: theme.colors.accentOn, fontWeight: "800" },
+  btnOutline: { borderWidth: 1, borderColor: theme.colors.border, paddingVertical: 12, borderRadius: 12, alignItems: "center", paddingHorizontal: 14 },
+  btnOutlineTxt: { color: theme.colors.text, fontWeight: "700" },
   btnDisabled: { opacity: 0.5 },
   card: {
     borderWidth: 1, borderColor: theme.colors.border, borderRadius: theme.radius.lg,
@@ -256,7 +256,7 @@ const s = StyleSheet.create({
   },
   cardSelected: { borderColor: theme.colors.accent, backgroundColor: theme.colors.accentSoft },
   cardTitle: { fontWeight: "800" },
-  cardMeta: { color: "#6B7280", marginTop: 4 },
+  cardMeta: { color: theme.colors.textMuted, marginTop: 4 },
   pendingBox: { borderWidth: 1, borderColor: "#F59E0B", backgroundColor: "#FFFBEB", borderRadius: 12, padding: 12, marginTop: 8 },
   pendingTitle: { fontWeight: "800", color: "#92400E" },
   pendingMsg: { marginTop: 6, color: "#92400E" },

--- a/travelswap_ai/travelswapai/screens/ProfileScreen.js
+++ b/travelswap_ai/travelswapai/screens/ProfileScreen.js
@@ -257,7 +257,7 @@ export default function ProfileScreen() {
 
       {/* Pubblicato il */}
       {item.created_at && (
-        <Text style={{ color: '#6B7280', marginTop: 8, fontSize: 12 }}>
+        <Text style={{ color: theme.colors.textMuted, marginTop: 8, fontSize: 12 }}>
           {t("listing.publishedOn", "Pubblicato il")} {fmtPubDate(item.created_at)}
         </Text>
       )}
@@ -478,11 +478,11 @@ export default function ProfileScreen() {
 const styles = StyleSheet.create({
   // card contenitori header/sezioni profilo
   card: {
-    backgroundColor: "#fff",
+    backgroundColor: theme.colors.surface,
     borderRadius: 16,
     padding: 16,
     borderWidth: 1,
-    borderColor: "#E5E7EB",
+    borderColor: theme.colors.border,
     marginBottom: 12,
   },
 
@@ -497,8 +497,8 @@ const styles = StyleSheet.create({
   avatar: { width: 56, height: 56, borderRadius: 28, backgroundColor: theme.colors.primary, alignItems: "center", justifyContent: "center" },
   avatarText: { color: theme.colors.boardingText, fontWeight: "800", fontSize: 16 },
   name: { fontSize: 16, fontWeight: "800", color: theme.colors.boardingText},
-  metaText: { color: "#6B7280" },
-  editBtn: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 10, backgroundColor: theme.colors.primary, borderWidth: 1, borderColor: "#E5E7EB" },
+  metaText: { color: theme.colors.textMuted },
+  editBtn: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 10, backgroundColor: theme.colors.primary, borderWidth: 1, borderColor: theme.colors.border },
   editBtnText: { fontWeight: "700", color: theme.colors.boardingText},
 
   // stats
@@ -511,20 +511,20 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: "#E5E7EB",
-    backgroundColor: "#F9FAFB",
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surfaceMuted,
   },
-  statBoxActive: { backgroundColor: "#EEF2FF", borderColor: "#C7D2FE" },
+  statBoxActive: { backgroundColor: theme.colors.primary, borderColor: theme.colors.primaryMuted },
   statIcon: { fontSize: 18, marginBottom: 4 },
   statValue: { fontSize: 16, fontWeight: "800", color: theme.colors.boardingText },
-  statLabel: { fontSize: 12, color: "#6B7280" },
+  statLabel: { fontSize: 12, color: theme.colors.textMuted },
 
   filterBar: {
-    marginTop: 10, padding: 8, borderRadius: 10, backgroundColor: "#F3F4F6",
+    marginTop: 10, padding: 8, borderRadius: 10, backgroundColor: theme.colors.surfaceMuted,
     flexDirection: "row", alignItems: "center", justifyContent: "space-between",
   },
-  filterText: { color: "#374151", fontWeight: "600" },
-  clearBtn: { paddingHorizontal: 10, paddingVertical: 6, borderRadius: 8, backgroundColor: "#111827" },
+  filterText: { color: theme.colors.textMuted, fontWeight: "600" },
+  clearBtn: { paddingHorizontal: 10, paddingVertical: 6, borderRadius: 8, backgroundColor: theme.colors.text },
   clearBtnText: { color: "#fff", fontWeight: "700" },
 
   sectionHeader: { marginTop: 0, marginBottom: 8, paddingHorizontal: 4, flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
@@ -536,24 +536,24 @@ const styles = StyleSheet.create({
     padding: 14, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
   },
   listCardTitle: { fontWeight: "800", color: theme.colors.boardingText },
-  listCardSub: { color: "#6B7280", marginTop: 4 },
-  listCardMeta: { color: "#111827", marginTop: 6, fontWeight: "600" },
+  listCardSub: { color: theme.colors.textMuted, marginTop: 4 },
+  listCardMeta: { color: theme.colors.text, marginTop: 6, fontWeight: "600" },
 
-  stateBadge: { marginLeft: 8, paddingHorizontal: 8, paddingVertical: 3, borderRadius: 999, backgroundColor: "#F3F4F6", borderWidth: 1, borderColor: "#E5E7EB" },
-  stateBadgeText: { fontSize: 12, fontWeight: "800", color: "#374151" },
+  stateBadge: { marginLeft: 8, paddingHorizontal: 8, paddingVertical: 3, borderRadius: 999, backgroundColor: theme.colors.surfaceMuted, borderWidth: 1, borderColor: theme.colors.border },
+  stateBadgeText: { fontSize: 12, fontWeight: "800", color: theme.colors.textMuted },
 
   overflowBtn: { marginLeft: 6, paddingHorizontal: 6, paddingVertical: 2, alignItems: "center", justifyContent: "center" },
-  overflowIcon: { fontSize: 20, color: "#6B7280", fontWeight: "800", marginTop: -2 },
+  overflowIcon: { fontSize: 20, color: theme.colors.textMuted, fontWeight: "800", marginTop: -2 },
 
-  pubDate: { marginTop: 2, color: "#6B7280", fontSize: 12 },
+  pubDate: { marginTop: 2, color: theme.colors.textMuted, fontSize: 12 },
 
   errorBox: { marginBottom: 10, padding: 12, borderRadius: 12, backgroundColor: "#FEF2F2", borderWidth: 1, borderColor: "#FECACA" },
   errorText: { color: "#991B1B" },
-  retryText: { color: "#2563EB", fontWeight: "700", marginTop: 6 },
+  retryText: { color: theme.colors.info, fontWeight: "700", marginTop: 6 },
 
   emptyWrap: { alignItems: "center", justifyContent: "center", paddingVertical: 24 },
-  emptyTitle: { fontWeight: "800", color: "#111827", marginBottom: 6 },
-  emptyText: { color: "#6B7280", textAlign: "center" },
+  emptyTitle: { fontWeight: "800", color: theme.colors.text, marginBottom: 6 },
+  emptyText: { color: theme.colors.textMuted, textAlign: "center" },
 
   fabWrap: { position: "absolute", right: 16 },
   fab: {
@@ -562,5 +562,5 @@ const styles = StyleSheet.create({
   },
   fabPlus: { color: theme.colors.boardingText, fontSize: 28, fontWeight: "900", marginTop: -2 },
 
-  skel: { backgroundColor: "#E5E7EB" },
+  skel: { backgroundColor: theme.colors.border },
 });


### PR DESCRIPTION
Chiude l'ultimo punto aperto del quality check (#8): le schermate secondarie passano ai token del tema Swap Gold. Da **~230 colori hardcoded a ~70**, e i rimasti sono tutti intenzionali (semafori di stato, tinte errore/avviso, bianco su scuro, ombre, fallback).

## Schermate toccate
Crea annuncio, Dettaglio annuncio, Dettaglio offerta, Invio proposta, Profilo, Suggeriti dall'AI + i componenti DateField/DateTimeField. **TrustScoreBadge non toccato**: è un semaforo, i suoi colori sono semantici.

## Scelte di rilievo
- I CTA principali **"Invia proposta"** e **"Proponi scambio"** passano all'**oro** con testo indigo, come tutti i CTA principali dell'app
- **"Analisi prezzo con AI"** in Crea annuncio passa all'oro: le azioni AI condividono lo stesso accento ovunque (coerente con l'enfasi AI chiesta)
- 🐛 **Fix contrasto trovato strada facendo**: il testo del bottone ghost "Proponi acquisto" in OfferDetail usava `theme.colors.primary` — dopo il refresh della palette è lavanda chiarissimo su fondo chiaro, quasi invisibile → ora indigo
- I pulsanti scuri neutri (near-black `#111827`/`#0F172A`) passano all'indigo brand `#1B2159`

## Verifica
- [x] esbuild sugli 8 file: sintassi OK
- [x] **Bundle Metro completo** (`expo export`): riuscito
- [x] Diff chirurgico: 135 righe modificate 1:1, nessun cambio di fine riga (controllato apposta)
- [x] Nessuna chiave i18n toccata (parità invariata)
- [ ] **Non provata su dispositivo reale** — è una PR solo estetica: se qualche colore non ti convince dal vivo, si ritocca il singolo token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_