### PR TITLE
Il bypass della firma dei webhook non si attiva più senza NODE_ENV

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -211,6 +211,22 @@ async function publishMessengerListing({ senderId, channel, send }, mid, s) {
 // --- Healthcheck / Debug ---
 const isDev = process.env.NODE_ENV === 'development';
 
+// NODE_ENV non impostata è una configurazione ambigua: non è sviluppo (i
+// debug restano chiusi) ma nemmeno produzione dichiarata, quindi Express
+// continua a rispondere con lo stack trace sugli errori non gestiti. Meglio
+// dirlo all'avvio che scoprirlo da una risposta HTTP.
+if (!process.env.NODE_ENV) {
+  console.warn('[ENV] NODE_ENV non impostata: in produzione va valorizzata a "production" (Express altrimenti espone gli stack trace).');
+}
+
+// Una configurazione che disattiva un controllo di sicurezza non deve essere
+// silenziosa: se la variabile è accesa ma l'ambiente non è sviluppo, il
+// bypass NON si applica (vedi /webhooks/facebook) e va detto, altrimenti chi
+// l'ha impostata crede che sia attivo.
+if (process.env.ALLOW_UNVERIFIED_WEBHOOK === 'true' && !isDev) {
+  console.warn('[SECURITY] ALLOW_UNVERIFIED_WEBHOOK=true ma NODE_ENV non è "development": la firma dei webhook resta OBBLIGATORIA. Rimuovi la variabile: fuori dallo sviluppo non serve.');
+}
+
 app.get('/health', (_req, res) => res.json({ ok: true }));
 
 // Endpoint di debug: SOLO in dev (rivelano stato di configurazione/ambiente)
@@ -323,9 +339,22 @@ app.get('/webhooks/facebook', (req, res) => {
 
 // --- Webhook receiver (POST) ---
 app.post('/webhooks/facebook', async (req, res) => {
-  // Il bypass della firma è consentito SOLO fuori da produzione
+  // Il bypass della firma vale SOLO in sviluppo DICHIARATO.
+  //
+  // Prima la condizione era `NODE_ENV !== 'production'`. Sembra equivalente,
+  // ma NODE_ENV non impostata è il default di molti hosting (Render incluso,
+  // se non la si aggiunge a mano): in quel caso il confronto è vero, e
+  // bastava ALLOW_UNVERIFIED_WEBHOOK=true perché il server accettasse in
+  // PRODUZIONE webhook non firmati da chiunque conoscesse l'URL. Da lì si
+  // pubblicano annunci a nome dell'account di default, si fanno partire
+  // chiamate OpenAI a spese nostre e si fa scrivere il bot a utenti
+  // arbitrari.
+  //
+  // `=== 'development'` inverte il default: senza NODE_ENV la firma è
+  // sempre verificata. Una configurazione mancante ora fallisce in modo
+  // sicuro, non permissivo.
   const allow = process.env.ALLOW_UNVERIFIED_WEBHOOK === 'true'
-    && process.env.NODE_ENV !== 'production';
+    && process.env.NODE_ENV === 'development';
   if (!allow && !isDev && !verifyFacebookSignature(req)) {
     return res.sendStatus(403);
   }


### PR DESCRIPTION
## Causa

La scorciatoia per testare i webhook in locale era condizionata così:

```js
const allow = process.env.ALLOW_UNVERIFIED_WEBHOOK === 'true'
  && process.env.NODE_ENV !== 'production';
```

Il secondo termine è una negazione: è vero non solo in sviluppo, ma anche
quando `NODE_ENV` **non è impostata affatto**. Render non valorizza
`NODE_ENV` di default, quindi in produzione la condizione era vera e — con
`ALLOW_UNVERIFIED_WEBHOOK=true` presente fra le variabili d'ambiente — la
verifica della firma HMAC veniva saltata: chiunque conoscesse l'URL poteva
inviare payload `/webhooks/facebook` non firmati e farli processare come se
arrivassero da Meta (creazione annunci, messaggi, sessioni bot).

Riprodotto in locale prima del fix: `ALLOW_UNVERIFIED_WEBHOOK=true` con
`NODE_ENV` non impostata → POST non firmato → **HTTP 200**.

## Fix

Condizione ribaltata in positivo, così il default (variabile assente) è il
comportamento sicuro:

```js
const allow = process.env.ALLOW_UNVERIFIED_WEBHOOK === 'true'
  && process.env.NODE_ENV === 'development';
```

Ora il bypass richiede un'affermazione esplicita di essere in sviluppo:
nessun valore di `NODE_ENV` diverso da `development` lo attiva.

Aggiunti due avvisi all'avvio, perché una configurazione sbagliata resti
visibile invece di essere silenziosa:

- `NODE_ENV` non impostata → ricorda che in produzione va valorizzata;
- `ALLOW_UNVERIFIED_WEBHOOK=true` fuori da `development` → dichiara che la
  firma resta comunque obbligatoria, così chi legge i log non crede che il
  flag stia facendo qualcosa.

## Verifiche

- Riprodotto il buco e verificato il fix in locale:
  - `ALLOW_UNVERIFIED_WEBHOOK=true`, `NODE_ENV` assente → **403** (prima 200)
  - `ALLOW_UNVERIFIED_WEBHOOK=true`, `NODE_ENV=development` → **200**
    (il test in locale continua a funzionare)
  - richiesta firmata correttamente → **200** in ogni configurazione
- `cd server && node --test` → **185/185 verdi**

## ⚠️ Azione manuale

Su Render, nelle Environment Variables:

1. **rimuovere** `ALLOW_UNVERIFIED_WEBHOOK` (dopo questa PR non fa più nulla
   in produzione, ma non ha motivo di restare);
2. **impostare** `NODE_ENV=production`.

Il punto 2 non serve al fix dei webhook — quello è chiuso dal codice a
prescindere — ma serve a Express: senza `NODE_ENV=production` continua a
restituire lo stack trace nelle risposte di errore non gestite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_