### PR TITLE
Traduzione annuncio: niente toggle "Vedi originale" fasullo quando il testo è già nella lingua richiesta

### DIFF
--- a/server/src/routes/translateListings.js
+++ b/server/src/routes/translateListings.js
@@ -71,7 +71,17 @@ translateListingsRouter.get("/api/listings/:id/translate", requireAuth, rateLimi
     // testi identici, sembrando rotto.
     const titleOk = tTitle !== null;
     const descOk = tDesc !== null;
-    if (!titleOk && !descOk) {
+
+    // Traduzione "vera" solo se il testo tradotto DIFFERISCE dall'originale.
+    // Se il contenuto è già nella lingua richiesta (es. annuncio italiano con
+    // app in italiano), OpenAI restituisce lo stesso testo: non è una vera
+    // traduzione. Trattarla come tale mostrava "Tradotto automaticamente" + il
+    // toggle "Vedi originale" che, alternando due testi identici, sembrava rotto.
+    const norm = (s) => String(s ?? "").trim().replace(/\s+/g, " ").toLowerCase();
+    const titleReal = titleOk && norm(tTitle) !== norm(title);
+    const descReal = descOk && norm(tDesc) !== norm(description);
+
+    if (!titleReal && !descReal) {
       return res.json({
         title, description, lang, originalLang,
         translated: false, titleTranslated: false, descriptionTranslated: false, cached: !!cached,
@@ -95,17 +105,18 @@ translateListingsRouter.get("/api/listings/:id/translate", requireAuth, rateLimi
     }
 
     return res.json({
-      title: titleOk ? tTitle : title,
-      description: descOk ? tDesc : description,
+      title: titleReal ? tTitle : title,
+      description: descReal ? tDesc : description,
       lang,
       originalLang,
       translated: true,
       // Flag per-campo: il client deve poter distinguere "tutto tradotto"
       // da "solo un campo tradotto", invece di mostrare un generico
       // "Tradotto automaticamente" che lascerebbe intendere (falsamente)
-      // che anche il campo rimasto in originale sia stato elaborato.
-      titleTranslated: titleOk,
-      descriptionTranslated: descOk,
+      // che anche il campo rimasto in originale sia stato elaborato. Un campo
+      // il cui testo coincide con l'originale NON conta come tradotto.
+      titleTranslated: titleReal,
+      descriptionTranslated: descReal,
       cached: !needTitle && !needDesc,
     });
   } catch (e) {


### PR DESCRIPTION
Segnalato dall'utente: nel dettaglio annuncio, il toggle **"Vedi originale" / "Mostra tradotto"** non fa nulla (e "Tradotto automaticamente in it" compare anche su un annuncio italiano con app in italiano).

## Causa
Quando il contenuto è **già nella lingua dell'app** (annuncio IT, app IT), OpenAI, a cui viene chiesto di tradurre IT→IT, restituisce lo **stesso identico testo**. Il server lo marcava comunque `translated: true`, quindi il client mostrava la caption "Tradotto automaticamente" e il toggle "Vedi originale" — che, alternando **due testi identici**, sembrava rotto.

## Fix (`translateListings.js`, solo server)
Un campo conta come tradotto **solo se il testo differisce dall'originale** (confronto normalizzato: trim + spazi + case). Se né titolo né descrizione differiscono → `translated: false`: niente caption, niente toggle. Gestisce anche le voci già in cache (stessa identità).

Effetto: cambiando lingua verso una **diversa** da quella dell'annuncio, la traduzione vera compare e il toggle funziona; con la stessa lingua, il toggle semplicemente non appare (perché non c'è nulla da alternare).

## Verifiche
- `node --check` OK; suite server **72/72**.
- Modifica **solo lato server** (`/api/listings/:id/translate`): attiva col redeploy del backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_