### PR TITLE
Fix fuso orario: scadenza hotel usava CURRENT_DATE invece del giorno italiano

### DIFF
--- a/supabase/migrations/20260722140000_fix_timezone_expiry.sql
+++ b/supabase/migrations/20260722140000_fix_timezone_expiry.sql
@@ -1,0 +1,100 @@
+-- Fix fuso orario sulla scadenza hotel (check_in): CURRENT_DATE è valutato
+-- nel fuso orario di SESSIONE del database (su Supabase, di default UTC), non
+-- nel fuso dell'utente italiano. check_in è una `date` semplice (nessun
+-- fuso incorporato) pensata come giorno di calendario italiano.
+--
+-- Bug dimostrato con Postgres reale: ogni notte, per ~1-2 ore dopo la
+-- mezzanotte italiana (l'ampiezza dipende dall'ora legale, +1/+2h), è già
+-- "domani" in Italia ma CURRENT_DATE (sessione UTC) pensa sia ancora "oggi".
+-- In quella finestra un hotel con check_in = ieri (calendario italiano):
+--   - NON viene marcato 'expired' da expire_my_stale_listings (resta
+--     azionabile/prenotabile ore dopo che il check-in locale è finito);
+--   - può ancora essere ACCETTATO da accept_offer_any (il controllo
+--     "viaggio già passato" non scatta), finalizzando uno scambio su una
+--     prenotazione ormai inutile.
+-- Fix: sostituire CURRENT_DATE con (now() AT TIME ZONE 'Europe/Rome')::date,
+-- esplicito e stabile qualunque sia il fuso di sessione del database
+-- (gestisce il cambio ora legale/solare automaticamente, via tzdata).
+--
+-- depart_at/now() (treni) restano invariati: sono entrambi timestamptz,
+-- il confronto tra due istanti assoluti non dipende dal fuso di sessione.
+
+CREATE OR REPLACE FUNCTION public.expire_my_stale_listings()
+RETURNS void
+LANGUAGE sql
+AS $$
+  UPDATE public.listings
+     SET status = 'expired'
+   WHERE user_id = auth.uid()
+     AND status = 'active'
+     AND (
+       (type = 'train' AND depart_at IS NOT NULL AND depart_at < now())
+       OR
+       (type = 'hotel' AND check_in IS NOT NULL AND check_in::date < (now() AT TIME ZONE 'Europe/Rome')::date)
+     );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.expire_my_stale_listings() TO authenticated;
+
+-- accept_offer_any basata sulla versione più recente (20260721230000), che
+-- introduceva il controllo "viaggio già passato": stesso fix, stesso motivo.
+CREATE OR REPLACE FUNCTION public.accept_offer_any(offer_id_text text) RETURNS public.offers
+    LANGUAGE plpgsql SECURITY DEFINER
+    AS $$
+declare
+  v_offer public.offers;
+  v_owner uuid;
+  v_passed boolean;
+begin
+  select * into v_offer from public.offers where id::text = offer_id_text for update;
+  if not found then raise exception 'Offer not found'; end if;
+
+  if v_offer.status = 'pending' and v_offer.expires_at < now() then
+    update public.offers set status = 'expired' where id = v_offer.id;
+    select * into v_offer from public.offers where id = v_offer.id;
+  end if;
+
+  select user_id into v_owner from public.listings where id::text = v_offer.to_listing_id::text;
+  if v_owner is null or v_owner <> auth.uid() then raise exception 'Not allowed'; end if;
+
+  if v_offer.status <> 'pending' then return v_offer; end if;
+
+  -- Data del viaggio passata su UNO QUALSIASI degli annunci coinvolti?
+  select bool_or(
+           (l.type = 'train' and l.depart_at is not null and l.depart_at < now())
+        or (l.type = 'hotel' and l.check_in  is not null and l.check_in::date < (now() AT TIME ZONE 'Europe/Rome')::date)
+         )
+    into v_passed
+  from public.listings l
+  where l.id::text = v_offer.to_listing_id::text
+     or (v_offer.from_listing_id is not null and l.id::text = v_offer.from_listing_id::text);
+
+  if coalesce(v_passed, false) then
+    -- niente accettazione: scade l'offerta e marca scaduti gli annunci ancora attivi
+    update public.offers set status = 'expired' where id = v_offer.id;
+    update public.listings set status = 'expired'
+     where id::text in (v_offer.to_listing_id::text, coalesce(v_offer.from_listing_id::text, '____none____'))
+       and status = 'active';
+    select * into v_offer from public.offers where id = v_offer.id;
+    return v_offer;  -- status = 'expired' -> il client mostra "non accettabile"
+  end if;
+
+  update public.offers
+     set status = 'accepted', reservation_expires_at = now() + interval '7 days'
+   where id = v_offer.id;
+
+  update public.offers set status = 'declined'
+   where to_listing_id::text = v_offer.to_listing_id::text
+     and id <> v_offer.id and status = 'pending';
+
+  if v_offer.type = 'swap' and v_offer.from_listing_id is not null then
+    update public.listings set status = 'reserved'
+     where id::text in (v_offer.to_listing_id::text, v_offer.from_listing_id::text);
+  else
+    update public.listings set status = 'reserved'
+     where id::text = v_offer.to_listing_id::text;
+  end if;
+
+  select * into v_offer from public.offers where id = v_offer.id;
+  return v_offer;
+end $$;


### PR DESCRIPTION
## Causa
`CURRENT_DATE` è valutato nel **fuso di sessione del database** (su Supabase, di default UTC), non nel fuso dell'utente italiano. `check_in` è una `date` semplice, pensata come giorno di calendario italiano. Ogni notte, per 1-2 ore dopo la mezzanotte italiana (l'ampiezza dipende dall'ora legale), è già "domani" in Italia ma `CURRENT_DATE` pensa sia ancora "oggi":
- `expire_my_stale_listings` non marcava `'expired'` un hotel con check_in di ieri in quella finestra;
- `accept_offer_any` non bloccava l'accettazione di un'offerta su quel viaggio, ormai concluso localmente.

## Prova del bug
Testato con Postgres reale (schema minimale + funzioni con lo stesso `WHERE` di produzione): a un istante 30 minuti dopo la mezzanotte italiana, un hotel con `check_in = ieri` (calendario italiano) **restava `active`** con la logica vecchia e **diventava `expired`** con quella nuova. Nessuna regressione: hotel ancora validi allo stesso istante restano `active` in entrambe le versioni; i treni (`depart_at`, `timestamptz`) sono già timezone-safe e non cambiano comportamento.

## Fix
Sostituito `CURRENT_DATE` con `(now() AT TIME ZONE 'Europe/Rome')::date` in entrambe le funzioni — esplicito e stabile qualunque sia il fuso di sessione del database, gestisce automaticamente ora legale/solare.
- `expire_my_stale_listings`: base `20260721120000` (unica versione esistente).
- `accept_offer_any`: base `20260721230000` (la più recente, con il controllo "viaggio passato"), preservando scadenza prenotazione e blocco su viaggio concluso.

## Verifiche
- `node --test` backend: **96/96** (nessun file JS toccato, solo migration SQL).
- Fix validato con test ad-hoc su Postgres locale: schema minimale + le funzioni **reali** applicate dal file di migration, righe di test che dimostrano il comportamento corretto prima/dopo. Non incluso nei test automatici del repo: non esiste un harness Postgres nella CI (coerente con l'assenza di runner di migration, vedi CLAUDE.md).

## ⚠️ Azione manuale
Va eseguita **a mano** nel SQL Editor di Supabase la migration `20260722140000_fix_timezone_expiry.sql` (ricrea `expire_my_stale_listings` e `accept_offer_any`). Senza, il bug resta: nessun rischio nuovo, solo la finestra di 1-2 ore/notte già descritta continua a esistere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg)_