### PR TITLE
CORS: normalizza gli origin e stampa la lista attiva all'avvio

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -52,13 +52,36 @@ const app = express();
 // se CORS_ORIGINS è configurata in produzione rischierebbe di bloccare l'app
 // web. Impostata quella variabile, la lista esplicita ha comunque la
 // precedenza e il fallback non viene mai usato.
+// Il confronto con l'header Origin del browser è una uguaglianza ESATTA di
+// stringhe: "https://esempio.it/" (con la barra finale) non corrisponde a
+// "https://esempio.it" e l'app verrebbe bloccata senza un errore che lo
+// spieghi. Sono i due modi in cui questa configurazione si sbaglia più
+// spesso, insieme al protocollo mancante: qui la barra finale viene tolta e
+// una voce senza http(s):// viene segnalata invece di restare a fallire in
+// silenzio.
+function normalizeOrigin(raw) {
+  const s = String(raw || '').trim().replace(/\/+$/, '');
+  if (!s) return null;
+  if (!/^https?:\/\//i.test(s)) {
+    console.warn(`[CORS] voce ignorata, manca http:// o https:// -> "${raw}"`);
+    return null;
+  }
+  return s;
+}
+
 const corsOrigins = (process.env.CORS_ORIGINS || '')
   .split(',')
-  .map(s => s.trim())
+  .map(normalizeOrigin)
   .filter(Boolean);
-if (!corsOrigins.length && process.env.NODE_ENV === 'production') {
-  console.warn('[CORS] CORS_ORIGINS non impostata in produzione: qualunque origin può chiamare questa API dal browser. Impostarla con la lista degli origin ammessi.');
+
+if (corsOrigins.length) {
+  // Stampato all'avvio per rendere la configurazione verificabile dai log:
+  // se un dominio atteso non compare qui, il browser lo bloccherà.
+  console.log('[CORS] origin ammessi:', corsOrigins.join(', '));
+} else if (process.env.NODE_ENV === 'production') {
+  console.warn('[CORS] CORS_ORIGINS non impostata (o vuota) in produzione: qualunque origin può chiamare questa API dal browser. Impostarla con la lista degli origin ammessi.');
 }
+
 app.use(cors({ origin: corsOrigins.length ? corsOrigins : true }));
 const rawBodySaver = (req, _res, buf) => { req.rawBody = buf; };
 // 15mb: il Check AI in creazione invia fino a 3 foto in base64 (~1-3MB


### PR DESCRIPTION
Seguito della PR #160, ora che `CORS_ORIGINS` è stata impostata in produzione.

## Contesto

Non serviva altro lato codice per il comportamento stretto: la lista esplicita era già quella che vale, e il ripiego permissivo scatta solo quando la variabile manca. Impostandola, la restrizione è già attiva.

Il rischio però si sposta: il confronto con l'header `Origin` del browser è un'**uguaglianza esatta di stringhe**, quindi un valore mal formattato blocca l'app web **senza un errore che lo spieghi** — si vedono solo chiamate fallite dal browser.

## Cosa cambia

- **Barra finale rimossa**: `https://esempio.it/` non corrisponde all'Origin `https://esempio.it`. È l'errore di configurazione più frequente, e il più difficile da diagnosticare.
- **Voce senza `http://` o `https://`** segnalata a log invece di fallire in silenzio.
- **Lista degli origin effettivamente ammessi stampata all'avvio**, così la configurazione diventa verificabile dai log del deploy: se un dominio atteso non compare lì, il browser lo bloccherà.

Nessun cambio di comportamento per una configurazione già corretta.

## Verifiche

- `cd server && node --test`: 185/185 verdi.
- Provato in avvio con un valore volutamente sporco (`"https://…onrender.com/, travelswapai.it ,https://app.travelswap.it"`): barra finale rimossa, voce senza protocollo ignorata con avviso, lista finale corretta, `/health` risponde.
- Nessuna migration.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_