### PR TITLE
fix: 404 rotte dirette web, campo destination hotel, feedback avvisi ricerca

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -674,6 +674,25 @@ if (isDev) {
   });
 }
 
+// --- Fallback SPA per le rotte client-side dell'app web ---
+// React Navigation genera URL SENZA il prefisso /app (es. /MainTabs/Home,
+// /Login, /ListingDetail): funzionano quando si arriva da un link interno
+// (navigazione client-side, che non tocca il server), ma un refresh o un
+// link diretto a una di queste rotte è una richiesta GET vera al server, che
+// prima non aveva nessuna route corrispondente fuori da /app e /app/* →
+// 404 (bug reale, capitato in produzione). Qui serviamo la stessa shell
+// index.html per qualunque GET non-API, così il browser scarica lo stesso
+// bundle e React Navigation instrada verso lo screen giusto lato client.
+const NON_APP_ROUTE_PREFIXES = ['/api', '/ai', '/webhooks', '/health', '/debug', '/dev', '/simulate', '/app'];
+app.get('*', (req, res, next) => {
+  if (req.method !== 'GET') return next();
+  if (NON_APP_ROUTE_PREFIXES.some((p) => req.path === p || req.path.startsWith(`${p}/`))) {
+    return next();
+  }
+  res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.sendFile(path.join(webAppDir, 'index.html'));
+});
+
 // --- Start ---
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {

--- a/server/src/services/trust/heuristics.js
+++ b/server/src/services/trust/heuristics.js
@@ -179,7 +179,12 @@ export function computeHeuristicChecks(listing, locale = 'it') {
   // 'treno' vs 'train' teneva spenti questi controlli per i treni reali.
   let completeness = 0;
   const required = ['description', 'price', 'startDate'];
-  if (type === 'hotel' || type === 'alloggio') required.push('endDate', 'destination');
+  // Un hotel valorizza 'location' (città/struttura), non 'destination' (che è
+  // per le tratte treno/volo): richiedere 'destination' qui la segnalava
+  // sempre mancante, anche a campi compilati (bug reale, capitato in
+  // produzione — vedi CreateListingScreen, che per gli hotel manda sempre
+  // destination:null).
+  if (type === 'hotel' || type === 'alloggio') required.push('endDate', 'location');
   if (type === 'train' || type === 'treno' || type === 'volo' || type === 'bus') required.push('origin', 'destination');
 
   let present = 0;

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -234,6 +234,8 @@ export const translations = {
       deleteMsg: "Non riceverai più notifiche per questa ricerca.",
       deleteError: "Impossibile eliminare l'avviso.",
       maxPriceNegative: "Il prezzo massimo non può essere negativo.",
+      missingFieldsHotel: "Inserisci la città.",
+      missingFieldsTrain: "Inserisci sia \"Da\" che \"A\".",
     },
 
     linkMessenger: {
@@ -1287,6 +1289,8 @@ export const translations = {
       deleteMsg: "You'll no longer get notified for this search.",
       deleteError: "Unable to delete the alert.",
       maxPriceNegative: "The maximum price can't be negative.",
+      missingFieldsHotel: "Enter the city.",
+      missingFieldsTrain: "Enter both \"From\" and \"To\".",
     },
 
     linkMessenger: {
@@ -2316,6 +2320,8 @@ export const translations = {
       deleteMsg: "Ya no recibirás notificaciones para esta búsqueda.",
       deleteError: "No se pudo eliminar el aviso.",
       maxPriceNegative: "El precio máximo no puede ser negativo.",
+      missingFieldsHotel: "Introduce la ciudad.",
+      missingFieldsTrain: "Introduce tanto \"Desde\" como \"Hasta\".",
     },
 
     linkMessenger: {

--- a/travelswap_ai/travelswapai/screens/SavedSearchesScreen.js
+++ b/travelswap_ai/travelswapai/screens/SavedSearchesScreen.js
@@ -64,7 +64,18 @@ function NewSearchForm({ onCreated, t }) {
   const canSave = type === "hotel" ? !!location.trim() : !!routeFrom.trim() && !!routeTo.trim();
 
   const handleSave = async () => {
-    if (!canSave) return;
+    if (!canSave) {
+      // Prima non c'era alcun feedback: il tap su "Crea avviso" con campi
+      // incompleti non faceva nulla di visibile, e l'utente non capiva
+      // perché (bug reale, capitato in produzione).
+      Alert.alert(
+        t("common.error", "Errore"),
+        type === "hotel"
+          ? t("savedSearches.missingFieldsHotel", "Inserisci la città.")
+          : t("savedSearches.missingFieldsTrain", "Inserisci sia \"Da\" che \"A\".")
+      );
+      return;
+    }
     // Il DB blocca max_price < 0 con un CHECK (saved_searches_max_price_check),
     // ma senza questo controllo l'utente vedrebbe l'errore Postgres grezzo
     // invece di un messaggio comprensibile.


### PR DESCRIPTION
## Summary
- `server/src/index.js`: fallback SPA per qualunque GET non-API fuori da `/app/*` — risolve 404 su refresh/link diretto a rotte interne (es. `/MainTabs/Home`, `/Login`, `/ListingDetail`).
- `server/src/services/trust/heuristics.js`: Check AI richiedeva `destination` anche per gli hotel (che valorizzano solo `location`), segnalando sempre un campo mancante.
- `screens/SavedSearchesScreen.js` + `lib/i18n/translations.js`: submit di "Crea avviso" con campi obbligatori vuoti ora mostra un errore invece di non fare nulla.

Trovati durante un test UX end-to-end sull'app live (travelswapai.onrender.com). Altri bug individuati nello stesso giro (auto-acquisto/scambio, conteggio annunci venditore, "password dimenticata") risultano già corretti su `main` — il sito live era semplicemente rimasto indietro rispetto a `main` di ~300 commit.

## Test plan
- [ ] Refresh su `/MainTabs/Home`, `/Login`, `/ListingDetail?...` non deve più dare 404
- [ ] Creare annuncio Hotel via "Compila con AI" + "Check AI": non deve più segnalare "destination" mancante
- [ ] "Crea avviso" di ricerca con campi vuoti: deve mostrare un errore invece di restare muto

🤖 Generated with [Claude Code](https://claude.com/claude-code)