### PR TITLE
Fix migration reservation_timeout: DROP get_offer_handshake prima del CREATE

### DIFF
--- a/supabase/migrations/20260721200000_reservation_timeout.sql
+++ b/supabase/migrations/20260721200000_reservation_timeout.sql
@@ -94,7 +94,10 @@ end $$;
 GRANT EXECUTE ON FUNCTION public.release_my_stale_reservations() TO authenticated;
 
 -- get_offer_handshake: espone anche la scadenza prenotazione (countdown).
-CREATE OR REPLACE FUNCTION public.get_offer_handshake(offer_id_text text)
+-- DROP necessario: cambia le colonne di ritorno (aggiunge reservation_expires_at)
+-- e CREATE OR REPLACE non può cambiare il tipo di ritorno di una funzione.
+DROP FUNCTION IF EXISTS public.get_offer_handshake(text);
+CREATE FUNCTION public.get_offer_handshake(offer_id_text text)
 RETURNS TABLE(status text, type text, amount numeric, currency text, i_confirmed boolean, other_confirmed boolean, reservation_expires_at timestamp with time zone)
 LANGUAGE sql SECURITY DEFINER
 SET search_path = public


### PR DESCRIPTION
## Summary
La migration `20260721200000_reservation_timeout.sql` usava `CREATE OR REPLACE` su `get_offer_handshake` cambiandone il tipo di ritorno (aggiunta `reservation_expires_at`), che Postgres rifiuta (`42P13`). Aggiunto `DROP FUNCTION IF EXISTS` prima del `CREATE`.

## ⚠️ Azione manuale
Solo per chi ha già provato a eseguire la migration e si è fermato sull'errore: rieseguire il blocco corretto di `get_offer_handshake` (DROP + CREATE).

https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg)_