### PR TITLE
Migration swap: confronta offer_status come testo (fix enum 22P02)

### DIFF
--- a/supabase/migrations/20260716120000_swap_accept_terminal_state.sql
+++ b/supabase/migrations/20260716120000_swap_accept_terminal_state.sql
@@ -100,6 +100,8 @@ update public.listings l
    and exists (
      select 1 from public.offers o
      where o.type = 'swap'
-       and o.status in ('accepted', 'finalized')
+       -- confronto come testo: 'finalized' non è (ancora) un valore dell'enum
+       -- offer_status, quindi evitiamo la coercizione che darebbe errore 22P02
+       and o.status::text in ('accepted', 'finalized')
        and (o.to_listing_id = l.id or o.from_listing_id = l.id)
    );


### PR DESCRIPTION
Applicando la migration `20260716120000_swap_accept_terminal_state.sql` su Supabase, l'`UPDATE` una-tantum falliva con:

```
ERROR: 22P02: invalid input value for enum offer_status: "finalized"
```

`'finalized'` è usato dal codice di `finalize_offer_any()` ma **non è mai stato aggiunto all'enum `offer_status`**. Nel confronto `o.status in ('accepted','finalized')` Postgres prova a convertire il letterale nell'enub → errore. Ed essendo la SQL Editor una singola transazione, l'errore annullava anche la `CREATE OR REPLACE` della funzione.

## Fix
Confronto `o.status::text in ('accepted','finalized')`: lo stato viene comparato come **testo**, quindi `'finalized'` resta un letterale e non viene validato contro l'enum. Nessun cambiamento di comportamento (oggi tutti gli swap accettati hanno stato `accepted`); resta forward-compatible se in futuro si aggiungerà `finalized` all'enum (necessario per il flusso pagamenti).

Solo SQL — nessun file app/server toccato, nessun rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_