### PR TITLE
Fix counters.exchanged sempre a zero (storico scambi non contava mai)

### DIFF
--- a/supabase/migrations/20260723120000_fix_exchanged_counter_status.sql
+++ b/supabase/migrations/20260723120000_fix_exchanged_counter_status.sql
@@ -1,0 +1,33 @@
+-- Bug: il contatore "storico" (badge "Con storico" + "Scambi completati" su
+-- SellerProfileScreen/ProfileScreen) conta profiles.counters.sold +
+-- counters.exchanged, ma refresh_profile_counters cerca listings con
+-- status = 'exchanged' — valore che NON VIENE MAI SCRITTO da nessuna parte:
+-- ogni punto che conclude uno scambio (after_update_offers_propagate,
+-- prima ancora nell'init) imposta sempre status = 'swapped', mai
+-- 'exchanged'. Risultato: counters.exchanged è sempre 0, per chiunque, da
+-- sempre — uno scambio completato non alza MAI lo storico di nessuno dei
+-- due lati, a differenza di una vendita (che usa correttamente 'sold').
+--
+-- Fix: conta gli stati realmente scritti per uno scambio concluso
+-- ('swapped', più gli alias storici 'exchanged'/'traded' già riconosciuti
+-- lato client da normStatusKey in lib/listingStatus.js, per sicurezza).
+CREATE OR REPLACE FUNCTION public.refresh_profile_counters(p_user uuid) RETURNS void
+    LANGUAGE sql
+    AS $$
+  update public.profiles pr
+  set counters = jsonb_build_object(
+    'active',    (select count(*) from public.listings l where l.user_id = p_user and l.status='active'),
+    'sold',      (select count(*) from public.listings l where l.user_id = p_user and l.status='sold'),
+    'exchanged', (select count(*) from public.listings l where l.user_id = p_user and l.status::text in ('swapped','exchanged','traded')),
+    'total',     (select count(*) from public.listings l where l.user_id = p_user)
+  ),
+  updated_at = now()
+  where pr.id = p_user;
+$$;
+
+-- Backfill: ricalcola subito i contatori di tutti gli utenti con almeno un
+-- annuncio 'swapped', così lo storico corretto compare senza aspettare il
+-- prossimo insert/update/delete su listings (il trigger esistente
+-- trg_listings_counters continua a tenerli aggiornati da qui in avanti).
+SELECT public.refresh_profile_counters(u.user_id)
+FROM (SELECT DISTINCT user_id FROM public.listings WHERE status::text = 'swapped') AS u;


### PR DESCRIPTION
## Contesto

Domanda dell'utente durante il test del badge "Con storico": "e se invece è scambiato come lo vedo?" — indagando ho trovato che uno scambio completato non alza MAI il contatore, per NESSUNO dei due lati.

## Causa

`refresh_profile_counters` (unica definizione, in `20260711160000_init.sql`, mai più toccata da allora) conta:

```sql
'exchanged', (select count(*) from public.listings l where l.user_id = p_user and l.status='exchanged'),
```

Ma **nessun** punto del codice scrive mai `status = 'exchanged'` su un annuncio — ogni funzione che conclude uno scambio (dalla migration iniziale fino a `after_update_offers_propagate`, versione più recente in `20260718110001_offers_timeout.sql`) imposta sempre `status = 'swapped'`. `'exchanged'` è un valore dell'enum mai realmente prodotto: un mismatch presente fin dalla primissima migration.

Risultato: `counters.exchanged` è sempre stato 0 per chiunque — il badge "Con storico" e la stat "Scambi completati" non hanno mai riflesso scambi conclusi, solo vendite (`counters.sold`, che invece è corretto).

## Fix

`refresh_profile_counters` ora conta gli stati realmente scritti per uno scambio concluso: `status::text in ('swapped','exchanged','traded')` (cast a testo prima del confronto: `'traded'` non è un valore reale dell'enum, il cast evita l'errore 22P02 descritto in CLAUDE.md). Backfill incluso per ricalcolare subito i contatori di chi ha già annunci `'swapped'`.

## ⚠️ Azione manuale

Nuova migration da applicare a mano nel SQL Editor di Supabase: `supabase/migrations/20260723120000_fix_exchanged_counter_status.sql`.

## Verifiche

- `node --test` nel backend: 96/96 verdi (nessun codice server toccato, fix puramente DB)
- Nessuna modifica client: la UI (`SellerProfileScreen`/`ProfileScreen`/`TrustBadges`) già legge `counters.exchanged` correttamente, il dato in arrivo era sbagliato a monte


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg)_