### PR TITLE
Rende modificabili le preferenze di viaggio dal profilo

### DIFF
--- a/travelswap_ai/travelswapai/App.js
+++ b/travelswap_ai/travelswapai/App.js
@@ -135,6 +135,11 @@ function RootNavigator() {
           <Stack.Screen name="ManageImages" component={ManageImagesScreen} options={{ title: "Foto annuncio" }} />
           <Stack.Screen name="ChainProposals" component={ChainProposalsScreen} options={{ title: "Scambi a 3" }} />
           <Stack.Screen name="SavedSearches" component={SavedSearchesScreen} options={{ title: "Avvisi di ricerca" }} />
+          <Stack.Screen name="EditPreferences" options={{ title: "Le tue preferenze" }}>
+            {(props) => (
+              <PreferencesOnboardingScreen {...props} mode="edit" onDone={() => props.navigation.goBack()} />
+            )}
+          </Stack.Screen>
           <Stack.Screen name="Matching" component={MatchingScreen} options={{ title: "Suggeriti dall'AI" }} />
         </>
       ) : (

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -94,6 +94,7 @@ export const translations = {
       title: "Profilo",
       editProfile: "Modifica profilo",
       savedListings: "I miei preferiti",
+      editPreferences: "Le mie preferenze",
       logout: "Esci",
       myListings: "I miei annunci",
       publishListing: "Pubblica annuncio",
@@ -183,6 +184,7 @@ export const translations = {
     prefsOnboarding: {
       title: "Le tue preferenze di viaggio",
       subtitle: "Aiutaci a trovarti gli scambi giusti — puoi cambiarle quando vuoi dal profilo.",
+      editSubtitle: "Aggiorna i tuoi gusti di viaggio: li usiamo per suggerirti scambi migliori.",
       typeLabel: "Cosa ti interessa di più?",
       typeTrain: "Treno",
       typeHotel: "Hotel",
@@ -193,6 +195,8 @@ export const translations = {
       save: "Salva preferenze",
       skip: "Salta per ora",
       saveError: "Impossibile salvare le preferenze.",
+      savedTitle: "Salvato",
+      savedMsg: "Preferenze aggiornate.",
     },
 
     editProfileScreen: {
@@ -784,6 +788,7 @@ export const translations = {
       title: "Profile",
       editProfile: "Edit profile",
       savedListings: "My favorites",
+      editPreferences: "My preferences",
       logout: "Logout",
       myListings: "My listings",
       publishListing: "Publish listing",
@@ -873,6 +878,7 @@ export const translations = {
     prefsOnboarding: {
       title: "Your travel preferences",
       subtitle: "Help us find the right swaps for you — you can change these anytime from your profile.",
+      editSubtitle: "Update your travel taste: we use it to suggest better swaps.",
       typeLabel: "What are you most interested in?",
       typeTrain: "Train",
       typeHotel: "Hotel",
@@ -883,6 +889,8 @@ export const translations = {
       save: "Save preferences",
       skip: "Skip for now",
       saveError: "Unable to save preferences.",
+      savedTitle: "Saved",
+      savedMsg: "Preferences updated.",
     },
 
     editProfileScreen: {
@@ -1459,6 +1467,7 @@ export const translations = {
       title: "Perfil",
       editProfile: "Editar perfil",
       savedListings: "Mis favoritos",
+      editPreferences: "Mis preferencias",
       logout: "Cerrar sesión",
       myListings: "Mis anuncios",
       publishListing: "Publicar anuncio",
@@ -1548,6 +1557,7 @@ export const translations = {
     prefsOnboarding: {
       title: "Tus preferencias de viaje",
       subtitle: "Ayúdanos a encontrarte los intercambios adecuados — puedes cambiarlas cuando quieras desde el perfil.",
+      editSubtitle: "Actualiza tus gustos de viaje: los usamos para sugerirte mejores intercambios.",
       typeLabel: "¿Qué te interesa más?",
       typeTrain: "Tren",
       typeHotel: "Hotel",
@@ -1558,6 +1568,8 @@ export const translations = {
       save: "Guardar preferencias",
       skip: "Saltar por ahora",
       saveError: "No se pudieron guardar las preferencias.",
+      savedTitle: "Guardado",
+      savedMsg: "Preferencias actualizadas.",
     },
 
     editProfileScreen: {

--- a/travelswap_ai/travelswapai/screens/PreferencesOnboardingScreen.js
+++ b/travelswap_ai/travelswapai/screens/PreferencesOnboardingScreen.js
@@ -2,7 +2,7 @@
 // registrazione, per alimentare da subito il matching AI (server/src/ai/
 // score.js legge prefs.types/maxPrice/location per il fallback euristico,
 // e l'AI vera li usa come contesto).
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, Alert, ScrollView,
 } from "react-native";
@@ -10,7 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { theme } from "../lib/theme";
 import { useI18n } from "../lib/i18n";
-import { saveMyPrefs, skipPrefsOnboarding } from "../lib/preferences";
+import { getMyPrefs, saveMyPrefs, skipPrefsOnboarding } from "../lib/preferences";
 import Input from "../components/ui/Input";
 import Button from "../components/ui/Button";
 
@@ -19,13 +19,33 @@ const TYPE_OPTIONS = [
   { key: "hotel", icon: "bed-outline", labelKey: "prefsOnboarding.typeHotel", fallback: "Hotel" },
 ];
 
-export default function PreferencesOnboardingScreen({ onDone }) {
+// mode "onboarding" (default): gate subito dopo la registrazione, con
+// "Salta per ora". mode "edit": raggiunta dal profilo in qualsiasi
+// momento, precarica le preferenze già salvate e non ha lo skip (c'è
+// già la freccia indietro dell'header).
+export default function PreferencesOnboardingScreen({ onDone, mode = "onboarding" }) {
   const { t } = useI18n();
+  const isEdit = mode === "edit";
   const [types, setTypes] = useState([]);
   const [maxPrice, setMaxPrice] = useState("");
   const [location, setLocation] = useState("");
   const [saving, setSaving] = useState(false);
   const [skipping, setSkipping] = useState(false);
+  const [loadingPrefs, setLoadingPrefs] = useState(isEdit);
+
+  useEffect(() => {
+    if (!isEdit) return;
+    let alive = true;
+    getMyPrefs()
+      .then((prefs) => {
+        if (!alive || !prefs) return;
+        setTypes(Array.isArray(prefs.types) ? prefs.types : []);
+        setMaxPrice(prefs.maxPrice != null ? String(prefs.maxPrice) : "");
+        setLocation(prefs.location || "");
+      })
+      .finally(() => { if (alive) setLoadingPrefs(false); });
+    return () => { alive = false; };
+  }, [isEdit]);
 
   const toggleType = (key) => {
     setTypes((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]));
@@ -40,6 +60,9 @@ export default function PreferencesOnboardingScreen({ onDone }) {
         maxPrice: Number.isFinite(priceNum) && priceNum > 0 ? priceNum : undefined,
         location: location.trim() || undefined,
       });
+      if (isEdit) {
+        Alert.alert(t("prefsOnboarding.savedTitle", "Salvato"), t("prefsOnboarding.savedMsg", "Preferenze aggiornate."));
+      }
       onDone?.();
     } catch (e) {
       Alert.alert(t("common.error", "Errore"), e?.message || t("prefsOnboarding.saveError", "Impossibile salvare le preferenze."));
@@ -63,12 +86,22 @@ export default function PreferencesOnboardingScreen({ onDone }) {
 
   const busy = saving || skipping;
 
+  if (loadingPrefs) {
+    return (
+      <SafeAreaView style={[styles.root, { alignItems: "center", justifyContent: "center" }]}>
+        <ActivityIndicator />
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView style={styles.root}>
       <ScrollView contentContainerStyle={styles.content}>
         <Text style={styles.title}>{t("prefsOnboarding.title", "Le tue preferenze di viaggio")}</Text>
         <Text style={styles.subtitle}>
-          {t("prefsOnboarding.subtitle", "Aiutaci a trovarti gli scambi giusti — puoi cambiarle quando vuoi dal profilo.")}
+          {isEdit
+            ? t("prefsOnboarding.editSubtitle", "Aggiorna i tuoi gusti di viaggio: li usiamo per suggerirti scambi migliori.")
+            : t("prefsOnboarding.subtitle", "Aiutaci a trovarti gli scambi giusti — puoi cambiarle quando vuoi dal profilo.")}
         </Text>
 
         <Text style={styles.sectionLabel}>{t("prefsOnboarding.typeLabel", "Cosa ti interessa di più?")}</Text>
@@ -119,13 +152,15 @@ export default function PreferencesOnboardingScreen({ onDone }) {
           style={{ marginTop: 8 }}
         />
 
-        <TouchableOpacity onPress={onSkip} disabled={busy} style={styles.skipBtn}>
-          {skipping ? (
-            <ActivityIndicator color={theme.colors.textMuted} />
-          ) : (
-            <Text style={styles.skipText}>{t("prefsOnboarding.skip", "Salta per ora")}</Text>
-          )}
-        </TouchableOpacity>
+        {!isEdit && (
+          <TouchableOpacity onPress={onSkip} disabled={busy} style={styles.skipBtn}>
+            {skipping ? (
+              <ActivityIndicator color={theme.colors.textMuted} />
+            ) : (
+              <Text style={styles.skipText}>{t("prefsOnboarding.skip", "Salta per ora")}</Text>
+            )}
+          </TouchableOpacity>
+        )}
       </ScrollView>
     </SafeAreaView>
   );

--- a/travelswap_ai/travelswapai/screens/ProfileScreen.js
+++ b/travelswap_ai/travelswapai/screens/ProfileScreen.js
@@ -335,6 +335,16 @@ export default function ProfileScreen() {
             </TouchableOpacity>
 
             <TouchableOpacity
+              style={[styles.editBtn, { marginTop: 8 }]}
+              onPress={() => {
+                navigation.navigate?.("EditPreferences");
+                navigation.getParent?.()?.navigate?.("EditPreferences");
+              }}
+            >
+              <Text style={styles.editBtnText}>✨ {t("profile.editPreferences", "Le mie preferenze")}</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
               style={[styles.editBtn, { marginTop: 8, backgroundColor: theme.colors.primary, borderColor: theme.colors.text }]}
               onPress={handleLogout}
             >


### PR DESCRIPTION
Chiude l'incoerenza segnalata nel documento di sintesi funzionalità: il testo prometteva *"puoi cambiarle quando vuoi dal profilo"*, ma non c'era alcun modo di farlo. Ora c'è.

## Cosa cambia
- `PreferencesOnboardingScreen` diventa riusabile con un nuovo prop `mode="edit"`: precarica le preferenze già salvate, nasconde "Salta per ora" (non ha senso fuori dal primo accesso), sottotitolo diverso, conferma "Salvato" dopo il salvataggio. Il comportamento in `mode="onboarding"` (default, usato al primo accesso) resta identico a prima.
- Nuova voce **"✨ Le mie preferenze"** nel Profilo → rotta `EditPreferences` nello Stack radice.

## Cosa restano a fare, per chiarezza
Le preferenze continuano a servire **solo** al motore di matching AI (fallback euristico in `score.js`: +15 tipo, +10 prezzo, +10 città; più contesto per l'AI vera) — non toccano Esplora, Avvisi di ricerca o gli scambi a 3, come già verificato in precedenza.

## Verifica
- [x] esbuild su tutti i file toccati: sintassi OK
- [x] Parità i18n it/en/es: **524/524/524 chiavi**
- [x] Bundle Metro completo (`expo export`): riuscito
- [ ] Non provata su dispositivo reale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_