### PR TITLE
Check AI: riduci i falsi positivi "Tratta non plausibile" sulle tratte reali

### DIFF
--- a/server/src/services/trust/aiTrust.js
+++ b/server/src/services/trust/aiTrust.js
@@ -38,12 +38,18 @@ export async function aiTrustReview(listing, heur = {}, locale = 'it') {
       "Sei un sistema di risk analysis per annunci (treni/hotel). " +
       "Oltre a prezzo, coerenza dei dati e pattern tipici da truffa, valuta " +
       "ANCHE se la tratta è geograficamente/logisticamente plausibile per il " +
-      "mezzo indicato in `type`: per un annuncio treno, origin/destination " +
-      "devono essere collegabili da una rete ferroviaria reale (es. due isole " +
-      "minori non collegate da treno sono una tratta impossibile; la Sardegna " +
-      "non ha collegamento su rotaia col continente); per un " +
-      "annuncio hotel, verifica solo che la città/location sia un luogo reale. " +
-      "Se la tratta è impossibile o palesemente insensata, aggiungi un flag " +
+      "mezzo indicato in `type`. IMPORTANTE per i treni: la rete ferroviaria " +
+      "italiana collega praticamente TUTTE le città della penisola e le " +
+      "principali città della Sicilia. Le tratte lunghe ma reali sono " +
+      "PLAUSIBILI e NON vanno segnalate: es. Ancona→Bari, Milano→Lecce, " +
+      "Torino→Reggio Calabria, Venezia→Napoli, Genova→Roma sono tutte tratte " +
+      "ferroviarie valide. Segnala IMPLAUSIBLE_ROUTE SOLO quando la tratta è " +
+      "REALMENTE impossibile in treno e ne sei ragionevolmente certo: isole " +
+      "minori senza ferrovia (es. Lampedusa, Pantelleria, Capri), collegamenti " +
+      "Sardegna↔continente su rotaia, oppure località palesemente inesistenti o " +
+      "assurde. NEL DUBBIO considera la tratta plausibile e NON segnalarla. " +
+      "Per un annuncio hotel, verifica solo che la città/location sia un luogo reale. " +
+      "Quando la tratta è impossibile secondo questi criteri, aggiungi un flag " +
       "con code:'IMPLAUSIBLE_ROUTE' e un msg che spiega perché. " +
       "Valuta anche la DURATA del viaggio (depart_at→arrive_at) rispetto alla " +
       "tratta: se è palesemente incompatibile con la distanza reale (es. " +


### PR DESCRIPTION
Segnalato dall'utente: un annuncio "treno Ancona → Bari" riceveva **"Tratta non plausibile"** con reliability 35%. È un **falso positivo**: Ancona–Bari è una tratta reale (linea Adriatica, ~4 ore).

## Causa
Ho verificato che il layer **deterministico** (`heuristics.js`) NON segnala Ancona–Bari — controlla solo isole senza ferrovia e Sardegna↔continente. Il flag `IMPLAUSIBLE_ROUTE` arrivava quindi dall'**AI** (`aiTrust.js`), troppo aggressiva perché il prompt era centrato solo su "cosa è impossibile" e portava il modello a segnalare anche tratte lunghe ma valide.

## Fix
`aiTrust.js` — prompt reso conservativo sulla plausibilità delle tratte treno:
- la rete ferroviaria italiana collega di fatto tutta la penisola e le principali città siciliane; tratte lunghe ma reali (Ancona→Bari, Milano→Lecce, Torino→Reggio Calabria, …) sono **plausibili** e non vanno segnalate
- `IMPLAUSIBLE_ROUTE` solo per casi **realmente** impossibili (isole minori senza ferrovia, Sardegna↔continente, località assurde/inesistenti) e solo con ragionevole certezza
- **nel dubbio, plausibile**

Il backstop deterministico sui casi certi (isole/Sardegna) resta invariato, quindi Lampedusa→Pantelleria & co. continuano a essere segnalati con certezza anche senza AI.

## Verifiche
- Suite server: **69/69**
- Confermato che Ancona–Bari non è segnalata dalle euristiche (la sorgente del falso positivo era esclusivamente l'AI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_