### PR TITLE
Fix "TypeError: fetch failed" su /api/chains/recompute: query IN troppo grande

### DIFF
--- a/server/src/models/listings.js
+++ b/server/src/models/listings.js
@@ -37,18 +37,26 @@ export async function listActiveListings({
 
   const clean = (listings || []).filter(l => isUUID(l.id));
 
-  // 2) Join con ultima valutazione TrustScore (view)
+  // 2) Join con ultima valutazione TrustScore (view). A lotti: un solo
+  // `.in("listing_id", ids)` con centinaia di id genera un URL di
+  // decine di migliaia di caratteri (filtro IN codificato in query
+  // string da PostgREST) che la connessione rifiuta a livello di rete
+  // prima ancora di arrivare a Supabase — manifestandosi come
+  // "TypeError: fetch failed" invece di un errore SQL leggibile (visto
+  // in produzione su /api/chains/recompute con 500+ annunci attivi).
   const ids = clean.map(l => l.id);
   let byIdTrust = new Map();
 
-  if (ids.length) {
+  const TRUST_CHUNK = 200;
+  for (let i = 0; i < ids.length; i += TRUST_CHUNK) {
+    const slice = ids.slice(i, i + TRUST_CHUNK);
     const { data: trusts, error: err2 } = await supabase
       .from("v_latest_trustscore")
       .select("listing_id, trust_score, evaluated_at")
-      .in("listing_id", ids);
+      .in("listing_id", slice);
 
     if (err2) throw err2;
-    byIdTrust = new Map((trusts || []).map(r => [String(r.listing_id), r]));
+    for (const r of trusts || []) byIdTrust.set(String(r.listing_id), r);
   }
 
   // 3) Merge + filtro minTrust


### PR DESCRIPTION
Risolve il 500 sul job cron "ricerca catene" (`/api/chains/recompute`), diagnosticato dai log di Render.

## Causa
`listActiveListings()` (usata da chains, matches, saved-searches, Esplora) faceva una singola query `WHERE listing_id IN (...)` passando **tutti** gli id degli annunci appena letti, per il join col TrustScore (`v_latest_trustscore`). PostgREST codifica il filtro IN nella query string dell'URL: con centinaia di id (lo swap a catena legge fino a 1000 annunci attivi) l'URL arriva a decine di migliaia di caratteri, oltre i limiti che la connessione di rete accetta — il risultato non è un errore SQL leggibile ma un fallimento a livello di trasporto (`TypeError: fetch failed` da undici, visto nei log Render), prima ancora che la richiesta arrivi a Supabase.

Confermato in produzione: i log di Render mostravano l'eccezione esatta dentro `listActiveListings`, chiamata da `findAndProposeChains` (`chains/recompute`). Lo schema DB (tabelle/funzioni dello swap a catena) è stato verificato presente e corretto — non era quello il problema.

## Fix
La query verso `v_latest_trustscore` ora gira **a lotti di 200 id** invece che tutti insieme — stesso pattern (`CHUNK`) già usato altrove nel codice per gli insert massivi. Controllato il resto del codice per lo stesso pattern (altre query `.in(...)`): tutte le altre sono già limitate a monte da un `.limit()` o hanno una dimensione naturale piccola — solo questa scalava con **tutti** gli annunci attivi del marketplace.

## Verifiche
- `node --check` OK
- `node --test` backend: **96/96**
- Nessuna migration, nessun file client toccato (fix solo server)

## ⚠️ Azione manuale
Nessuna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg)_