### PR TITLE
fix(critico): il server crasha all'avvio se manca OPENAI_API_KEY

### DIFF
--- a/server/src/parsers/fbParser.js
+++ b/server/src/parsers/fbParser.js
@@ -10,9 +10,13 @@ import OpenAI from 'openai';
  * Richiede: process.env.OPENAI_API_KEY
  */
 
-const client = new OpenAI({
-  apiKey: (process.env.OPENAI_API_KEY || '').trim(),
-});
+// Bug preesistente corretto: con apiKey vuota il costruttore di OpenAI
+// lancia comunque un'eccezione a livello di modulo — a import time, ben
+// prima che aiExtract() abbia mai la possibilità di controllare la chiave
+// — facendo cadere l'intero server all'avvio, non solo l'import da
+// Messenger. Costruito solo se la chiave è presente.
+const OPENAI_KEY = (process.env.OPENAI_API_KEY || '').trim();
+const client = OPENAI_KEY ? new OpenAI({ apiKey: OPENAI_KEY }) : null;
 
 // Schema base con tutti i campi a null
 function emptyParsed() {
@@ -129,7 +133,7 @@ const FEW_SHOTS = [
 ];
 
 async function aiExtract(text) {
-  if (!client.apiKey) {
+  if (!client) {
     throw new Error('Missing OPENAI_API_KEY');
   }
 

--- a/server/src/services/trust/aiTrust.js
+++ b/server/src/services/trust/aiTrust.js
@@ -1,7 +1,13 @@
 // server/src/services/trust/aiTrust.js
 import OpenAI from "openai";
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+// Bug preesistente corretto: il costruttore di OpenAI lancia un'eccezione
+// a livello di modulo se la chiave manca — a import time, prima che il
+// controllo esplicito qui sotto (riga ~15) abbia mai la possibilità di
+// scattare — facendo cadere l'intero server all'avvio, non solo questa
+// funzione. Costruito solo se la chiave è presente, stesso pattern già
+// corretto in ai/score.js.
+const openai = process.env.OPENAI_API_KEY ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY }) : null;
 
 /**
  * Valuta un listing con AI e restituisce:

--- a/server/src/services/trust/translate/openaiProvider.js
+++ b/server/src/services/trust/translate/openaiProvider.js
@@ -1,6 +1,10 @@
 import OpenAI from "openai";
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+// Se la chiave manca, il costruttore di OpenAI lancia un'eccezione a livello
+// di modulo — a import time, non dentro una funzione — che far cadere
+// l'intero server all'avvio (bug preesistente, stesso pattern trovato anche
+// in aiTrust.js e fbParser.js). Costruito solo se la chiave è presente.
+const client = process.env.OPENAI_API_KEY ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY }) : null;
 const MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
 
 const PH_RE = /(\{[A-Z0-9_]+\}|<<[A-Z0-9_]+>>)/gi;
@@ -20,6 +24,7 @@ function normalize(s="") {
 
 export async function openaiTranslate({ text, targetLang, sourceLang="auto" }) {
   if (!text) return "";
+  if (!client) return null; // chiave non configurata: fallimento distinto, vedi commento sopra
   const { safe, m } = protect(text);
   const sys = "You are a concise professional translator. Preserve tokens like __PH_0__ EXACTLY. Output only the translated text.";
   const user = `Target language: ${targetLang}\nSource language: ${sourceLang}\n\n${safe}`;


### PR DESCRIPTION
## Contesto

Su richiesta esplicita dell'utente ("mi controlli se le chiamate a OpenAI partono e funzionano correttamente"), ho controllato sistematicamente tutti i 7 file server che usano OpenAI. Trovato un bug di stabilità reale in 3 di questi.

## Il bug

`openaiProvider.js` (traduzione), `aiTrust.js` (TrustScore/Check AI) e `fbParser.js` (bot Messenger) creavano il client OpenAI con `new OpenAI({ apiKey: ... })` **a livello di modulo, incondizionatamente**. Se la chiave manca o è vuota, il costruttore lancia un'eccezione — a import time, prima che qualsiasi controllo "se manca la chiave, usa un fallback" dentro le funzioni abbia mai la possibilità di scattare.

**Conseguenza reale**: se `OPENAI_API_KEY` non fosse configurata (o venisse rimossa/rinominata per errore su Render), l'intero server smetterebbe di avviarsi — non solo le funzionalità AI, tutta l'app. Il crash esatto è già comparso una volta nei log di questa sessione: `OpenAIError: The OPENAI_API_KEY environment variable is missing or empty`.

`aiTrust.js` era un bug già noto (segnalato in un giro di analisi precedente, mai corretto). `openaiProvider.js` e `fbParser.js` avevano lo stesso identico problema, non ancora notato.

## Fix

Stesso pattern già usato correttamente in altri 4 file (`score.js`, `chainMatch.js`, `chainExplain.js`, `descriptionParse.js`):

```js
const client = process.env.OPENAI_API_KEY ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY }) : null;
```

Ora tutti e 7 i file sono coerenti — la chiave mancante degrada la singola funzionalità AI (con fallback già esistenti), non l'intero server.

## Verifica fatta

- Sintassi verificata (`node --check`) su tutti e 3 i file.
- **Test concreto**: avviato il server locale con `OPENAI_API_KEY` completamente assente. Prima di questo fix sarebbe crashato subito all'avvio; ora risponde normalmente (200 sulla home).
- 58/58 test server esistenti passano invariati.
- Nessuna modifica lato app: solo file server, nessun rebuild della versione web necessario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_