### PR TITLE
fix(critico): sicurezza matching AI + webhook Messenger senza risposta HTTP

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -349,7 +349,7 @@ app.post('/webhooks/facebook', async (req, res) => {
                     { title: "CERCO", payload: "CV_CERCO" },
                     { title: "VENDO", payload: "CV_VENDO" }
                   ]);
-                  return;
+                  return res.sendStatus(200);
                 }
                 try {
                   const ownerId = await getLinkedUserId(senderId);
@@ -375,7 +375,7 @@ app.post('/webhooks/facebook', async (req, res) => {
                   console.error('[Messenger Confirm Publish] Error:', e);
                   await sendFbText(senderId, "⚠️ C'è stato un problema nella pubblicazione. Riprova tra poco.");
                 }
-                return;
+                return res.sendStatus(200);
               } else if (p === 'PUB_MODIFICA') {
                 await sendFbText(senderId,
                   "✏️ Nessun problema! Dimmi cosa vuoi correggere: azione (CERCO/VENDO), tipo (treno/hotel), date o prezzo."
@@ -387,7 +387,7 @@ app.post('/webhooks/facebook', async (req, res) => {
                     { title: "🏨 Hotel", payload: "TYPE_HOTEL" }
                   ]);
                 }
-                return;
+                return res.sendStatus(200);
               }
             } catch (e) {
               console.error('[Messenger Postback] Error:', e);

--- a/server/src/models/fbLink.js
+++ b/server/src/models/fbLink.js
@@ -34,7 +34,12 @@ export async function createLinkCode(userId) {
   if (!supabase) throw new Error("Supabase client not configured");
   if (!userId) throw new Error("Missing userId");
 
-  await supabase.from("fb_link_codes").delete().eq("user_id", userId).is("used_at", null);
+  const { error: delError } = await supabase
+    .from("fb_link_codes")
+    .delete()
+    .eq("user_id", userId)
+    .is("used_at", null);
+  if (delError) console.error("[fbLink] createLinkCode: errore pulizia codici precedenti:", delError.message);
 
   const code = randomCode();
   const expiresAt = new Date(Date.now() + CODE_TTL_MINUTES * 60000).toISOString();
@@ -87,7 +92,7 @@ export async function getLinkedUserId(senderId) {
     .eq("sender_id", senderId)
     .maybeSingle();
   if (error) {
-    console.log("[fbLink] getLinkedUserId error:", error.message);
+    console.error("[fbLink] getLinkedUserId error:", error.message);
     return null;
   }
   return data?.user_id || null;

--- a/server/src/routes/match.js
+++ b/server/src/routes/match.js
@@ -22,10 +22,11 @@ matchesRouter.get("/snapshot/ping", (req, res) => {
  * GET /api/matches/snapshot?userId=...
  * Risponde: { items, count, generatedAt }
  */
-matchesRouter.get("/snapshot", async (req, res) => {
+matchesRouter.get("/snapshot", requireAuth, async (req, res) => {
   try {
     const userId = String(req.query?.userId || "");
     if (!isUUID(userId)) return res.status(400).json({ error: "Invalid userId" });
+    if (userId !== req.user.id) return res.status(403).json({ error: "Forbidden" });
     const out = await getUserSnapshot(userId);
     return res.json(out);
   } catch (e) {
@@ -40,12 +41,13 @@ matchesRouter.get("/snapshot", async (req, res) => {
  * Risponde: { userId, generatedAt, count }
  */
 
-matchesRouter.post("/snapshot/recompute", async (req, res) => {
+matchesRouter.post("/snapshot/recompute", requireAuth, async (req, res) => {
   try {
     const userId = String(req.body?.userId || "");
     const topPerListing = req.body?.topPerListing ?? 3;
     const maxTotal = req.body?.maxTotal ?? 50;
     if (!isUUID(userId)) return res.status(400).json({ error: "Invalid userId" });
+    if (userId !== req.user.id) return res.status(403).json({ error: "Forbidden" });
 
     // Se hai creato l’RPC v2, preferisci la SQL:
     // const out = await recomputeUserSnapshotSQL(userId, { topPerListing, maxTotal });
@@ -57,11 +59,14 @@ matchesRouter.post("/snapshot/recompute", async (req, res) => {
     return res.status(500).json({ error: String(e?.message || e) });
   }
 });
-matchesRouter.post("/ai/recompute", async (req, res) => {
+matchesRouter.post("/ai/recompute", requireAuth, async (req, res) => {
   try {
     const { userId, topPerListing = 3, maxTotal = 50 } = req.body || {};
     if (!userId || !isUUID(userId)) {
       return res.status(400).json({ ok: false, error: "missing/invalid userId" });
+    }
+    if (userId !== req.user.id) {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
     }
 
     // 1) calcolo AI


### PR DESCRIPTION
## Summary

**1. Endpoint del matching AI accessibili senza autenticazione**
- `server/src/routes/match.js` importava `requireAuth` ma non lo applicava a nessuna delle 3 route: chiunque conoscesse lo `userId` (UUID) di un altro utente poteva leggere il suo snapshot di suggerimenti AI o forzarne il ricalcolo (`GET /api/matches/snapshot`, `POST /api/matches/snapshot/recompute`, `POST /api/matches/ai/recompute`), senza essere autenticato come lui
- Applicato `requireAuth` alle 3 route (lasciata aperta solo `/snapshot/ping`, diagnostica e senza dati utente)
- Aggiunto anche un controllo di ownership esplicito: lo `userId` nella richiesta deve coincidere con `req.user.id` (403 altrimenti)

**2. Webhook Messenger non rispondeva 200 dopo conferma/modifica pubblicazione**
- Nel gestore del postback "Conferma pubblicazione" via Messenger (`PUB_CONFERMA`/`PUB_MODIFICA` in `server/src/index.js`), tre percorsi (sessione scaduta, pubblicazione riuscita, richiesta di modifica) uscivano dalla route con un `return;` nudo invece di rispondere con `res.sendStatus(200)` come fa il resto del webhook — Facebook restava senza risposta HTTP e reinviava lo stesso evento più volte, con rischio di messaggi duplicati all'utente
- Diagnosi nata investigando una segnalazione separata (collegamento Messenger che "non fa nulla" dopo aver scritto il codice in chat): zona di codice contigua, stesso pattern di risposta HTTP mancante, non la causa di quel bug specifico ma un difetto reale trovato durante l'indagine
- Corretti anche due errori minori in `server/src/models/fbLink.js`: l'eliminazione dei codici di collegamento precedenti non controllava l'esito, e un log di errore usava `console.log` invece di `console.error`

## Test plan
- [x] Verificato che il client (`lib/backendApi.js` → `fetchJson`) allega già sempre il token Supabase su queste chiamate, quindi nessun impatto sull'app per gli utenti loggati
- [x] Testato in locale: le 3 route del matching ora rispondono `401 Missing bearer token` senza header di autenticazione
- [x] Testato in locale: `/api/matches/snapshot/ping` resta raggiungibile senza auth (invariato, solo diagnostico)
- [x] `node --check` su tutti i file modificati
- [x] Server avviato in locale, boot pulito, `/health` risponde 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
