### PR TITLE
Hotfix match: punteggio arrotondato a intero (colonna score è INTEGER)

### DIFF
--- a/server/src/ai/score.js
+++ b/server/src/ai/score.js
@@ -382,6 +382,13 @@ export function budgetDateFactor(f, l) {
   return Math.max(0, Math.min(1, factor));
 }
 
+// Punteggio finale = base × fattore, arrotondato a INTERO. La colonna
+// matches.score è di tipo integer: senza arrotondamento l'insert fallirebbe
+// (Postgres rifiuta un valore frazionario come "48.172" con un 400).
+export function adjustedScore(baseScore, f, l) {
+  return Math.round(Number(baseScore || 0) * budgetDateFactor(f, l));
+}
+
 export function heuristicScore(user, listings) {
   const f = user?.fromListing || null;
 

--- a/server/src/models/matches.js
+++ b/server/src/models/matches.js
@@ -1,6 +1,6 @@
 // server/src/models/matches.js
 import { isUUID } from '../util/uuid.js';
-import { scoreWithAI, heuristicScore, budgetDateFactor } from '../ai/score.js';
+import { scoreWithAI, heuristicScore, adjustedScore } from '../ai/score.js';
 import {
   //fetchActiveListingsForMatching,
   //insertMatchesSnapshot,
@@ -130,11 +130,7 @@ const tasks = fromListings.map((f) => async () => {
   // come data lo abbassa. Preciso e testabile, indipendente dall'LLM.
   const candById = new Map(useCands.map((c) => [c.id, c]));
   const scored = base
-    .map(s => {
-      const factor = budgetDateFactor(f, candById.get(s.id));
-      const adj = Number(s.score || 0) * factor;
-      return { ...s, score: Math.round(adj * 1000) / 1000 };
-    })
+    .map(s => ({ ...s, score: adjustedScore(s.score, f, candById.get(s.id)) }))
     .sort((a,b) => (b.score - a.score) || String(a.id).localeCompare(String(b.id)));
 
   console.log(`[from ${f.id}] scored:`, scored.length);

--- a/server/test/matchBudgetDate.test.js
+++ b/server/test/matchBudgetDate.test.js
@@ -1,7 +1,7 @@
 // Test del modificatore deterministico budget + prossimità data (Fase 2).
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { priceFit, dateFit, budgetDateFactor } from '../src/ai/score.js';
+import { priceFit, dateFit, budgetDateFactor, adjustedScore } from '../src/ai/score.js';
 
 const cerco = (price, date) => ({ cerco_vendo: 'CERCO', price, depart_at: date });
 const vendo = (price, date) => ({ cerco_vendo: 'VENDO', price, depart_at: date });
@@ -60,4 +60,20 @@ test('budgetDateFactor: solo fuori budget (data ok) → 0.75', () => {
 test('budgetDateFactor: input mancante → 1', () => {
   assert.equal(budgetDateFactor(null, vendo(50)), 1);
   assert.equal(budgetDateFactor(cerco(60), null), 1);
+});
+
+test('adjustedScore: sempre INTERO (la colonna matches.score è integer)', () => {
+  const d0 = '2026-08-01T10:00:00Z';
+  // 90 * 0.75 = 67.5 → 68 (intero, mai frazionario come "48.172")
+  const s1 = adjustedScore(90, cerco(60, d0), vendo(90, d0)); // solo fuori budget
+  assert.equal(Number.isInteger(s1), true);
+  assert.equal(s1, 68);
+  // caso che generava il bug: base frazionaria per il fattore
+  const s2 = adjustedScore(64, cerco(60, d0), vendo(75, '2026-08-04T22:00:00Z'));
+  assert.equal(Number.isInteger(s2), true);
+});
+
+test('adjustedScore: in budget e stessa data → punteggio base invariato', () => {
+  const d0 = '2026-08-01T10:00:00Z';
+  assert.equal(adjustedScore(90, cerco(60, d0), vendo(50, d0)), 90);
 });


### PR DESCRIPTION
Segnalato dall'utente (screenshot): ricalcolando i **Suggeriti** → `HTTP 500: Supabase insert failed [400]: invalid input syntax for type integer: "48.172"`.

## Causa
Regressione introdotta dalla **Fase 2** (PR #84): il modificatore budget/data moltiplica il punteggio base per un fattore 0..1, producendo valori **frazionari** (es. `90 × 0.75 = 67.5`, oppure `48.172`). Ma la colonna `matches.score` è di tipo **INTEGER** → l'insert fallisce e il ricalcolo va in 500. Prima non emergeva perché i punteggi erano sempre interi (AI/euristica).

## Fix
- `score.js`: nuovo **`adjustedScore(base, f, l)` = `round(base × budgetDateFactor)`** → sempre intero.
- `matches.js`: usa `adjustedScore` invece del calcolo inline frazionario.
- **2 nuovi test** che blindano l'invariante "sempre intero" (incl. il caso che generava il bug). Suite server **84/84**.

## Verifiche
- `node --check` OK; suite **84/84** verde.
- Solo lato server: attivo col redeploy. Dopo il deploy, "Suggeriti" torna a ricalcolare senza errori.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_