### PR TITLE
fix: audit proattivo backend — webhook Messenger quick reply + auth finto in listing.js

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -414,7 +414,7 @@ if (quickPayload) {
       { title: "CERCO", payload: "CV_CERCO" },
       { title: "VENDO", payload: "CV_VENDO" }
     ]);
-    return;
+    return res.sendStatus(200);
   }
 
   // 👇 normalizza alias/valori PRIMA di confermare
@@ -431,7 +431,7 @@ if (quickPayload) {
         { title: "🏨 Hotel", payload: "TYPE_HOTEL" }
       ]);
     }
-    return;
+    return res.sendStatus(200);
   }
 
   try {
@@ -458,7 +458,7 @@ if (quickPayload) {
     console.error('[Messenger QuickReply CONFIRM] Error:', e);
     await sendFbText(senderId, "⚠️ C'è stato un problema nella pubblicazione. Riprova tra poco.");
   }
-  return;
+  return res.sendStatus(200);
 }
 
 
@@ -473,7 +473,7 @@ if (quickPayload) {
           { title: "🏨 Hotel", payload: "TYPE_HOTEL" }
         ]);
       }
-      return;
+      return res.sendStatus(200);
     }
 
     // 🔹 2) Gestione normale delle quick replies (CERCO/VENDO, TIPO)

--- a/server/src/routes/listing.js
+++ b/server/src/routes/listing.js
@@ -1,17 +1,9 @@
 import { Router } from 'express';
 import { isUUID } from '../util/uuid.js';
 import { createListing, getListingPublic, listActiveListings, updateListing } from '../models/listings.js';
-import express from 'express';
-import { supabase } from '../db.js';
+import { requireAuth } from '../middleware/requireAuth.js';
 
-//export const listingsRouter = express.Router();
 export const listingsRouter = Router();
-
-// Esempio: middleware auth che setta req.user.id
-function requireAuth(req, res, next) {
-  if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
-  next();
-}
 
 listingsRouter.get('/', async (req, res) => {
   const { ownerId, limit } = req.query;


### PR DESCRIPTION
## Summary

Trovati durante un audit proattivo dell'intero backend, innescato dai due fix di sicurezza mergiati poco fa in PR #51 (auth mancante sul matching AI, risposta HTTP mancante nel webhook Messenger).

**1. Webhook Messenger senza risposta HTTP anche nei quick reply**
- Stesso bug corretto nella sezione dei postback (PR #51), presente anche nella sezione parallela dei quick reply (bottoni CERCO/VENDO, tipo, Conferma/Modifica): 4 punti in cui la route usciva con `return;` nudo invece di `return res.sendStatus(200);`
- Stesso impatto: Facebook non riceve risposta HTTP e può reinviare lo stesso evento, con rischio di messaggi duplicati durante il flusso guidato via Messenger
- Verificato con un audit sistematico (ricerca di `return;` nudo in tutti i route handler di `server/src/`): questi erano gli ultimi punti mancanti, tutto il resto del backend è pulito

**2. `requireAuth` finto in `server/src/routes/listing.js`**
- Il file definiva un proprio `requireAuth` locale che controllava solo se `req.user?.id` fosse già presente, ma nessun middleware lo popolava mai — l'unico punto in tutto il backend che assegna `req.user` è il vero `middleware/requireAuth.js`, mai importato qui
- Effetto pratico: `POST /api/listings`, `PATCH /api/listings/:id`, `POST /api/listings/:id/cancel` rispondevano sempre 401. **Nessun impatto utente reale** — verificato che l'app non usa queste route per creare/modificare/annullare annunci (passa direttamente da Supabase)
- Corretto comunque: è un pattern pericoloso da lasciare in giro (falso senso di sicurezza se in futuro un middleware meno rigoroso popolasse `req.user` senza verifica del token)
- Sostituito con l'import del vero `requireAuth`, rimossi import inutilizzati

## Test plan
- [x] `node --check` su tutti i file modificati
- [x] Server avviato in locale, boot pulito
- [x] Testato: `POST /api/listings` senza token ora risponde `401 Missing bearer token` (messaggio del vero middleware, non più dello stub)
- [x] Audit sistematico di tutte le route in `server/src/routes/` per gli stessi due pattern di bug: nessun altro problema trovato (dettaglio: `chains.js`, `savedSearches.js`, `fbLink.js`, `priceCheck.js`, `translateListings.js`, `trustscore.js` già correttamente protetti)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_