### PR TITLE
Match: tolleranza sulle date (niente crollo a 0% per pochi giorni)

### DIFF
--- a/server/src/ai/score.js
+++ b/server/src/ai/score.js
@@ -83,10 +83,11 @@ Regole vincolanti:
 - Un elemento in "scores" per OGNI listing (nessuna omissione).
 - "score" intero 0..100.
 - La complementarità è il criterio principale: se l'annuncio sorgente è CERCO, i candidati VENDO equivalenti valgono molto (e viceversa). Due annunci con lo stesso cerco_vendo NON sono complementari.
-- "bidirectional" = true SOLO se (cerco_vendo del sorgente e del candidato sono complementari) E (stesso type) E (stessa tratta route_from→route_to, o stessa località per hotel) E (le date coincidono o sono nello stesso giorno). Altrimenti false.
+- IMPORTANTE: la vicinanza di DATA/ORARIO e la differenza di PREZZO/budget vengono valutate SEPARATAMENTE, in modo deterministico, DOPO di te. NON abbassare lo score per date diverse o prezzi diversi: uno scarto di pochi giorni o un prezzo un po' più alto NON devono azzerare il match. Valuta SOLO: complementarità (CERCO↔VENDO), stesso tipo, stessa tratta/località.
+- "bidirectional" = true SOLO se (cerco_vendo del sorgente e del candidato sono complementari) E (stesso type) E (stessa tratta route_from→route_to, o stessa località per hotel). Le date NON entrano in questa condizione. Altrimenti false.
 - Se cerco_vendo del sorgente o del candidato è null ⇒ bidirectional=false.
 - Tipo diverso dal sorgente (train vs hotel) ⇒ score basso (max 30).
-- Stessa tratta/direzione e stesso giorno aumentano molto lo score; tratta diversa o direzione inversa lo riducono.
+- Stessa tratta/direzione alza molto lo score; tratta diversa o direzione inversa lo riduce.
 - Linee guida score: <=30 irrilevante, 50=debole, 70=buona, 85+=eccellente, 90+=reciproco quasi perfetto.
 - "explanation" in italiano, breve e concreta (es. "VENDO complementare al tuo CERCO, stessa tratta Roma→Vienna").
 
@@ -333,7 +334,12 @@ function dayOf(l) {
 //     il punteggio cala (stesso momento = nessuna penalità).
 // Pesi moderati: nel caso peggiore il punteggio si dimezza, così un match
 // strutturale forte (tratta/tipo/complementarità) resta comunque rilevante.
-const DATE_WINDOW_DAYS = Number(process.env.MATCH_DATE_WINDOW_DAYS ?? 7);   // a N giorni → fit 0
+// Data: c'è una TOLLERANZA piena entro DATE_GRACE_DAYS (un match a 1 giorno di
+// distanza non viene penalizzato), poi un calo GRADUALE fino a DATE_WINDOW_DAYS.
+// Anche a distanza massima il match non si azzera: il peso DATE_WEIGHT limita la
+// riduzione (al più −25%). Lo zero secco che si vedeva veniva dall'AI, non da qui.
+const DATE_GRACE_DAYS  = Number(process.env.MATCH_DATE_GRACE_DAYS ?? 1);    // entro N giorni → nessuna penalità
+const DATE_WINDOW_DAYS = Number(process.env.MATCH_DATE_WINDOW_DAYS ?? 14);  // oltre la grazia, calo lineare su N giorni
 const BUDGET_TOLERANCE = Number(process.env.MATCH_BUDGET_TOLERANCE ?? 0.5); // +50% oltre budget → fit 0
 const PRICE_WEIGHT = Number(process.env.MATCH_PRICE_WEIGHT ?? 0.25);
 const DATE_WEIGHT  = Number(process.env.MATCH_DATE_WEIGHT ?? 0.25);
@@ -365,12 +371,15 @@ export function priceFit(f, l) {
   return Math.max(0, 1 - over);
 }
 
-// 0..1: 1 se le date coincidono, cala fino a 0 a DATE_WINDOW_DAYS di distanza.
+// 0..1: 1 entro DATE_GRACE_DAYS (tolleranza piena), poi calo lineare fino a 0 a
+// DATE_GRACE_DAYS + DATE_WINDOW_DAYS. Neutro (1) se manca una data.
 export function dateFit(f, l) {
   const a = dateMs(f), b = dateMs(l);
   if (a == null || b == null) return 1; // se manca una data, nessuna penalità
   const days = Math.abs(a - b) / 86400000;
-  return Math.max(0, 1 - days / DATE_WINDOW_DAYS);
+  if (days <= DATE_GRACE_DAYS) return 1; // qualche giorno di tolleranza
+  const decay = (days - DATE_GRACE_DAYS) / DATE_WINDOW_DAYS;
+  return Math.max(0, 1 - decay);
 }
 
 // Fattore combinato 0..1 da applicare al punteggio base.
@@ -397,7 +406,6 @@ export function heuristicScore(user, listings) {
     const compCV = fCV === "CERCO" ? "VENDO" : fCV === "VENDO" ? "CERCO" : null;
     const fType = String(f.type || "").toLowerCase();
     const [fA, fB] = routeOf(f);
-    const fDay = dayOf(f);
     const fLoc = normPlace(f.location);
 
     return (listings || [])
@@ -411,14 +419,16 @@ export function heuristicScore(user, listings) {
         const sameRoute = fA && fB && lA && lB && fA === lA && fB === lB;
         const reverseRoute = fA && fB && lA && lB && fA === lB && fB === lA;
         const sameHotelLoc = fType === "hotel" && fLoc && normPlace(l?.location) === fLoc;
-        const sameDay = !!fDay && dayOf(l) === fDay;
 
+        // Il punteggio base è STRUTTURALE (tipo, complementarità, tratta). La
+        // vicinanza di data e il budget sono applicati dopo, in modo
+        // deterministico, da budgetDateFactor — così la data non è contata due
+        // volte e uno scarto di pochi giorni non azzera il match.
         let s = 35; // base: senza alcuna affinità il candidato è poco rilevante
         if (sameType) s += 15;
         if (complementary) s += 20;
         if (sameRoute || sameHotelLoc) s += 20;
         else if (reverseRoute) s += 8;
-        if (sameDay) s += 10;
         if (!sameType) s = Math.min(s, 30); // tipo diverso: mai oltre "irrilevante"
 
         const bidirectional = complementary && sameType && (sameRoute || sameHotelLoc);

--- a/server/test/matchBudgetDate.test.js
+++ b/server/test/matchBudgetDate.test.js
@@ -29,11 +29,17 @@ test('priceFit: neutro (1) se stesso cerco_vendo o prezzo mancante', () => {
   assert.equal(priceFit(cerco(60), vendo(null)), 1);
 });
 
-test('dateFit: stessa data → 1, a 7 giorni → 0, a 3.5 → 0.5', () => {
+test('dateFit: tolleranza entro 1 giorno, poi calo lineare (finestra 14)', () => {
   const d0 = '2026-08-01T10:00:00Z';
-  assert.equal(dateFit(cerco(60, d0), vendo(50, d0)), 1);
-  assert.equal(dateFit(cerco(60, d0), vendo(50, '2026-08-08T10:00:00Z')), 0);
-  assert.equal(dateFit(cerco(60, d0), vendo(50, '2026-08-04T22:00:00Z')), 0.5);
+  assert.equal(dateFit(cerco(60, d0), vendo(50, d0)), 1);                          // stessa data
+  assert.equal(dateFit(cerco(60, d0), vendo(50, '2026-08-02T10:00:00Z')), 1);      // 1 giorno → tolleranza piena
+  assert.equal(dateFit(cerco(60, d0), vendo(50, '2026-08-09T10:00:00Z')), 0.5);    // 8 giorni → 1-(8-1)/14
+  assert.equal(dateFit(cerco(60, d0), vendo(50, '2026-08-16T10:00:00Z')), 0);      // 15 giorni → 0
+});
+
+test('dateFit: uno scarto di 1 giorno NON penalizza (il caso 79%→0%)', () => {
+  const d0 = '2026-08-01T10:00:00Z';
+  assert.equal(dateFit(cerco(60, d0), vendo(60, '2026-08-02T10:00:00Z')), 1);
 });
 
 test('dateFit: neutro (1) se manca una data', () => {
@@ -45,11 +51,17 @@ test('budgetDateFactor: in budget e stessa data → 1 (nessuna penalità)', () =
   assert.equal(budgetDateFactor(cerco(60, d0), vendo(50, d0)), 1);
 });
 
-test('budgetDateFactor: fuori budget e data lontana → 0.5 (dimezzato)', () => {
+test('budgetDateFactor: fuori budget e data molto lontana → 0.5 (dimezzato)', () => {
   const f = cerco(60, '2026-08-01T10:00:00Z');
-  const l = vendo(90, '2026-08-08T10:00:00Z'); // priceFit 0, dateFit 0
-  // 1 - 0.25*1 - 0.25*1 = 0.5
+  const l = vendo(90, '2026-08-16T10:00:00Z'); // priceFit 0, dateFit 0 (15 giorni)
+  // 1 - 0.25*1 - 0.25*1 = 0.5 → il match non scende mai sotto la metà
   assert.equal(budgetDateFactor(f, l), 0.5);
+});
+
+test('budgetDateFactor: match strutturale a 1 giorno di distanza resta pieno', () => {
+  const f = cerco(60, '2026-08-01T10:00:00Z');
+  const l = vendo(60, '2026-08-02T10:00:00Z'); // in budget, 1 giorno → nessuna penalità
+  assert.equal(budgetDateFactor(f, l), 1);
 });
 
 test('budgetDateFactor: solo fuori budget (data ok) → 0.75', () => {


### PR DESCRIPTION
Segnalato dall'utente: due annunci compro/vendo **stessa data → 79%**; spostando **di un giorno** una delle due date → **0%**. Troppo brusco.

## Diagnosi
Il punteggio base è dell'**AI** (OpenAI configurato: infatti 79% e non 90% dell'euristica). Il crollo a 0% **veniva dall'AI**, che sovra-penalizzava la differenza di data. Il modificatore deterministico della Fase 2 è invece gentile e da solo **non può azzerare** (al più −25%).

## Fix
- **Prompt AI**: data/ora e prezzo **non entrano più** nel punteggio dell'AI — li valuta il layer deterministico *dopo*. L'AI ora giudica **solo** complementarità (CERCO↔VENDO), tipo e tratta/località. `bidirectional` diventa **strutturale** (via il "stesso giorno" come requisito). Così un match a pochi giorni di distanza non viene più azzerato dal modello.
- **`dateFit` deterministico con tolleranza**: piena entro **`DATE_GRACE_DAYS`** (default **1** giorno), poi calo **lineare** su **`DATE_WINDOW_DAYS`** (default **14**). Anche a distanza massima il match **non si azzera**: il peso data toglie al più il 25%.
- **Euristica** (fallback): rimosso il bonus "+10 stesso giorno" per non contare la data due volte (ora la gestisce solo il modificatore).
- Tutto **regolabile via env** (`MATCH_DATE_GRACE_DAYS`, `MATCH_DATE_WINDOW_DAYS`, pesi, tolleranza budget).

## Comportamento risultante (scenario dell'utente)
| Scarto date | Prima | Ora |
|---|---|---|
| stessa data | 79% | 79% |
| **1 giorno** | **0%** | **79%** (tolleranza piena) |
| ~8 giorni | 0% | ~68% (calo dolce) |
| ≥15 giorni | 0% | non sotto ~metà del base |

## Verifiche
- `node --check` OK; test aggiornati + nuovi casi ("1 giorno = nessuna penalità"). Suite server **86/86**.
- Solo lato server: attivo col redeploy; effetto **dal prossimo ricalcolo** dei match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgxrtKyVwS8cTPE8QZ1eof)_