### PR TITLE
Fix seed test scambi a 3: cap 10 annunci attivi blocca il rumore su U4

### DIFF
--- a/supabase/seed_stress_test_matching.sql
+++ b/supabase/seed_stress_test_matching.sql
@@ -65,6 +65,18 @@
 -- entrambi i gruppi.
 -- ============================================================
 
+-- La PARTE 1 mette 500 annunci attivi su un solo utente (U4) di proposito
+-- (rumore realistico, vedi sopra): dal 23/07 esiste anche un trigger che
+-- blocca oltre 10 annunci ATTIVI per utente (trg_listings_active_cap,
+-- 20260723110000_active_listing_cap.sql), pensato per bloccare esattamente
+-- questo pattern quando capita per errore a un utente vero. Qui è
+-- volontario e lo script è solo per test admin via SQL Editor, quindi
+-- disattiviamo il trigger per la durata dello script invece di adattare
+-- il cap (che deve restare stretto per gli utenti reali) — senza questo,
+-- l'INSERT si fermava alla riga 11 con un'eccezione che faceva fare
+-- rollback anche alla PARTE 2 (i 12 annunci "veri"), lasciando zero righe.
+ALTER TABLE public.listings DISABLE TRIGGER trg_listings_active_cap;
+
 DO $$
 DECLARE
   -- <<< SOSTITUISCI questi 4 UUID con quelli reali recuperati sopra >>>
@@ -208,6 +220,8 @@ BEGIN
       (now() + interval '11 days')::date, (now() + interval '13 days')::date, 75.00, 'EUR', 'active', now(), now());
 
 END $$;
+
+ALTER TABLE public.listings ENABLE TRIGGER trg_listings_active_cap;
 
 -- ---------- Verifica rapida ----------
 -- Atteso "veri": 6 righe (U1,U2,U3 con esattamente 1 VENDO + 2 CERCO


### PR DESCRIPTION
## Causa

`supabase/seed_stress_test_matching.sql` inserisce 500 annunci di "rumore" attivi su un solo utente (U4) per simulare un volume realistico durante il test dello swap a catena. Il trigger `trg_listings_active_cap` (tetto di 10 annunci attivi per utente, aggiunto in `20260723110000_active_listing_cap.sql`) blocca questo inserimento con un'eccezione alla riga 11 — ed essendo tutto dentro un unico blocco `DO $$ ... END $$`, il rollback si porta via anche la Parte 2 dello script (i 12 annunci "veri" che formano la catena a 3). Risultato: lo script terminava con zero righe inserite, senza un errore facile da individuare in coda al risultato del SQL Editor.

## Fix

Lo script disattiva `trg_listings_active_cap` subito prima dell'inserimento e lo riattiva subito dopo — è dato di test lanciato a mano da SQL Editor, non un utente reale, quindi bypassare il cap qui non indebolisce la protezione lato app/trigger per gli utenti veri.

## Verifiche

- Nessun codice app/server toccato: solo lo script SQL di test in `supabase/` (non è una migration, nessuna azione manuale richiesta lato Supabase).
- Root cause confermata insieme all'utente: query diagnostiche su `chain_proposals`/`chain_participants`/`listings` mostravano zero righe di test effettivamente inserite nonostante lo script fosse stato eseguito con UUID validi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjTdDnzkWgaLNZUUQ1PYGg)_