### PR TITLE
Concorrenza AI dei match: due livelli separati e picco da 12 a 4

### DIFF
--- a/server/src/ai/score.js
+++ b/server/src/ai/score.js
@@ -1,6 +1,7 @@
 // server/src/ai/score.js
 import OpenAI from "openai";
 import { mapWithConcurrency } from "../lib/concurrency.js";
+import { envInt } from "../lib/envNumber.js";
 
 // -----------------------------------------------------------------------------
 // Config
@@ -14,10 +15,20 @@ const MODEL = process.env.MATCH_AI_MODEL || "gpt-4o-mini";
 const TEMPERATURE = Number(process.env.MATCH_AI_TEMP ?? 0); // default: deterministico
 const TOP_P = Number(process.env.MATCH_AI_TOP_P ?? 1);
 const MAX_LISTINGS_PER_CALL = Number(process.env.MATCH_AI_BATCH ?? 40);
-// Batch AI in volo contemporaneamente: basso di proposito, alzarlo troppo
-// espone ai rate limit di OpenAI (429) che costerebbero più della latenza
-// risparmiata.
-const AI_BATCH_CONCURRENCY = Number(process.env.MATCH_AI_CONCURRENCY ?? 3);
+// Batch AI in volo contemporaneamente DENTRO una singola chiamata a
+// scoreWithAI. È il livello INTERNO: chi chiama (models/matches.js) lancia a
+// sua volta più sorgenti in parallelo, quindi le due concorrenze si
+// MOLTIPLICANO.
+//
+// Prima questa costante leggeva MATCH_AI_CONCURRENCY, la stessa variabile del
+// livello esterno: con i default di allora (esterno 4, interno 3) il picco
+// reale era di 12 richieste OpenAI contemporanee, non 4 — ed è quello che ha
+// fatto sbattere l'account contro il limite di token al minuto (429). Peggio,
+// abbassare la variabile per rimediare abbassava ENTRAMBI i livelli
+// insieme, quindi l'effetto era quadratico e imprevedibile.
+//
+// Ora ha una variabile propria: i due livelli si regolano separatamente.
+const AI_BATCH_CONCURRENCY = envInt('MATCH_AI_BATCH_CONCURRENCY', 2);
 const MATCH_AI_TIMEOUT_MS = Number(process.env.MATCH_AI_TIMEOUT_MS ?? 45000); // default 45s
 
 

--- a/server/src/lib/envNumber.js
+++ b/server/src/lib/envNumber.js
@@ -1,0 +1,28 @@
+// Lettura di un numero da variabile d'ambiente, con default e minimo.
+//
+// Nasce da due modi diversi di leggere la STESSA variabile che convivevano nel
+// codice: `Number(process.env.X ?? 4)` e `Number(process.env.X || 4)`.
+// Sembrano equivalenti e non lo sono:
+//
+//   X non impostata   ->  ?? dà 4,  || dà 4        uguali
+//   X=""              ->  ?? dà 0 (NaN mancato),   || dà 4
+//   X="0"             ->  ?? dà 0,   || dà 4
+//   X="due"           ->  ?? dà NaN, || dà NaN
+//
+// Uno 0 o un NaN come limite di concorrenza è peggio di un valore sbagliato:
+// un pool con limite 0 non avvia nessun worker e il lavoro non finisce mai.
+// Qui il valore viene sempre riportato dentro un intervallo sensato.
+
+/**
+ * @param {string} name  nome della variabile d'ambiente
+ * @param {number} fallback valore da usare se assente, vuota o non numerica
+ * @param {{min?: number, max?: number}} [bounds]
+ * @returns {number} intero dentro [min, max]
+ */
+export function envInt(name, fallback, { min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const raw = process.env[name];
+  const parsed = raw == null || String(raw).trim() === '' ? NaN : Number(raw);
+  const value = Number.isFinite(parsed) ? Math.trunc(parsed) : Number(fallback);
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}

--- a/server/src/models/matches.js
+++ b/server/src/models/matches.js
@@ -12,6 +12,7 @@ import { listActiveListingsOfUser, listMatchesForFromMany, getLatestUserSnapshot
 import { listActiveListings } from './listings.js';
 import { sendExpoPush } from '../lib/push.js';
 import { mapWithConcurrency } from '../lib/concurrency.js';
+import { envInt } from '../lib/envNumber.js';
 
 // Snapshot rinfrescati in parallelo dopo propagate/retract. Tetto basso: ogni
 // snapshot fa comunque scritture su match_snapshots, e questo gira dentro una
@@ -177,7 +178,12 @@ const tasks = fromListings.map((f) => async () => {
 });
 
 // esegui con concorrenza limitata (configurabile via env)
-const CONCURRENCY = Number(process.env.MATCH_AI_CONCURRENCY || 4);
+// Sorgenti elaborate in parallelo. È il livello ESTERNO: ogni task qui dentro
+// chiama scoreWithAI, che a sua volta apre fino a MATCH_AI_BATCH_CONCURRENCY
+// richieste OpenAI. Il picco di chiamate contemporanee è il PRODOTTO dei due
+// (prima 4 x 3 = 12, ora 2 x 2 = 4): è la moltiplicazione che ha portato
+// l'account a superare il limite di token al minuto.
+const CONCURRENCY = envInt('MATCH_AI_CONCURRENCY', 2);
 const rows = await runPool(tasks, CONCURRENCY);
 if (rows.length) {
   // Ricalcolo riuscito: ORA è sicuro sostituire i match precedenti delle

--- a/server/test/envNumber.test.js
+++ b/server/test/envNumber.test.js
@@ -1,0 +1,65 @@
+// Lettura dei limiti di concorrenza dall'ambiente (lib/envNumber.js).
+//
+// Un limite di concorrenza sbagliato non dà un errore: dà un comportamento.
+// Con 0 il pool non avvia nessun worker e il ricalcolo non finisce mai; con
+// NaN il confronto fallisce silenziosamente. Questi test fissano il
+// comportamento per ogni valore che l'ambiente può davvero contenere,
+// stringhe vuote e spazi compresi (una variabile "svuotata" su Render resta
+// impostata, con valore "").
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { envInt } from '../src/lib/envNumber.js';
+
+const NOME = 'TEST_ENV_INT_TMP';
+
+function conValore(v, fn) {
+  const prima = process.env[NOME];
+  if (v === undefined) delete process.env[NOME];
+  else process.env[NOME] = v;
+  try { fn(); } finally {
+    if (prima === undefined) delete process.env[NOME];
+    else process.env[NOME] = prima;
+  }
+}
+
+test('variabile assente: vale il default', () => {
+  conValore(undefined, () => assert.equal(envInt(NOME, 2), 2));
+});
+
+test('variabile valida: vince sull\'ambiente', () => {
+  conValore('5', () => assert.equal(envInt(NOME, 2), 5));
+});
+
+test('stringa vuota o soli spazi: vale il default, non 0', () => {
+  // È il caso che rompeva: Number('') è 0, e con `?? default` la stringa
+  // vuota non è nullish, quindi passava e diventava un limite di 0.
+  conValore('',    () => assert.equal(envInt(NOME, 2), 2));
+  conValore('   ', () => assert.equal(envInt(NOME, 2), 2));
+});
+
+test('valore non numerico: vale il default, non NaN', () => {
+  conValore('due',  () => assert.equal(envInt(NOME, 3), 3));
+  conValore('4abc', () => assert.equal(envInt(NOME, 3), 3));
+});
+
+test('zero e negativi sono riportati al minimo', () => {
+  // Un pool con limite 0 non avvia nessun worker: il lavoro resta appeso.
+  conValore('0',  () => assert.equal(envInt(NOME, 2), 1));
+  conValore('-7', () => assert.equal(envInt(NOME, 2), 1));
+});
+
+test('i decimali vengono troncati a intero', () => {
+  conValore('3.9', () => assert.equal(envInt(NOME, 2), 3));
+});
+
+test('il tetto massimo, quando indicato, viene rispettato', () => {
+  conValore('999', () => assert.equal(envInt(NOME, 2, { max: 10 }), 10));
+});
+
+test('un default assurdo non produce comunque un limite inutilizzabile', () => {
+  conValore(undefined, () => {
+    assert.equal(envInt(NOME, 0), 1);
+    assert.equal(envInt(NOME, NaN), 1);
+    assert.equal(envInt(NOME, undefined), 1);
+  });
+});


### PR DESCRIPTION
## Il numero non era quello che sembrava

Le chiamate OpenAI del ricalcolo match sono **annidate su due livelli**: `models/matches.js` elabora N sorgenti in parallelo, e **ogni** sorgente chiama `scoreWithAI`, che a sua volta manda più batch in parallelo. Le due concorrenze si **moltiplicano**.

Erano governate dalla **stessa** variabile `MATCH_AI_CONCURRENCY`, letta però con due default diversi:

| Livello | File | Default |
|---|---|---|
| esterno (sorgenti) | `models/matches.js` | `\|\| 4` |
| interno (batch) | `ai/score.js` | `?? 3` |

Il picco reale era quindi di **12 richieste OpenAI contemporanee**, non 4 — ed è quel picco ad aver portato l'account oltre il limite di token al minuto (il `429` visto durante un Check AI). Peggio: abbassare la variabile per rimediare abbassava **entrambi** i livelli insieme, con effetto quadratico e difficile da prevedere.

## Fix

Due variabili distinte, default più bassi:

```
MATCH_AI_CONCURRENCY        2   (esterno: sorgenti in parallelo)
MATCH_AI_BATCH_CONCURRENCY  2   (interno: batch dentro scoreWithAI)
```

Picco: **2 × 2 = 4** chiamate contemporanee invece di 12. Il ricalcolo dei match diventa più lento — è il compromesso scelto rispetto ad alzare il tier OpenAI.

Entrambe restano regolabili da Render senza toccare il codice, e ora si regolano **indipendentemente**.

## Lettura dell'ambiente

I due punti leggevano la variabile in due modi non equivalenti, `Number(x ?? 4)` e `Number(x || 4)`. Con la variabile **svuotata** — che su Render resta impostata, con valore `""` — il primo dà `0` e il secondo `4`. Un limite di concorrenza a 0 non è un valore sbagliato: è un pool che non avvia nessun worker e non finisce mai.

Nuovo helper `envInt` che riporta sempre il valore dentro un intervallo utilizzabile.

## Verifiche

- `cd server && node --test` → **221/221 verdi** (erano 213, +8 nuovi)
- nuovo `server/test/envNumber.test.js`: variabile assente, vuota, con soli spazi, non numerica, zero, negativa, decimale, sopra il tetto, e default assurdo — nessuno di questi casi produce `0` o `NaN` come limite
- nessuna modifica lato client, bundle web non toccato

Nessuna migration in questa PR.

## Non toccato

`CHAIN_AI_CONCURRENCY` (default 3, percorso delle catene di scambio) resta com'è: non è annidato, quindi il suo picco è davvero 3. Se il 429 si ripresenta, è il prossimo candidato.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_