### PR TITLE
Fix TrustScore: orario tratta ignorato e spiegazione nascosta sopra l'85%

### DIFF
--- a/server/src/services/trust/heuristics.js
+++ b/server/src/services/trust/heuristics.js
@@ -197,9 +197,13 @@ export function computeHeuristicChecks(listing, locale = 'it') {
   if (startDate && endDate) {
     const s = new Date(startDate);
     const e = new Date(endDate);
-    if (isFinite(s) && isFinite(e) && e < s) {
+    // <= (non solo <): un arrivo COINCIDENTE con la partenza (stesso istante,
+    // tipico di una tratta in giornata con solo la data troncata) è una
+    // tratta impossibile quanto un arrivo precedente, ma prima passava
+    // inosservato perché la condizione era solo "e < s".
+    if (isFinite(s) && isFinite(e) && e <= s) {
       consistency -= 0.6;
-      flags.push({ code: 'DATE_SWAP', msg: 'Data fine anteriore alla data inizio' });
+      flags.push({ code: 'DATE_SWAP', msg: 'Arrivo non successivo alla partenza (stesso istante o precedente)' });
       fixes.push({ field: 'endDate', suggestion: fixText('dateOrder', lang) });
     }
   }

--- a/travelswap_ai/travelswapai/lib/useTrustScore.js
+++ b/travelswap_ai/travelswapai/lib/useTrustScore.js
@@ -119,13 +119,30 @@ function normalizeFormToListing(input) {
     return undefined;
   };
 
+  // Per il treno partenza/arrivo sono un ISTANTE preciso, non solo una data:
+  // troncare all'ora (toIsoDate) rendeva impossibile per il controllo di
+  // coerenza lato server ("arrivo non successivo alla partenza", vedi
+  // heuristics.js) accorgersi di un arrivo coincidente o precedente alla
+  // partenza nello STESSO giorno — bug reale: annuncio con orari identici,
+  // TrustScore 86% senza alcuna segnalazione. Per l'hotel invece check-in/out
+  // restano concetti "di giornata": toIsoDate va bene.
+  const toIsoDateTime = (d) => {
+    if (!d) return undefined;
+    try {
+      if (d instanceof Date) return d.toISOString();
+      const dt = new Date(String(d).trim());
+      if (!isNaN(dt.getTime())) return dt.toISOString();
+    } catch {}
+    return undefined;
+  };
+
   let startDate, endDate;
   if (t === 'hotel') {
     startDate = toIsoDate(ci);
     endDate = toIsoDate(co);
   } else if (t === 'train') {
-    startDate = toIsoDate(dep);
-    endDate = toIsoDate(arr);
+    startDate = toIsoDateTime(dep);
+    endDate = toIsoDateTime(arr);
   }
 
   // Oggetto finale nel formato richiesto dal backend

--- a/travelswap_ai/travelswapai/screens/CreateListingScreen.js
+++ b/travelswap_ai/travelswapai/screens/CreateListingScreen.js
@@ -604,14 +604,15 @@ const initialJsonRef = useRef(null);
     });
   }, [trustData, form?.type]);
 
-  // Un punteggio basso senza un flag preciso (es. media pesata bassa ma nessuna
-  // soglia superata) lasciava l'utente senza spiegazione. Se non c'è già un
-  // flag a raccontare il motivo, indichiamo la componente più debole tra
-  // controlli di base / testo AI / foto AI — così il "perché" c'è sempre.
+  // Il "perché" del punteggio deve essere SEMPRE visibile, non solo quando è
+  // basso (regola di prodotto): prima la soglia score>=85 nascondeva questa
+  // spiegazione anche a un 86% senza alcun flag, facendo mostrare "Nessun
+  // problema rilevato" — fuorviante, perché 86% non è 100% e un motivo per
+  // cui non lo è esiste sempre. Ora si nasconde solo a punteggio pieno (100).
   const trustExplain = useMemo(() => {
     if (!trustData || trustData.aiAvailable === false) return null;
     const score = Number(trustData?.trustScore);
-    if (!Number.isFinite(score) || score >= 85) return null;
+    if (!Number.isFinite(score) || score >= 100) return null;
     if (flagsNoImg?.length) return null; // già spiegato da un flag puntuale
     const sub = trustData?.subScores || {};
     const parts = [


### PR DESCRIPTION
## Summary
- `lib/useTrustScore.js` troncava partenza/arrivo treno alla sola data prima di inviarli al server: il controllo di coerenza date non vedeva mai l'ora, quindi un arrivo coincidente/precedente nella stessa giornata restava invisibile (caso reale: annuncio con orari uguali, score 86% senza alcun flag).
- `server/src/services/trust/heuristics.js`: il controllo era "arrivo prima della partenza" (`e < s`), non copriva l'arrivo coincidente (`e == s`).
- `CreateListingScreen.js`: la spiegazione "perché questo punteggio" si nascondeva già sopra score 85, in contrasto con la regola di prodotto (CLAUDE.md: il perché va SEMPRE visibile) — ora si nasconde solo a punteggio pieno (100).

## Test plan
- [x] `cd server && node --test test/heuristics.test.js` (16/16 verdi)
- [x] Parse JSX / syntax check sui file toccati

https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg)_