### PR TITLE
Blocca modifica annunci conclusi, rinomina chip, redesign card Esplora

### DIFF
--- a/supabase/migrations/20260721140000_listings_lock_terminal_status.sql
+++ b/supabase/migrations/20260721140000_listings_lock_terminal_status.sql
@@ -1,0 +1,30 @@
+-- Un annuncio venduto/scambiato (transazione conclusa) non deve più essere
+-- modificabile: prima il controllo esisteva solo lato client (bottone
+-- "Modifica" nascosto in ListingDetailScreen/ProfileScreen), quindi
+-- bypassabile chiamando direttamente supabase.from('listings').update() —
+-- le RLS listings_owner_update/listings_update_user verificano solo
+-- "auth.uid() = user_id", nessuna condizione sullo status.
+--
+-- Si applica SOLO quando lo stato di PARTENZA è già concluso: una riga che
+-- sta transitando DA active/pending/reserved VERSO sold/swapped (l'esito
+-- normale di un'offerta accettata, vedi accept_offer/after_update_offers_propagate)
+-- non è toccata da questo controllo, perché lì OLD.status non è ancora
+-- concluso. Un update "no-op" (nessuna colonna realmente cambiata) resta
+-- permesso, per non rompere eventuali riscritture idempotenti.
+CREATE OR REPLACE FUNCTION public.before_update_listings_lock_terminal()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+begin
+  if lower(old.status::text) in ('sold', 'swapped', 'exchanged', 'traded')
+     and to_jsonb(new) is distinct from to_jsonb(old) then
+    raise exception 'listing % is already %: concluded listings cannot be modified', old.id, old.status;
+  end if;
+  return new;
+end;
+$$;
+
+DROP TRIGGER IF EXISTS trg_listings_lock_terminal ON public.listings;
+CREATE TRIGGER trg_listings_lock_terminal
+  BEFORE UPDATE ON public.listings
+  FOR EACH ROW EXECUTE FUNCTION public.before_update_listings_lock_terminal();

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -307,7 +307,7 @@ export const translations = {
         swapped: "Scambiati",
         sold: "Venduti",
         reserved: "Riservati",
-        pending: "Proposte in corso",
+        pending: "In trattativa",
         paused: "In pausa",
         expired: "Scaduti",
       },
@@ -606,6 +606,8 @@ export const translations = {
       saveError: "Impossibile salvare le modifiche.",
       savedTitle: "Modifiche salvate",
       savedMsg: "L'annuncio è stato aggiornato.",
+      concludedTitle: "Annuncio non modificabile",
+      concludedMsg: "Questo annuncio è già venduto o scambiato: la transazione è conclusa e non può più essere modificata.",
     },
 
     // --- Offerte ---
@@ -1252,7 +1254,7 @@ export const translations = {
         swapped: "Swapped",
         sold: "Sold",
         reserved: "Reserved",
-        pending: "Offers in progress",
+        pending: "Under negotiation",
         paused: "Paused",
         expired: "Expired",
       },
@@ -1539,6 +1541,8 @@ export const translations = {
       saveError: "Unable to save changes.",
       savedTitle: "Changes saved",
       savedMsg: "The listing has been updated.",
+      concludedTitle: "Listing not editable",
+      concludedMsg: "This listing has already been sold or swapped: the deal is closed and it can no longer be edited.",
     },
 
     offers: {
@@ -2177,7 +2181,7 @@ export const translations = {
         swapped: "Intercambiados",
         sold: "Vendidos",
         reserved: "Reservados",
-        pending: "Propuestas en curso",
+        pending: "En negociación",
         paused: "En pausa",
         expired: "Caducados",
       },
@@ -2473,6 +2477,8 @@ export const translations = {
       saveError: "No se pudieron guardar los cambios.",
       savedTitle: "Cambios guardados",
       savedMsg: "El anuncio se ha actualizado.",
+      concludedTitle: "Anuncio no editable",
+      concludedMsg: "Este anuncio ya se ha vendido o intercambiado: la transacción está cerrada y ya no se puede modificar.",
     },
 
     offers: {

--- a/travelswap_ai/travelswapai/lib/listingStatus.js
+++ b/travelswap_ai/travelswapai/lib/listingStatus.js
@@ -1,0 +1,35 @@
+// lib/listingStatus.js — stato annuncio: normalizzazione, colori badge e
+// stati "conclusi" (transazione chiusa, non più modificabile). Condiviso tra
+// ProfileScreen (i miei annunci) e ListingDetailScreen (dettaglio pubblico)
+// per non avere due mappature che possono divergere.
+
+export const STATUS_COLORS = {
+  active: { bg: "#DCFCE7", border: "#86EFAC", fg: "#166534" },
+  swapped: { bg: "#E0E7FF", border: "#A5B4FC", fg: "#3730A3" },
+  sold: { bg: "#DBEAFE", border: "#93C5FD", fg: "#1E40AF" },
+  reserved: { bg: "#FEF3C7", border: "#FCD34D", fg: "#92400E" },
+  pending: { bg: "#FEF3C7", border: "#FCD34D", fg: "#92400E" },
+  paused: { bg: "#F3F4F6", border: "#D1D5DB", fg: "#4B5563" },
+  expired: { bg: "#FEE2E2", border: "#FCA5A5", fg: "#991B1B" },
+};
+
+/** Normalizza lo stato grezzo del DB (con i suoi alias) in una chiave
+ * canonica, usata sia per il colore del badge sia per la chiave i18n
+ * listing.state.*. */
+export function normStatusKey(status) {
+  const s = String(status || "").toLowerCase();
+  if (["swapped", "traded", "exchanged"].includes(s)) return "swapped";
+  if (["pending", "review"].includes(s)) return "pending";
+  if (s === "sold") return "sold";
+  if (s === "reserved") return "reserved";
+  if (s === "expired") return "expired";
+  if (s === "paused") return "paused";
+  return "active"; // default e stringa vuota
+}
+
+/** Transazione conclusa (venduto/scambiato): l'annuncio non è più
+ * modificabile né riattivabile, a differenza di paused/expired. */
+export function isConcludedStatus(status) {
+  const k = normStatusKey(status);
+  return k === "sold" || k === "swapped";
+}

--- a/travelswap_ai/travelswapai/screens/CreateListingScreen.js
+++ b/travelswap_ai/travelswapai/screens/CreateListingScreen.js
@@ -28,6 +28,7 @@ import { parseListingFromTextAI } from "../lib/descriptionParser"; // OpenAI par
 import { Image } from "react-native";
 import { listImages, uploadImage, deleteImage } from "../lib/listingImages";
 import { parseLocalizedNumber } from "../lib/number";
+import { isConcludedStatus } from "../lib/listingStatus";
 
 /* ---------- CONST ---------- */
 const FOOTER_H = 96; // usato per dare spazio sotto alle slide
@@ -1447,6 +1448,19 @@ const initialJsonRef = useRef(null);
 
   /* ---------- PUBBLICA / SALVA MODIFICHE ---------- */
   const onPublishOrSave = async () => {
+    // Venduto/scambiato: transazione conclusa, non più modificabile (stesso
+    // vincolo lato DB, vedi trigger before_update_listings_lock_terminal). Un
+    // ingresso qui è già anomalo (il bottone "Modifica" è nascosto per questi
+    // stati sia nel dettaglio annuncio sia nell'action sheet di Profilo), ma
+    // la route resta raggiungibile: blocco comunque il submit.
+    if (mode === "edit" && isConcludedStatus(originalStatusRef.current)) {
+      Alert.alert(
+        t("editListing.concludedTitle", "Annuncio non modificabile"),
+        t("editListing.concludedMsg", "Questo annuncio è già venduto o scambiato: la transazione è conclusa e non può più essere modificata.")
+      );
+      return;
+    }
+
     // Il Check AI deve sempre riflettere il contenuto che si sta per
     // pubblicare (sempre in creazione, o se non ancora fatto; in entrambe le
     // modalità anche se le foto sono cambiate dall'ultima verifica —

--- a/travelswap_ai/travelswapai/screens/HomeScreen.js
+++ b/travelswap_ai/travelswapai/screens/HomeScreen.js
@@ -52,6 +52,16 @@ function isTopPick(p) {
   return (p.bidirectional === true && p.score >= 80) || (p.bidirectional === false && p.score >= 90);
 }
 
+// Data breve per la card ("24 lug"), senza dover aprire il dettaglio.
+function formatShortDate(iso, locale) {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleDateString(locale || undefined, { day: "2-digit", month: "short" });
+  } catch {
+    return "";
+  }
+}
+
 // Estrae i migliori suggerimenti AI dallo snapshot backend, in modo
 // tollerante alla forma della risposta (come fa MatchingScreen). Best
 // effort: se manca o è malformato, la striscia "Per te" resta nascosta.
@@ -346,15 +356,23 @@ export default function HomeScreen() {
           new Date(item.created_at).toLocaleDateString(locale || undefined)
         : null;
 
+    // Date del viaggio/soggiorno, visibili in card senza dover aprire il
+    // dettaglio: prima comparivano solo tratta+tipo, mai le date effettive.
+    const dateLine = typeLc === "hotel"
+      ? [formatShortDate(item.check_in, locale), formatShortDate(item.check_out, locale)].filter(Boolean).join(" → ")
+      : formatShortDate(item.depart_at, locale);
+
     return (
       <TouchableOpacity
         onPress={() => navigation.navigate("ListingDetail", { id: item.id })}
         activeOpacity={0.8}
         style={styles.card}
       >
-        {/* Titolo con icona tipo (in alto a sx) */}
+        {/* Titolo con icona tipo (in alto a sx); "tuo annuncio" ridotto a
+            pill accanto al salva (prima riga intera sotto il titolo) e
+            tratta+prezzo sulla stessa riga per guadagnare spazio verticale. */}
         <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
-          <View style={{ flexDirection: "row", alignItems: "center", flexShrink: 1 }}>
+          <View style={{ flexDirection: "row", alignItems: "center", flexShrink: 1, marginRight: 8 }}>
             {typeLc === "train" ? (
               <Ionicons name="train-outline" size={18} color={theme.colors.boardingText} style={{ marginRight: 6 }} />
             ) : typeLc === "hotel" ? (
@@ -364,22 +382,28 @@ export default function HomeScreen() {
               {stripPriceFromTitle(item.title) || tt("listing.untitled", "Senza titolo")}
             </Text>
           </View>
-          <SaveButton listingId={item.id} size={22} />
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+            {isMine ? (
+              <View style={styles.mineBadge}>
+                <Text style={styles.mineBadgeText} numberOfLines={1}>{tt("listing.yourListingBadge", "È un tuo annuncio")}</Text>
+              </View>
+            ) : null}
+            <SaveButton listingId={item.id} size={22} />
+          </View>
         </View>
 
-        {isMine ? (
-          <Text style={styles.mineTag}>{tt("listing.yourListingBadge", "È un tuo annuncio")}</Text>
-        ) : null}
-
-        <Text style={styles.cardSub}>
-          {typeLabel} • {item.location || item.route_from || "-"}
-        </Text>
-
-        {item.price != null && (
-          <Text style={styles.cardMeta}>
-            {formatMoney(item.price, item.currency)}
+        <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
+          <Text style={[styles.cardSub, { flex: 1, flexShrink: 1, marginRight: 8 }]} numberOfLines={1}>
+            {typeLabel} • {item.location || item.route_from || "-"}
           </Text>
-        )}
+          {item.price != null ? (
+            <Text style={styles.cardMeta} numberOfLines={1}>
+              {formatMoney(item.price, item.currency)}
+            </Text>
+          ) : null}
+        </View>
+
+        {dateLine ? <Text style={styles.cardDates}>{dateLine}</Text> : null}
 
         {published ? (
           <Text style={styles.cardPublished}>{published}</Text>
@@ -621,20 +645,23 @@ const styles = StyleSheet.create({
     padding: 14, backgroundColor: theme.colors.surface, ...theme.shadow.sm,
   },
   cardTitle: { fontWeight: "800", color: theme.colors.boardingText },
-  mineTag: {
-    alignSelf: "flex-start",
-    marginTop: 6,
-    paddingHorizontal: 8,
+  // Pill piccola accanto al salva (prima riga intera sotto il titolo):
+  // guadagna una riga di spazio verticale nella card.
+  mineBadge: {
+    paddingHorizontal: 7,
     paddingVertical: 2,
     borderRadius: 999,
     backgroundColor: theme.colors.accentSoft,
+    maxWidth: 90,
+  },
+  mineBadgeText: {
     color: theme.colors.accent,
-    fontSize: 11,
+    fontSize: 10,
     fontWeight: "700",
-    overflow: "hidden",
   },
   cardSub: { color: theme.colors.textMuted, marginTop: 4 },
-  cardMeta: { color: theme.colors.text, marginTop: 6, fontWeight: "600" },
+  cardMeta: { color: theme.colors.text, fontWeight: "600" },
+  cardDates: { color: theme.colors.textMuted, marginTop: 4, fontSize: 12, fontWeight: "600" },
   cardPublished: { color: theme.colors.textMuted, marginTop: 8, fontSize: 12 },
   errorBox: { flex: 1, alignItems: "center", justifyContent: "center", padding: 16, backgroundColor: theme.colors.background },
   error: { color: theme.colors.danger, marginBottom: 8, textAlign: "center" },

--- a/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
+++ b/travelswap_ai/travelswapai/screens/ListingDetailScreen.js
@@ -22,6 +22,7 @@ import { useI18n } from "../lib/i18n";
 import { useListingTranslation } from "../lib/useListingTranslation";
 import { usePriceCheck } from "../lib/usePriceCheck";
 import { stripPriceFromTitle } from "../lib/listingTitle";
+import { normStatusKey, isConcludedStatus } from "../lib/listingStatus";
 
 /* ========= Utils ========= */
 
@@ -251,7 +252,12 @@ useEffect(() => {
   const arriveAt  = listing?.arrive_at  ?? listing?.arriveAt  ?? null;
   const createdAt = listing?.created_at ?? listing?.createdAt ?? null;
   const publishedAgo = timeAgoLocalized(createdAt, locale);
-  const isNewBadge   = (() => {
+  // Un annuncio concluso (venduto/scambiato) non è più "nuovo" in senso utile:
+  // prima il ribbon leggeva solo created_at<24h, quindi un annuncio venduto
+  // pubblicato di recente mostrava comunque "Nuovo", e uno più vecchio non
+  // mostrava alcuno stato — l'utente non capiva che la transazione era chiusa.
+  const concludedStatusKey = isConcludedStatus(listing?.status) ? normStatusKey(listing?.status) : null;
+  const isNewBadge = !concludedStatusKey && (() => {
     if (!createdAt) return false;
     const d = new Date(String(createdAt));
     if (isNaN(d.getTime())) return false;
@@ -371,7 +377,9 @@ useEffect(() => {
             <ImageCarousel images={images} height={220} />
           </View>
         ) : null}
-        {isOwner ? (
+        {/* Venduto/scambiato: transazione conclusa, non più modificabile
+            (stesso vincolo lato DB, vedi trigger before_update_listings_lock_terminal). */}
+        {isOwner && !concludedStatusKey ? (
           <TouchableOpacity
             onPress={() => navigation.navigate("CreateListing", { mode: "edit", listingId })}
             style={{ alignSelf: "flex-start", marginBottom: 12, paddingVertical: 8, paddingHorizontal: 12, borderRadius: 10, borderWidth: 1, borderColor: theme.colors.border, backgroundColor: theme.colors.surface }}
@@ -382,7 +390,11 @@ useEffect(() => {
           </TouchableOpacity>
         ) : null}
         <View style={styles.headerCard}>
-          {isNewBadge ? (
+          {concludedStatusKey ? (
+            <View style={styles.ribbonWrap} pointerEvents="none">
+              <View style={styles.ribbon}><Text style={styles.ribbonText}>{tt(`listing.state.${concludedStatusKey}`, concludedStatusKey)}</Text></View>
+            </View>
+          ) : isNewBadge ? (
             <View style={styles.ribbonWrap} pointerEvents="none">
               <View style={styles.ribbon}><Text style={styles.ribbonText}>{tt("matching.new","Nuovo")}</Text></View>
             </View>

--- a/travelswap_ai/travelswapai/screens/ProfileScreen.js
+++ b/travelswap_ai/travelswapai/screens/ProfileScreen.js
@@ -29,34 +29,9 @@ import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
 import { stripPriceFromTitle } from "../lib/listingTitle";
 import { formatMoney } from "../lib/number";
+import { STATUS_COLORS, normStatusKey, isConcludedStatus } from "../lib/listingStatus";
 
 const APP_VERSION = Constants.expoConfig?.version || "1.0.0";
-
-// Colori per stato annuncio: prima tutti i badge erano grigi identici, così
-// lo stato si leggeva solo parola per parola. Un minimo di colore permette la
-// scansione a colpo d'occhio (verde=attivo, rosso=scaduto, ambra=in trattativa…).
-const STATUS_COLORS = {
-  active:   { bg: "#DCFCE7", border: "#86EFAC", fg: "#166534" },
-  swapped:  { bg: "#E0E7FF", border: "#A5B4FC", fg: "#3730A3" },
-  sold:     { bg: "#DBEAFE", border: "#93C5FD", fg: "#1E40AF" },
-  reserved: { bg: "#FEF3C7", border: "#FCD34D", fg: "#92400E" },
-  pending:  { bg: "#FEF3C7", border: "#FCD34D", fg: "#92400E" },
-  paused:   { bg: "#F3F4F6", border: "#D1D5DB", fg: "#4B5563" },
-  expired:  { bg: "#FEE2E2", border: "#FCA5A5", fg: "#991B1B" },
-};
-
-// Normalizza lo stato grezzo del DB (con i suoi alias) in una chiave canonica,
-// usata sia per il colore del badge sia per la chiave i18n listing.state.*.
-function normStatusKey(status) {
-  const s = String(status || "").toLowerCase();
-  if (["swapped", "traded", "exchanged"].includes(s)) return "swapped";
-  if (["pending", "review"].includes(s)) return "pending";
-  if (s === "sold") return "sold";
-  if (s === "reserved") return "reserved";
-  if (s === "expired") return "expired";
-  if (s === "paused") return "paused";
-  return "active"; // default e stringa vuota
-}
 
 function StatItem({ label, icon, value, active, onPress }) {
   return (
@@ -386,7 +361,7 @@ export default function ProfileScreen() {
     { key: "swapped", icon: "🔁", label: t("listing.filters.swapped", "Scambiati") },
     { key: "sold", icon: "💰", label: t("listing.filters.sold", "Venduti") },
     { key: "reserved", icon: "🔒", label: t("listing.filters.reserved", "Riservati") },
-    { key: "pending", icon: "🕑", label: t("listing.filters.pending", "Proposte in corso") },
+    { key: "pending", icon: "🕑", label: t("listing.filters.pending", "In trattativa") },
     { key: "paused", icon: "⏸️", label: t("listing.filters.paused", "In pausa") },
     { key: "expired", icon: "⛔️", label: t("listing.filters.expired", "Scaduti") },
   ];
@@ -599,7 +574,12 @@ export default function ProfileScreen() {
                 onPress: () => toggleStatus(actionSheetItem),
               }]
             : []),
-          { label: t("common.edit", "Modifica"), onPress: () => onEdit(actionSheetItem) },
+          // Venduto/scambiato: transazione conclusa, annuncio non più
+          // modificabile (prima "Modifica" restava sempre visibile anche su
+          // questi stati, mentre "Pausa/Riattiva" sopra li esclude già).
+          ...(!isConcludedStatus(actionSheetItem.status)
+            ? [{ label: t("common.edit", "Modifica"), onPress: () => onEdit(actionSheetItem) }]
+            : []),
           { label: t("common.delete", "Elimina"), destructive: true, onPress: () => onDeleteConfirm(actionSheetItem) },
         ] : []}
       />


### PR DESCRIPTION
## Summary
- Annunci `sold`/`swapped`: etichetta corretta nel dettaglio annuncio (prima "Nuovo" o nessuna) e bottone Modifica nascosto (dettaglio, menu Profilo, submit); nuovo trigger DB `trg_listings_lock_terminal` come backstop (prima solo lato client, bypassabile).
- `lib/listingStatus.js`: `normStatusKey`/`STATUS_COLORS` condivisi tra ProfileScreen e ListingDetailScreen (prima duplicati).
- Chip "Proposte in corso" → "In trattativa": contava i propri annunci in stato pending, non le offerte inviate, nome fuorviante.
- Card Esplora: tag "È un tuo annuncio" ridotto a pill accanto al salva (prima riga intera), tratta e prezzo sulla stessa riga (prezzo a destra), date del viaggio/soggiorno visibili senza aprire il dettaglio.

## ⚠️ Azione manuale
Nuova migration da eseguire su Supabase: `supabase/migrations/20260721140000_listings_lock_terminal_status.sql`.

## Test plan
- [x] Parse JSX sui file RN toccati
- [x] Parità traduzioni it/en/es invariata
- [ ] Verifica manuale: aprire un annuncio venduto/scambiato (etichetta + niente Modifica), controllare il chip "In trattativa" in Profilo, controllare il nuovo layout card in Esplora

https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg)_