### PR TITLE
Match Fase 2: budget massimo + prossimità data nel punteggio (deterministico)

### DIFF
--- a/server/src/ai/score.js
+++ b/server/src/ai/score.js
@@ -322,6 +322,66 @@ function dayOf(l) {
   return Number.isFinite(d.getTime()) ? d.toISOString().slice(0, 10) : null;
 }
 
+// -----------------------------------------------------------------------------
+// Modificatore deterministico budget + prossimità data (Fase 2)
+// -----------------------------------------------------------------------------
+// Applica un fattore 0..1 al punteggio base (AI o euristico) in base a due
+// segnali NUMERICI, calcolati con precisione invece di affidarli all'LLM:
+//   • budget: per un annuncio CERCO il campo `price` è il budget massimo. Se il
+//     VENDO abbinato costa ENTRO budget → nessuna penalità; più sfora, più cala.
+//   • data/ora: più le date principali (partenza / check-in) sono lontane, più
+//     il punteggio cala (stesso momento = nessuna penalità).
+// Pesi moderati: nel caso peggiore il punteggio si dimezza, così un match
+// strutturale forte (tratta/tipo/complementarità) resta comunque rilevante.
+const DATE_WINDOW_DAYS = Number(process.env.MATCH_DATE_WINDOW_DAYS ?? 7);   // a N giorni → fit 0
+const BUDGET_TOLERANCE = Number(process.env.MATCH_BUDGET_TOLERANCE ?? 0.5); // +50% oltre budget → fit 0
+const PRICE_WEIGHT = Number(process.env.MATCH_PRICE_WEIGHT ?? 0.25);
+const DATE_WEIGHT  = Number(process.env.MATCH_DATE_WEIGHT ?? 0.25);
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function dateMs(l) {
+  const v = l?.depart_at ?? l?.departAt ?? l?.check_in ?? l?.checkIn ?? null;
+  if (!v) return null;
+  const d = new Date(v);
+  return Number.isFinite(d.getTime()) ? d.getTime() : null;
+}
+
+// 0..1: 1 se il prezzo di vendita è entro il budget del CERCO, cala oltre.
+// Neutro (1) se manca un dato o non c'è una coppia compratore/venditore chiara.
+export function priceFit(f, l) {
+  const fCV = String(f?.cerco_vendo || "").toUpperCase();
+  const lCV = String(l?.cerco_vendo || "").toUpperCase();
+  let budget = null, sale = null;
+  if (fCV === "CERCO" && lCV === "VENDO") { budget = num(f?.price); sale = num(l?.price); }
+  else if (fCV === "VENDO" && lCV === "CERCO") { budget = num(l?.price); sale = num(f?.price); }
+  else return 1; // stesso cerco_vendo o campi mancanti: prezzo non confrontabile
+  if (budget == null || sale == null || budget <= 0) return 1;
+  if (sale <= budget) return 1;
+  const over = (sale - budget) / (budget * BUDGET_TOLERANCE);
+  return Math.max(0, 1 - over);
+}
+
+// 0..1: 1 se le date coincidono, cala fino a 0 a DATE_WINDOW_DAYS di distanza.
+export function dateFit(f, l) {
+  const a = dateMs(f), b = dateMs(l);
+  if (a == null || b == null) return 1; // se manca una data, nessuna penalità
+  const days = Math.abs(a - b) / 86400000;
+  return Math.max(0, 1 - days / DATE_WINDOW_DAYS);
+}
+
+// Fattore combinato 0..1 da applicare al punteggio base.
+export function budgetDateFactor(f, l) {
+  if (!f || !l) return 1;
+  const p = priceFit(f, l);
+  const d = dateFit(f, l);
+  const factor = 1 - PRICE_WEIGHT * (1 - p) - DATE_WEIGHT * (1 - d);
+  return Math.max(0, Math.min(1, factor));
+}
+
 export function heuristicScore(user, listings) {
   const f = user?.fromListing || null;
 

--- a/server/src/models/matches.js
+++ b/server/src/models/matches.js
@@ -1,6 +1,6 @@
 // server/src/models/matches.js
 import { isUUID } from '../util/uuid.js';
-import { scoreWithAI, heuristicScore } from '../ai/score.js';
+import { scoreWithAI, heuristicScore, budgetDateFactor } from '../ai/score.js';
 import {
   //fetchActiveListingsForMatching,
   //insertMatchesSnapshot,
@@ -124,8 +124,17 @@ const tasks = fromListings.map((f) => async () => {
     ? ai
     : heuristicScore(contextUser, useCands);
 
+  // Modificatore deterministico budget + prossimità data (Fase 2): applicato
+  // sopra al punteggio base (AI o euristico). Un VENDO dentro il budget del
+  // CERCO e vicino come data mantiene il punteggio; fuori budget o lontano
+  // come data lo abbassa. Preciso e testabile, indipendente dall'LLM.
+  const candById = new Map(useCands.map((c) => [c.id, c]));
   const scored = base
-    .map(s => ({ ...s, score: Math.round(Number(s.score || 0) * 1000) / 1000 }))
+    .map(s => {
+      const factor = budgetDateFactor(f, candById.get(s.id));
+      const adj = Number(s.score || 0) * factor;
+      return { ...s, score: Math.round(adj * 1000) / 1000 };
+    })
     .sort((a,b) => (b.score - a.score) || String(a.id).localeCompare(String(b.id)));
 
   console.log(`[from ${f.id}] scored:`, scored.length);

--- a/server/test/matchBudgetDate.test.js
+++ b/server/test/matchBudgetDate.test.js
@@ -1,0 +1,63 @@
+// Test del modificatore deterministico budget + prossimità data (Fase 2).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { priceFit, dateFit, budgetDateFactor } from '../src/ai/score.js';
+
+const cerco = (price, date) => ({ cerco_vendo: 'CERCO', price, depart_at: date });
+const vendo = (price, date) => ({ cerco_vendo: 'VENDO', price, depart_at: date });
+
+test('priceFit: VENDO entro il budget del CERCO → 1', () => {
+  assert.equal(priceFit(cerco(60), vendo(50)), 1);
+  assert.equal(priceFit(cerco(60), vendo(60)), 1); // uguale al budget
+});
+
+test('priceFit: VENDO oltre budget → cala; a +50% → 0', () => {
+  // budget 60, tolleranza 50% ⇒ 90 azzera. 75 = metà strada ⇒ 0.5
+  assert.equal(priceFit(cerco(60), vendo(90)), 0);
+  assert.equal(priceFit(cerco(60), vendo(75)), 0.5);
+});
+
+test('priceFit: funziona anche con sorgente VENDO e candidato CERCO', () => {
+  // il budget è quello del CERCO (candidato): 60; il VENDO (sorgente) costa 75
+  assert.equal(priceFit(vendo(75), cerco(60)), 0.5);
+});
+
+test('priceFit: neutro (1) se stesso cerco_vendo o prezzo mancante', () => {
+  assert.equal(priceFit(cerco(60), cerco(50)), 1);
+  assert.equal(priceFit(vendo(60), vendo(50)), 1);
+  assert.equal(priceFit(cerco(null), vendo(50)), 1);
+  assert.equal(priceFit(cerco(60), vendo(null)), 1);
+});
+
+test('dateFit: stessa data → 1, a 7 giorni → 0, a 3.5 → 0.5', () => {
+  const d0 = '2026-08-01T10:00:00Z';
+  assert.equal(dateFit(cerco(60, d0), vendo(50, d0)), 1);
+  assert.equal(dateFit(cerco(60, d0), vendo(50, '2026-08-08T10:00:00Z')), 0);
+  assert.equal(dateFit(cerco(60, d0), vendo(50, '2026-08-04T22:00:00Z')), 0.5);
+});
+
+test('dateFit: neutro (1) se manca una data', () => {
+  assert.equal(dateFit(cerco(60, null), vendo(50, '2026-08-01T10:00:00Z')), 1);
+});
+
+test('budgetDateFactor: in budget e stessa data → 1 (nessuna penalità)', () => {
+  const d0 = '2026-08-01T10:00:00Z';
+  assert.equal(budgetDateFactor(cerco(60, d0), vendo(50, d0)), 1);
+});
+
+test('budgetDateFactor: fuori budget e data lontana → 0.5 (dimezzato)', () => {
+  const f = cerco(60, '2026-08-01T10:00:00Z');
+  const l = vendo(90, '2026-08-08T10:00:00Z'); // priceFit 0, dateFit 0
+  // 1 - 0.25*1 - 0.25*1 = 0.5
+  assert.equal(budgetDateFactor(f, l), 0.5);
+});
+
+test('budgetDateFactor: solo fuori budget (data ok) → 0.75', () => {
+  const d0 = '2026-08-01T10:00:00Z';
+  assert.equal(budgetDateFactor(cerco(60, d0), vendo(90, d0)), 0.75);
+});
+
+test('budgetDateFactor: input mancante → 1', () => {
+  assert.equal(budgetDateFactor(null, vendo(50)), 1);
+  assert.equal(budgetDateFactor(cerco(60), null), 1);
+});


### PR DESCRIPTION
Fase 2 di 2 della feature richiesta. Il budget del "Cerco" (raccolto in Fase 1, PR #83) e la prossimità di data/ora ora **entrano nel punteggio di match**.

## Come funziona
Un **modificatore deterministico** (fattore 0..1) applicato **sopra** al punteggio base (AI o euristico), così la parte numerica è precisa e non affidata all'LLM:

- **Budget**: per un annuncio **CERCO** il campo `price` è il budget massimo. Un **VENDO entro budget** non viene penalizzato; oltre budget il match cala (a **+50%** oltre → contributo azzerato). Vale in entrambe le direzioni (sorgente CERCO↔candidato VENDO e viceversa).
- **Data/ora**: più le date principali (partenza / check-in) sono lontane, più il match cala (stesso momento → nessuna penalità; a **7 giorni** → azzerato).
- **Pesi moderati** (0.25 + 0.25): nel caso peggiore il punteggio si **dimezza**, così un match strutturale forte (tratta/tipo/complementarità) resta comunque rilevante e non sparisce.
- Tutto **parametrizzabile via env**: `MATCH_DATE_WINDOW_DAYS`, `MATCH_BUDGET_TOLERANCE`, `MATCH_PRICE_WEIGHT`, `MATCH_DATE_WEIGHT`.

## File
- `score.js`: nuove `priceFit` / `dateFit` / `budgetDateFactor` (esportate, pure e testabili).
- `matches.js`: applica il fattore in fase di scoring, su ogni candidato.

## Verifiche
- `node --check` OK; **10 nuovi test** (in/out budget, direzioni, prossimità data, combinazione, input mancanti). Suite server **82/82**.
- Modifica **solo lato server**: attiva col redeploy. I nuovi punteggi valgono **dal prossimo ricalcolo** dei match (pubblicazione/modifica annuncio, o "Suggeriti" dal profilo).

## Esempio
CERCO budget 60€, 1 ago. Un VENDO a 50€ lo stesso giorno → fattore **1.0** (match pieno). Lo stesso VENDO a 90€ e a 7 giorni → fattore **0.5** (match dimezzato).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_