### PR TITLE
Estendi il controllo TrustScore agli annunci pubblicati via Messenger

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -20,6 +20,7 @@ import { parseFacebookText } from './parsers/fbParser.js';
 import { upsertListingFromFacebook } from './models/fbIngest.js';
 import { sendFbText, sendFbQuickReplies } from './lib/fbSend.js'; // quick replies
 import { mergeParsed, missingFields, nextPromptFor } from './lib/announceRules.js';
+import { decideMessengerPublishOutcome } from './lib/messengerPublishOutcome.js';
 import { getSession, saveSession, clearSession } from './models/fbSessionStore.js';
 import { looksLikeLinkCode, tryLinkFromMessage, getLinkedUserId } from './models/fbLink.js';
 import { parseLocalizedNumber } from './util/number.js';
@@ -139,8 +140,6 @@ function summaryText(s) {
 // dell'esito reale: fbIngest applica ora lo stesso gate TrustScore/moderazione
 // del Feed anche a questo canale (prima veniva bypassato), quindi qui va
 // gestito esplicitamente anche il caso "scartato", non solo successo/errore.
-// La sessione NON viene svuotata quando l'annuncio è scartato, così l'utente
-// può correggere testo/prezzo e riconfermare senza ripartire da zero.
 async function publishMessengerListing(senderId, mid, s) {
   try {
     const ownerId = await getLinkedUserId(senderId);
@@ -156,20 +155,9 @@ async function publishMessengerListing(senderId, mid, s) {
         end_date: s.check_out || s.arrive_at || null
       }
     });
-    if (result?.skipped) {
-      await sendFbText(
-        senderId,
-        "⚠️ Non ho pubblicato l'annuncio: il controllo automatico dei contenuti l'ha segnalato come poco " +
-        "chiaro o poco affidabile (es. descrizione poco plausibile). Prova a correggere i dati e a confermare di nuovo."
-      );
-      return;
-    }
-    await clearSession(senderId);
-    await sendFbText(
-      senderId,
-      "✅ Fantastico! Il tuo annuncio è stato pubblicato con successo su TravelSwap 🎉\n" +
-      "Grazie per aver condiviso — buona fortuna con lo scambio! ✈️🏨🚆"
-    );
+    const outcome = decideMessengerPublishOutcome(result);
+    if (outcome.clearSession) await clearSession(senderId);
+    await sendFbText(senderId, outcome.message);
   } catch (e) {
     console.error('[Messenger Confirm Publish] Error:', e);
     await sendFbText(senderId, "⚠️ C'è stato un problema nella pubblicazione. Riprova tra poco.");

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -135,6 +135,46 @@ function summaryText(s) {
     `• Prezzo: ${pr}`
   );
 }
+// Pubblica l'annuncio confermato via Messenger e informa l'utente
+// dell'esito reale: fbIngest applica ora lo stesso gate TrustScore/moderazione
+// del Feed anche a questo canale (prima veniva bypassato), quindi qui va
+// gestito esplicitamente anche il caso "scartato", non solo successo/errore.
+// La sessione NON viene svuotata quando l'annuncio è scartato, così l'utente
+// può correggere testo/prezzo e riconfermare senza ripartire da zero.
+async function publishMessengerListing(senderId, mid, s) {
+  try {
+    const ownerId = await getLinkedUserId(senderId);
+    const result = await upsertListingFromFacebook({
+      channel: 'facebook:messenger',
+      externalId: mid,
+      contactUrl: null,
+      rawText: '', // opzionale
+      ownerId,
+      parsed: {
+        ...s,
+        start_date: s.check_in || s.depart_at || null,
+        end_date: s.check_out || s.arrive_at || null
+      }
+    });
+    if (result?.skipped) {
+      await sendFbText(
+        senderId,
+        "⚠️ Non ho pubblicato l'annuncio: il controllo automatico dei contenuti l'ha segnalato come poco " +
+        "chiaro o poco affidabile (es. descrizione poco plausibile). Prova a correggere i dati e a confermare di nuovo."
+      );
+      return;
+    }
+    await clearSession(senderId);
+    await sendFbText(
+      senderId,
+      "✅ Fantastico! Il tuo annuncio è stato pubblicato con successo su TravelSwap 🎉\n" +
+      "Grazie per aver condiviso — buona fortuna con lo scambio! ✈️🏨🚆"
+    );
+  } catch (e) {
+    console.error('[Messenger Confirm Publish] Error:', e);
+    await sendFbText(senderId, "⚠️ C'è stato un problema nella pubblicazione. Riprova tra poco.");
+  }
+}
 // =========================================================
 
 // --- Healthcheck / Debug ---
@@ -366,30 +406,7 @@ app.post('/webhooks/facebook', async (req, res) => {
                   ]);
                   return res.sendStatus(200);
                 }
-                try {
-                  const ownerId = await getLinkedUserId(senderId);
-                  const result = await upsertListingFromFacebook({
-                    channel: 'facebook:messenger',
-                    externalId: m?.mid || `${senderId}:${m.timestamp}`,
-                    contactUrl: null,
-                    rawText: '', // opzionale
-                    ownerId,
-                    parsed: {
-                      ...s,
-                      start_date: s.check_in || s.depart_at || null,
-                      end_date: s.check_out || s.arrive_at || null
-                    }
-                  });
-                  await clearSession(senderId);
-                  await sendFbText(
-                    senderId,
-                    "✅ Fantastico! Il tuo annuncio è stato pubblicato con successo su TravelSwap 🎉\n" +
-                    "Grazie per aver condiviso — buona fortuna con lo scambio! ✈️🏨🚆"
-                  );
-                } catch (e) {
-                  console.error('[Messenger Confirm Publish] Error:', e);
-                  await sendFbText(senderId, "⚠️ C'è stato un problema nella pubblicazione. Riprova tra poco.");
-                }
+                await publishMessengerListing(senderId, m?.mid || `${senderId}:${m.timestamp}`, s);
                 return res.sendStatus(200);
               } else if (p === 'PUB_MODIFICA') {
                 await sendFbText(senderId,
@@ -449,30 +466,7 @@ if (quickPayload) {
     return res.sendStatus(200);
   }
 
-  try {
-    const ownerId = await getLinkedUserId(senderId);
-    const result = await upsertListingFromFacebook({
-      channel: 'facebook:messenger',
-      externalId: m.message?.mid || `${senderId}:${m.timestamp}`,
-      contactUrl: null,
-      rawText: '', // opzionale
-      ownerId,
-      parsed: {
-        ...s,
-        start_date: s.check_in || s.depart_at || null,
-        end_date:   s.check_out || s.arrive_at || null
-      }
-    });
-    await clearSession(senderId);
-    await sendFbText(
-      senderId,
-      "✅ Fantastico! Il tuo annuncio è stato pubblicato con successo su TravelSwap 🎉\n" +
-      "Grazie per aver condiviso — buona fortuna con lo scambio! ✈️🏨🚆"
-    );
-  } catch (e) {
-    console.error('[Messenger QuickReply CONFIRM] Error:', e);
-    await sendFbText(senderId, "⚠️ C'è stato un problema nella pubblicazione. Riprova tra poco.");
-  }
+  await publishMessengerListing(senderId, m.message?.mid || `${senderId}:${m.timestamp}`, s);
   return res.sendStatus(200);
 }
 

--- a/server/src/lib/messengerPublishOutcome.js
+++ b/server/src/lib/messengerPublishOutcome.js
@@ -1,0 +1,23 @@
+// server/src/lib/messengerPublishOutcome.js
+// Decide messaggio da mandare all'utente e se svuotare la sessione, a
+// partire dal risultato di upsertListingFromFacebook. Isolata dal resto
+// (nessuna chiamata a Facebook/DB) così da poter testare la regola senza
+// mockare I/O — vedi test/messengerPublishOutcome.test.js. La sessione NON
+// viene svuotata quando l'annuncio è scartato dal TrustScore, così l'utente
+// può correggere testo/prezzo e riconfermare senza ripartire da zero.
+export function decideMessengerPublishOutcome(result) {
+  if (result?.skipped) {
+    return {
+      clearSession: false,
+      message:
+        "⚠️ Non ho pubblicato l'annuncio: il controllo automatico dei contenuti l'ha segnalato come poco " +
+        "chiaro o poco affidabile (es. descrizione poco plausibile). Prova a correggere i dati e a confermare di nuovo.",
+    };
+  }
+  return {
+    clearSession: true,
+    message:
+      "✅ Fantastico! Il tuo annuncio è stato pubblicato con successo su TravelSwap 🎉\n" +
+      "Grazie per aver condiviso — buona fortuna con lo scambio! ✈️🏨🚆",
+  };
+}

--- a/server/src/models/fbIngest.js
+++ b/server/src/models/fbIngest.js
@@ -7,13 +7,19 @@ import { parseLocalizedNumber } from '../util/number.js';
 // NB: lo schema richiede: user_id (not null), type (not null), title (not null), location (not null), price (not null)
 const DEFAULT_LISTING_OWNER_ID = (process.env.DEFAULT_LISTING_OWNER_ID || '').trim();
 
-// Sotto questa soglia, un annuncio dal canale Feed non viene pubblicato (solo
-// loggato): il Feed ingerisce da post/commenti di CHIUNQUE sulla Pagina,
-// senza alcuna conferma umana come garantisce invece il flusso guidato di
-// Messenger (missingFields in announceRules.js, conferma esplicita prima di
-// PUB_CONFERMA) — la stessa soglia usata altrove per "annuncio confuso/poco
-// affidabile" (vedi INCOHERENT_TYPE in routes/trustscore.js).
+// Sotto questa soglia, un annuncio da Facebook (Feed o Messenger) non viene
+// pubblicato. Il flusso guidato di Messenger (missingFields in
+// announceRules.js, conferma esplicita prima di PUB_CONFERMA) garantisce che
+// i CAMPI siano completi e coerenti, ma non dice nulla sulla PLAUSIBILITÀ del
+// contenuto (foto non pertinenti, testo poco credibile, ecc.): quella è
+// responsabilità del TrustScore, e vale indipendentemente da quanto il canale
+// sia "guidato" — un utente può confermare via Messenger un annuncio con
+// contenuto scarso tanto quanto uno pubblicato dal Feed. Stessa soglia usata
+// altrove per "annuncio confuso/poco affidabile" (vedi INCOHERENT_TYPE in
+// routes/trustscore.js). Nome env var storico (era solo per il Feed), non
+// rinominato per non rompere una configurazione di produzione esistente.
 const FB_FEED_MIN_TRUST_SCORE = Number(process.env.FB_FEED_MIN_TRUST_SCORE ?? 50);
+const TRUST_SCORE_GATED_CHANNELS = new Set(['facebook:feed', 'facebook:messenger']);
 
 function pick(v, fb) {
   // fallback semplice
@@ -141,15 +147,15 @@ export async function upsertListingFromFacebook({ channel, externalId, contactUr
   // inventata, pubblicato senza che nessuno l'avesse mai confermata.
   if (!pres.az) throw new Error('Missing cerco_vendo (ambiguous)');
 
-  // Il Feed pubblica da post/commenti di CHIUNQUE interagisca con la Pagina,
-  // senza alcuna conferma umana (Messenger invece guida l'utente e chiede
-  // conferma esplicita prima di pubblicare, vedi PUB_CONFERMA in index.js):
-  // far passare anche questi annunci dalla stessa pipeline Check AI/TrustScore
-  // già obbligatoria per chi pubblica dall'app, invece di andare live senza
-  // nessuna verifica. Sotto soglia (o contenuto segnalato dalla moderazione):
-  // non pubblicare, solo loggare.
+  // Sia il Feed (post/commenti di CHIUNQUE interagisca con la Pagina) sia
+  // Messenger (flusso guidato con conferma esplicita, vedi PUB_CONFERMA in
+  // index.js) passano dalla stessa pipeline Check AI/TrustScore già
+  // obbligatoria per chi pubblica dall'app, invece di andare live senza
+  // nessuna verifica di contenuto. Sotto soglia (o contenuto segnalato dalla
+  // moderazione): non pubblicare (il chiamante decide se loggare soltanto,
+  // come per il Feed, o avvisare l'utente, come fa Messenger in index.js).
   let trustAuditPayload = null;
-  if (channel === 'facebook:feed') {
+  if (TRUST_SCORE_GATED_CHANNELS.has(channel)) {
     const scored = await computeFullTrustScore({
       title: pres.title,
       type: pres.type,
@@ -164,7 +170,7 @@ export async function upsertListingFromFacebook({ channel, externalId, contactUr
     }, 'it');
 
     if (scored.moderationFlagged || scored.trustScore < FB_FEED_MIN_TRUST_SCORE) {
-      console.log('[fbIngest] Feed listing scartato (TrustScore basso o contenuto segnalato):', {
+      console.log(`[fbIngest] Listing scartato su canale ${channel} (TrustScore basso o contenuto segnalato):`, {
         externalId, trustScore: scored.trustScore, moderationFlagged: scored.moderationFlagged,
       });
       return { id: null, skipped: true, reason: scored.moderationFlagged ? 'moderation_flagged' : 'low_trust_score', trustScore: scored.trustScore };

--- a/server/src/models/fbIngest.js
+++ b/server/src/models/fbIngest.js
@@ -21,6 +21,19 @@ const DEFAULT_LISTING_OWNER_ID = (process.env.DEFAULT_LISTING_OWNER_ID || '').tr
 const FB_FEED_MIN_TRUST_SCORE = Number(process.env.FB_FEED_MIN_TRUST_SCORE ?? 50);
 const TRUST_SCORE_GATED_CHANNELS = new Set(['facebook:feed', 'facebook:messenger']);
 
+// Estratte come funzioni pure (nessun accesso a Supabase/OpenAI) così da
+// poter testare la regola "chi viene controllato e con quale soglia" senza
+// dover mockare rete/DB — vedi test/fbIngestTrustGate.test.js.
+export function shouldGateChannel(channel) {
+  return TRUST_SCORE_GATED_CHANNELS.has(channel);
+}
+
+export function evaluateTrustGate(scored, threshold = FB_FEED_MIN_TRUST_SCORE) {
+  if (scored?.moderationFlagged) return { publishable: false, reason: 'moderation_flagged' };
+  if (Number(scored?.trustScore) < threshold) return { publishable: false, reason: 'low_trust_score' };
+  return { publishable: true, reason: null };
+}
+
 function pick(v, fb) {
   // fallback semplice
   return v ?? fb ?? null;
@@ -155,7 +168,7 @@ export async function upsertListingFromFacebook({ channel, externalId, contactUr
   // moderazione): non pubblicare (il chiamante decide se loggare soltanto,
   // come per il Feed, o avvisare l'utente, come fa Messenger in index.js).
   let trustAuditPayload = null;
-  if (TRUST_SCORE_GATED_CHANNELS.has(channel)) {
+  if (shouldGateChannel(channel)) {
     const scored = await computeFullTrustScore({
       title: pres.title,
       type: pres.type,
@@ -169,11 +182,12 @@ export async function upsertListingFromFacebook({ channel, externalId, contactUr
       images: parsed?.image_url ? [{ url: parsed.image_url }] : [],
     }, 'it');
 
-    if (scored.moderationFlagged || scored.trustScore < FB_FEED_MIN_TRUST_SCORE) {
+    const gate = evaluateTrustGate(scored);
+    if (!gate.publishable) {
       console.log(`[fbIngest] Listing scartato su canale ${channel} (TrustScore basso o contenuto segnalato):`, {
         externalId, trustScore: scored.trustScore, moderationFlagged: scored.moderationFlagged,
       });
-      return { id: null, skipped: true, reason: scored.moderationFlagged ? 'moderation_flagged' : 'low_trust_score', trustScore: scored.trustScore };
+      return { id: null, skipped: true, reason: gate.reason, trustScore: scored.trustScore };
     }
     trustAuditPayload = scored;
   }

--- a/server/test/fbIngestTrustGate.test.js
+++ b/server/test/fbIngestTrustGate.test.js
@@ -1,0 +1,44 @@
+// Test per la regola "quali canali Facebook vengono controllati dal
+// TrustScore prima di pubblicare, e con quale esito" (fbIngest.js).
+// Copre la regressione: prima solo 'facebook:feed' passava dal gate, un
+// annuncio confermato via 'facebook:messenger' andava live senza alcun
+// controllo di contenuto/moderazione.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldGateChannel, evaluateTrustGate } from '../src/models/fbIngest.js';
+
+test('shouldGateChannel: feed e messenger sono entrambi soggetti al TrustScore', () => {
+  assert.equal(shouldGateChannel('facebook:feed'), true);
+  assert.equal(shouldGateChannel('facebook:messenger'), true);
+});
+
+test('shouldGateChannel: canali non riconosciuti non sono gated', () => {
+  assert.equal(shouldGateChannel('facebook:simulate'), false);
+  assert.equal(shouldGateChannel(undefined), false);
+  assert.equal(shouldGateChannel(''), false);
+});
+
+test('evaluateTrustGate: punteggio sopra soglia e nessun flag -> pubblicabile', () => {
+  const out = evaluateTrustGate({ trustScore: 80, moderationFlagged: false }, 50);
+  assert.deepEqual(out, { publishable: true, reason: null });
+});
+
+test('evaluateTrustGate: punteggio esattamente sulla soglia -> pubblicabile', () => {
+  const out = evaluateTrustGate({ trustScore: 50, moderationFlagged: false }, 50);
+  assert.equal(out.publishable, true);
+});
+
+test('evaluateTrustGate: punteggio sotto soglia -> scartato per low_trust_score', () => {
+  const out = evaluateTrustGate({ trustScore: 30, moderationFlagged: false }, 50);
+  assert.deepEqual(out, { publishable: false, reason: 'low_trust_score' });
+});
+
+test('evaluateTrustGate: contenuto flaggato dalla moderazione -> scartato anche con punteggio alto', () => {
+  const out = evaluateTrustGate({ trustScore: 90, moderationFlagged: true }, 50);
+  assert.deepEqual(out, { publishable: false, reason: 'moderation_flagged' });
+});
+
+test('evaluateTrustGate: moderazione ha priorità sul motivo se entrambi i problemi sono presenti', () => {
+  const out = evaluateTrustGate({ trustScore: 10, moderationFlagged: true }, 50);
+  assert.equal(out.reason, 'moderation_flagged');
+});

--- a/server/test/messengerPublishOutcome.test.js
+++ b/server/test/messengerPublishOutcome.test.js
@@ -1,0 +1,30 @@
+// Test per la regola "cosa dire all'utente Messenger e se svuotare la
+// sessione" dopo aver provato a pubblicare (lib/messengerPublishOutcome.js).
+// Copre la regressione: prima del gate TrustScore su Messenger, il bot
+// mandava sempre il messaggio di successo, anche quando in teoria l'annuncio
+// non fosse stato inserito.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { decideMessengerPublishOutcome } from '../src/lib/messengerPublishOutcome.js';
+
+test('risultato pubblicato (con id) -> messaggio di successo e sessione svuotata', () => {
+  const out = decideMessengerPublishOutcome({ id: 'abc-123' });
+  assert.equal(out.clearSession, true);
+  assert.match(out.message, /pubblicato con successo/);
+});
+
+test('risultato scartato dal TrustScore -> messaggio di avviso e sessione NON svuotata', () => {
+  const out = decideMessengerPublishOutcome({ id: null, skipped: true, reason: 'low_trust_score', trustScore: 30 });
+  assert.equal(out.clearSession, false);
+  assert.match(out.message, /[Nn]on ho pubblicato/);
+});
+
+test('risultato scartato per moderazione -> stesso comportamento (sessione preservata)', () => {
+  const out = decideMessengerPublishOutcome({ id: null, skipped: true, reason: 'moderation_flagged', trustScore: 90 });
+  assert.equal(out.clearSession, false);
+});
+
+test('risultato mancante/undefined non esplode e viene trattato come successo', () => {
+  const out = decideMessengerPublishOutcome(undefined);
+  assert.equal(out.clearSession, true);
+});


### PR DESCRIPTION
## Causa

Un annuncio confermato via il bot Messenger (`PUB_CONFERMA`) veniva pubblicato (`status: 'active'`) senza mai passare dal controllo TrustScore/moderazione contenuti. Il gate esisteva già in `fbIngest.js` ma era condizionato a `channel === 'facebook:feed'`: il flusso guidato di Messenger garantisce solo la completezza dei campi (prezzo, tratta, date), non la plausibilità del contenuto (foto non pertinenti, testo poco credibile), quindi un annuncio scadente confermato via Messenger non veniva mai segnalato né bloccato, a differenza del Feed.

## Fix

- `server/src/models/fbIngest.js`: il gate TrustScore (`computeFullTrustScore` + soglia minima + flag di moderazione) ora si applica sia a `facebook:feed` sia a `facebook:messenger`. Estratte come funzioni pure `shouldGateChannel()` e `evaluateTrustGate()` per isolare la regola di decisione dalla chiamata reale a Supabase/OpenAI.
- `server/src/index.js`: eliminata la duplicazione tra i due punti che gestiscono `PUB_CONFERMA` (postback e quick-reply), estratta in `publishMessengerListing()`. Quando l'annuncio viene scartato dal gate, il bot ora avvisa l'utente (invece di mostrare comunque il messaggio di successo) e **non svuota la sessione**, così l'utente può correggere i dati e riconfermare senza ripartire da zero.
- Nuovo `server/src/lib/messengerPublishOutcome.js`: `decideMessengerPublishOutcome()` isola la regola "che messaggio mandare e se svuotare la sessione", separata da `index.js` perché quel file avvia un server reale (`app.listen`) a livello top e non è importabile da un test.

## Verifiche

- `cd server && node --test`: 107/107 verdi (96 preesistenti + 11 nuovi in `test/fbIngestTrustGate.test.js` e `test/messengerPublishOutcome.test.js`, che coprono la regola di gating per canale/soglia e il comportamento post-pubblicazione su Messenger).
- `node --check` su tutti i file JS toccati.
- Nessun file React Native toccato, nessuna migration SQL: nessuna azione manuale richiesta lato Supabase.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_