### PR TITLE
Le lacune dichiarate dall&#39;AI vengono verificate prima di mostrarle

### DIFF
--- a/server/src/services/trust/aiTrust.js
+++ b/server/src/services/trust/aiTrust.js
@@ -1,5 +1,6 @@
 // server/src/services/trust/aiTrust.js
 import { createOpenAIClient } from "../../lib/openaiClient.js";
+import { reasonWithoutFalseClaims, fixesWithoutFalseClaims } from "./falseClaims.js";
 
 // Bug preesistente corretto: il costruttore di OpenAI lancia un'eccezione
 // a livello di modulo se la chiave manca — a import time, prima che il
@@ -95,25 +96,29 @@ export async function aiTrustReview(listing, heur = {}, locale = 'it') {
       "e un msg che spiega la discrepanza in modo concreto. " +
       "SEMPRE, anche quando non c'è nessun flag da segnalare, spiega in " +
       "'textReason' PERCHÉ hai assegnato quel 'textScore': una sola frase " +
-      "breve e CONCRETA, riferita a questo annuncio, che dica cosa manca o " +
-      "cosa lo rende meno solido (es. 'la descrizione non indica orario e " +
-      "classe del biglietto', 'il titolo ripete i dati senza aggiungere " +
-      "informazioni utili'). Se il punteggio non è massimo un motivo esiste " +
-      "sempre: NON rispondere con frasi generiche tipo 'va bene' o " +
-      "'nessun problema'. Se e solo se 'textScore' è 100, lascia " +
-      "'textReason' come stringa vuota. Non citare mai il punteggio " +
-      "numerico dentro 'textReason'. " +
+      "breve e CONCRETA, riferita a QUESTO annuncio, che dica cosa lo rende " +
+      "meno solido. Se il punteggio non è massimo un motivo esiste sempre: " +
+      "NON rispondere con frasi generiche tipo 'va bene' o 'nessun " +
+      "problema'. Se e solo se 'textScore' è 100, lascia 'textReason' come " +
+      "stringa vuota. Non citare mai il punteggio numerico dentro " +
+      "'textReason'. " +
+      // Nessun esempio di frase, e nessun elenco di dati "tipicamente
+      // mancanti": erano lì per spiegare la regola, ma il modello li copiava
+      // alla lettera. Un annuncio la cui descrizione diceva "546 seconda
+      // classe" si è visto rispondere che mancavano il numero del treno e la
+      // classe — cioè le due voci nominate qui come esempio. Le istruzioni
+      // restano astratte di proposito; la verifica vera è deterministica,
+      // lato server (services/trust/falseClaims.js).
       "REGOLA VINCOLANTE su 'textReason' e su ogni 'msg': prima di scrivere " +
       "che un dato MANCA o non è indicato, RILEGGI l'oggetto Listing qui " +
       "sotto e cerca quel dato in TUTTI i campi — 'title', 'description' e i " +
       "campi strutturati (type, origin, destination, location, startDate, " +
-      "endDate, price). Un dato presente anche in UNO SOLO di questi campi " +
-      "NON è mancante e non va segnalato come tale, nemmeno se compare in " +
-      "una forma diversa da quella che ti aspetti (es. il numero del treno " +
-      "scritto solo nella descrizione, l'orario dentro il testo invece che " +
-      "nella data). Segnala solo ciò che hai VERIFICATO essere assente: se " +
-      "non sei certo che manchi, scegli un altro motivo reale oppure " +
-      "commenta la qualità di ciò che è scritto, mai inventare una lacuna. " +
+      "endDate, price) — anche se compare in una forma diversa da quella che " +
+      "ti aspetti. Un dato presente anche in UNO SOLO di questi campi NON è " +
+      "mancante. Segnala solo ciò che hai VERIFICATO essere assente: se non " +
+      "sei certo che manchi, preferisci commentare la QUALITÀ di ciò che è " +
+      "scritto (chiarezza, ordine, informazioni utili all'acquirente) invece " +
+      "di dichiarare una lacuna. Mai inventare una lacuna. " +
       "Restituisci SOLO un JSON con la forma: " +
       "{ textScore:number(0-100), textReason:string, imageScore:number(0-100), flags:[{code:string,msg:string}], suggestedFixes:[{field:string,suggestion:string}] } " +
       `I valori di 'msg', 'suggestion' e 'textReason' devono essere scritti in ${LANG_NAME} (i 'code' restano invariati, in inglese maiuscolo). ` +
@@ -196,10 +201,15 @@ export async function aiTrustReview(listing, heur = {}, locale = 'it') {
     const clamp01 = (n) => Math.min(100, Math.max(0, Number(n ?? 0)));
     const out = {
       textScore: clamp01(parsed.textScore ?? heur?.score ?? 55),
-      textReason: cleanTextReason(parsed.textReason),
+      // La spiegazione e i suggerimenti passano da un controllo che NON si
+      // fida del modello: un'affermazione "manca X" viene confrontata con
+      // l'annuncio, e se X c'è la frase viene scartata. Una spiegazione falsa
+      // è peggio di nessuna spiegazione — manda a correggere qualcosa che è
+      // già a posto.
+      textReason: reasonWithoutFalseClaims(cleanTextReason(parsed.textReason), listing),
       imageScore: clamp01(parsed.imageScore ?? (imageUrls.length ? 60 : 50)),
       flags: Array.isArray(parsed.flags) ? parsed.flags : [],
-      suggestedFixes: Array.isArray(parsed.suggestedFixes) ? parsed.suggestedFixes : [],
+      suggestedFixes: fixesWithoutFalseClaims(parsed.suggestedFixes, listing),
     };
 
     return out;

--- a/server/src/services/trust/falseClaims.js
+++ b/server/src/services/trust/falseClaims.js
@@ -1,0 +1,151 @@
+// Verifica deterministica delle affermazioni "manca X" prodotte dall'AI.
+//
+// Caso reale che ha motivato questo file: un annuncio con descrizione
+// "Vendo treno Palermo mazara 546 seconda classe per il 1 agosto 08:07/10:20"
+// riceveva come spiegazione del punteggio "La descrizione non specifica il
+// numero del treno e la classe del biglietto" — due dati che sono scritti
+// nella descrizione, uno accanto all'altro.
+//
+// Il prompt conteneva già una regola vincolante contro questo errore, ma la
+// regola stessa nominava "il numero del treno" e "la classe del biglietto"
+// come esempi: il modello ha restituito esattamente quelle due voci. Gli
+// esempi in un prompt orientano l'output anche quando servono a vietare un
+// comportamento, quindi la regola scritta non basta e serve un controllo che
+// non dipenda dal modello.
+//
+// Perché SOPPRIMERE e non correggere: CLAUDE.md chiede che il "perché" del
+// punteggio sia sempre visibile, ma una spiegazione FALSA è peggio di nessuna
+// spiegazione — manda l'utente a "sistemare" qualcosa che è già a posto, e gli
+// fa credere che sia l'app a sbagliare (è esattamente quello che è successo).
+// Non si riscrive la frase perché non si può sapere quale motivo VERO l'AI
+// avrebbe dovuto dare al suo posto: inventarlo sarebbe lo stesso errore.
+
+/** Testo su cui l'AI ha giudicato: titolo + descrizione. */
+function listingText(listing) {
+  return [listing?.title, listing?.description].filter(Boolean).join(' \n ');
+}
+
+// Verbi con cui si afferma che un dato è assente.
+const MISSING_CLAIM_RE =
+  /(non\s+(?:specific|indic|riport|menzion|precis|chiaris|esplicit)\w*|non\s+(?:è|e'|sono)\s+(?:indicat|specificat|riportat|precisat)\w*|manca\w*|assent\w*|priv[oa]\s+di|omette|omess\w*)/i;
+
+/** Numero di treno scritto nel testo, in una delle forme d'uso comune. */
+function hasTrainNumber(text) {
+  // "treno 546", "treno n. 546", "treno numero 546"
+  if (/\btreno\s*(?:n(?:umero)?[.°]?\s*)?\d{2,5}\b/i.test(text)) return true;
+  // sigle di categoria: FR 9512, IC 546, REG 12345, EC 40, ITL 8991
+  if (/\b(?:fr|fa|fb|ic|icn|reg|rv|ec|en|itl|es)\s*\.?\s*\d{2,5}\b/i.test(text)) return true;
+
+  // Numero isolato di 3-5 cifre: è quasi sempre il numero del treno, ma va
+  // escluso ciò che numericamente gli somiglia — un anno e un importo.
+  for (const m of text.matchAll(/\b(\d{3,5})\b/g)) {
+    const n = m[1];
+    if (/^(?:19|20)\d{2}$/.test(n)) continue;                     // anno
+    const before = text.slice(Math.max(0, m.index - 2), m.index);
+    const after = text.slice(m.index + n.length, m.index + n.length + 6);
+    if (/[€$£]\s*$/.test(before)) continue;                       // "€546"
+    if (/^\s*(?:€|\$|£|eur\b|euro\b)/i.test(after)) continue;     // "546 euro"
+    return true;
+  }
+  return false;
+}
+
+function hasTicketClass(text) {
+  return /\b(?:prima|seconda|1[ªa°]?|2[ªa°]?)\s*classe\b/i.test(text)
+    || /\bclasse\s*(?:prima|seconda|1|2)\b/i.test(text)
+    || /\b(?:business|standard|economy|premium|executive|first\s+class|second\s+class)\b/i.test(text);
+}
+
+function hasTime(text, listing) {
+  if (/\b\d{1,2}[:.]\d{2}\b/.test(text)) return true;
+  // startDate con una componente oraria diversa da mezzanotte
+  const d = listing?.startDate ? new Date(listing.startDate) : null;
+  if (d && Number.isFinite(d.getTime()) && /\d{2}:\d{2}/.test(String(listing.startDate))) return true;
+  return false;
+}
+
+function hasPrice(text, listing) {
+  if (Number(listing?.price) > 0) return true;
+  return /\d\s*(?:€|eur\b|euro\b)/i.test(text) || /(?:€|\$|£)\s*\d/.test(text);
+}
+
+function hasDate(text, listing) {
+  if (listing?.startDate) return true;
+  if (/\b\d{1,2}[\/.-]\d{1,2}(?:[\/.-]\d{2,4})?\b/.test(text)) return true;
+  return /\b\d{1,2}\s+(?:gen|feb|mar|apr|mag|giu|lug|ago|set|ott|nov|dic)\w*/i.test(text);
+}
+
+function hasRoute(text, listing) {
+  if (listing?.origin && listing?.destination) return true;
+  if (listing?.location) return true;
+  return false;
+}
+
+// Ogni voce: come l'AI la NOMINA quando la dichiara mancante, e come si
+// verifica che in realtà ci sia.
+const CLAIMABLE_ITEMS = [
+  { id: 'numero_treno', named: /numero\s+(?:del\s+)?treno|codice\s+(?:del\s+)?treno|train\s+number/i, isPresent: (t) => hasTrainNumber(t) },
+  { id: 'classe',       named: /\bclasse\b|\bclass\b/i,                                              isPresent: (t) => hasTicketClass(t) },
+  { id: 'orario',       named: /\borari?o?\b|\bora\s+di\s+(?:partenza|arrivo)\b/i,                   isPresent: (t, l) => hasTime(t, l) },
+  { id: 'prezzo',       named: /\bprezzo\b|\bcosto\b|\bimporto\b/i,                                  isPresent: (t, l) => hasPrice(t, l) },
+  { id: 'data',         named: /\bdata\b|\bdate\b/i,                                                 isPresent: (t, l) => hasDate(t, l) },
+  { id: 'tratta',       named: /\btratta\b|\bpercorso\b|\bdestinazione\b|\bpartenza\b/i,             isPresent: (t, l) => hasRoute(t, l) },
+];
+
+/**
+ * Voci che una frase dichiara mancanti pur essendo presenti nell'annuncio.
+ * Funzione pura: nessuna chiamata esterna, verificabile da sola.
+ *
+ * @param {string} sentence  frase prodotta dall'AI (textReason o suggestion)
+ * @param {object} listing   l'annuncio valutato
+ * @returns {string[]} id delle voci contraddette (vuoto se la frase regge)
+ */
+export function falseMissingClaims(sentence, listing) {
+  const s = String(sentence || '');
+  if (!s.trim()) return [];
+  if (!MISSING_CLAIM_RE.test(s)) return [];   // non afferma che manchi nulla
+
+  const text = listingText(listing);
+  if (!text.trim()) return [];                // niente con cui confrontare
+
+  return CLAIMABLE_ITEMS
+    .filter((item) => item.named.test(s) && item.isPresent(text, listing))
+    .map((item) => item.id);
+}
+
+/**
+ * La spiegazione del punteggio, se regge; null se afferma che manca un dato
+ * che invece c'è. Basta UNA voce contraddetta: una frase che contiene
+ * un'affermazione falsa non è mostrabile, e non si può ritagliarne la parte
+ * buona senza riscriverla.
+ */
+export function reasonWithoutFalseClaims(reason, listing) {
+  const bad = falseMissingClaims(reason, listing);
+  if (!bad.length) return reason ?? null;
+  console.warn(`[trustscore] textReason soppresso, dichiara mancanti dati presenti: ${bad.join(', ')} — "${reason}"`);
+  return null;
+}
+
+/**
+ * I suggerimenti che non chiedono di aggiungere qualcosa che c'è già.
+ * Qui si filtra voce per voce, perché ogni suggerimento è indipendente dagli
+ * altri: gli altri restano utili.
+ */
+export function fixesWithoutFalseClaims(fixes, listing) {
+  if (!Array.isArray(fixes)) return [];
+  return fixes.filter((f) => {
+    const testo = [f?.suggestion, f?.msg].filter(Boolean).join(' ');
+    // "Aggiungere il numero del treno" non contiene un verbo di assenza ma
+    // afferma la stessa cosa: chiedere di aggiungere un dato presente è
+    // altrettanto sbagliato.
+    const comeAssenza = /\b(aggiung\w*|inserisc\w*|specific\w*|indic\w*|precis\w*|complet\w*)\b/i.test(testo)
+      ? `non specifica ${testo}`
+      : testo;
+    const bad = falseMissingClaims(comeAssenza, listing);
+    if (bad.length) {
+      console.warn(`[trustscore] suggerimento soppresso, dati già presenti: ${bad.join(', ')} — "${testo}"`);
+      return false;
+    }
+    return true;
+  });
+}

--- a/server/test/falseClaims.test.js
+++ b/server/test/falseClaims.test.js
@@ -1,0 +1,126 @@
+// Verifica delle affermazioni "manca X" prodotte dall'AI (falseClaims.js).
+//
+// Caso reale di partenza: descrizione "Vendo treno Palermo mazara 546 seconda
+// classe per il 1 agosto 08:07/10:20", spiegazione del punteggio "La
+// descrizione non specifica il numero del treno e la classe del biglietto".
+// Entrambi i dati sono scritti lì, uno accanto all'altro.
+//
+// I test tengono insieme le due direzioni, che tirano da parti opposte:
+// sopprimere le frasi FALSE senza sopprimere quelle VERE, perché una
+// spiegazione mancante è comunque una perdita (CLAUDE.md: il perché del
+// punteggio deve restare visibile).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  falseMissingClaims, reasonWithoutFalseClaims, fixesWithoutFalseClaims,
+} from '../src/services/trust/falseClaims.js';
+
+const ANNUNCIO = {
+  title: 'Vendo treno Palermo → Mazara solo andata',
+  description: 'Vendo treno Palermo mazara 546 seconda classe per il 1 agosto 08:07/10:20',
+  type: 'train', origin: 'Palermo', destination: 'Mazara del Vallo',
+  startDate: '2026-08-01T08:07:00Z', price: 30,
+};
+
+test('il caso reale: la frase dichiara mancanti due dati che ci sono', () => {
+  const frase = 'La descrizione non specifica il numero del treno e la classe del biglietto.';
+  const bad = falseMissingClaims(frase, ANNUNCIO);
+  assert.deepEqual(bad.sort(), ['classe', 'numero_treno']);
+  assert.equal(reasonWithoutFalseClaims(frase, ANNUNCIO), null);
+});
+
+test('una spiegazione VERA non viene toccata', () => {
+  // Nessuno di questi dati è nell'annuncio, oppure la frase non parla di
+  // assenza: deve passare intatta.
+  for (const frase of [
+    'Il titolo ripete la descrizione senza aggiungere informazioni utili.',
+    'La descrizione non indica il nome del titolare del biglietto.',
+    'Il testo è scritto tutto in minuscolo e si legge con fatica.',
+    'La descrizione non specifica se il biglietto è rimborsabile.',
+  ]) {
+    assert.equal(reasonWithoutFalseClaims(frase, ANNUNCIO), frase, frase);
+  }
+});
+
+test('una frase che non parla di assenze non viene mai analizzata', () => {
+  const frase = 'La classe del biglietto è indicata chiaramente.';
+  assert.deepEqual(falseMissingClaims(frase, ANNUNCIO), []);
+});
+
+test('il numero del treno è riconosciuto nelle forme d\'uso comune', () => {
+  const frase = 'Manca il numero del treno.';
+  for (const desc of [
+    'treno 546 per Palermo', 'treno n. 9512', 'treno numero 12345',
+    'FR 9512 in partenza', 'IC 546', 'REG 12345', 'Regionale 546 delle 08:07',
+  ]) {
+    assert.ok(
+      falseMissingClaims(frase, { description: desc }).includes('numero_treno'),
+      `non riconosciuto in: ${desc}`,
+    );
+  }
+});
+
+test('un anno o un importo non vengono scambiati per numero di treno', () => {
+  // Se li scambiasse, sopprimerebbe una segnalazione VERA.
+  const frase = 'Manca il numero del treno.';
+  for (const desc of [
+    'Biglietto per il 1 agosto 2026',
+    'Prezzo 1200 euro trattabili',
+    'Costo €1500 tutto compreso',
+  ]) {
+    assert.deepEqual(
+      falseMissingClaims(frase, { description: desc }), [],
+      `falso positivo su: ${desc}`,
+    );
+  }
+});
+
+test('la classe è riconosciuta nelle sue diverse forme', () => {
+  const frase = 'Non è indicata la classe.';
+  for (const desc of [
+    'seconda classe', 'prima classe', '2ª classe', '1a classe',
+    'posto business', 'tariffa standard', 'economy',
+  ]) {
+    assert.ok(
+      falseMissingClaims(frase, { description: desc }).includes('classe'),
+      `non riconosciuta in: ${desc}`,
+    );
+  }
+});
+
+test('orario, prezzo e data si verificano anche sui campi strutturati', () => {
+  const soloStrutturati = { title: 'Treno', description: 'Cedo il posto.', startDate: '2026-08-01T08:07:00Z', price: 30 };
+  assert.ok(falseMissingClaims('Manca il prezzo.', soloStrutturati).includes('prezzo'));
+  assert.ok(falseMissingClaims('Manca la data.', soloStrutturati).includes('data'));
+  assert.ok(falseMissingClaims("Non è indicato l'orario.", soloStrutturati).includes('orario'));
+});
+
+test('senza testo e senza campi non si sopprime nulla', () => {
+  // Qui l'AI potrebbe avere ragione: niente con cui contraddirla.
+  assert.deepEqual(falseMissingClaims('Manca il numero del treno.', {}), []);
+  assert.deepEqual(falseMissingClaims('Manca il prezzo.', { title: '', description: '' }), []);
+});
+
+test('input vuoti o assenti non fanno esplodere nulla', () => {
+  assert.deepEqual(falseMissingClaims('', ANNUNCIO), []);
+  assert.deepEqual(falseMissingClaims(null, ANNUNCIO), []);
+  assert.deepEqual(falseMissingClaims('Manca tutto.', null), []);
+  assert.equal(reasonWithoutFalseClaims(null, ANNUNCIO), null);
+});
+
+test('i suggerimenti si filtrano uno per uno, non in blocco', () => {
+  const fixes = [
+    { field: 'description', suggestion: 'Aggiungere il numero del treno e confermare la classe.' },
+    { field: 'description', suggestion: 'Indicare se il biglietto è cedibile a terzi.' },
+    { field: 'images', suggestion: 'Aggiungere una foto del biglietto.' },
+  ];
+  const out = fixesWithoutFalseClaims(fixes, ANNUNCIO);
+  assert.equal(out.length, 2, 'deve cadere solo il primo');
+  assert.ok(out.every((f) => !/numero del treno/i.test(f.suggestion)));
+});
+
+test('fixesWithoutFalseClaims regge input non validi', () => {
+  assert.deepEqual(fixesWithoutFalseClaims(null, ANNUNCIO), []);
+  assert.deepEqual(fixesWithoutFalseClaims(undefined, ANNUNCIO), []);
+  assert.deepEqual(fixesWithoutFalseClaims([{}], ANNUNCIO), [{}]);
+});


### PR DESCRIPTION
Annuncio con descrizione *"Vendo treno Palermo mazara **546** **seconda classe** per il 1 agosto 08:07/10:20"*, spiegazione del punteggio:

> La descrizione non specifica il numero del treno e la classe del biglietto.

Sono scritti lì, uno accanto all'altro. Stesso errore nel suggerimento AI, che chiedeva di aggiungerli.

## Perché la regola scritta non bastava

Il prompt conteneva **già** una `REGOLA VINCOLANTE` contro esattamente questo errore. Il problema è che la regola, per spiegarsi, nominava *"il numero del treno"* e *"la classe del biglietto"* come esempi di dati da cercare bene prima di dichiararli assenti — e il modello ha restituito quelle due voci.

Anche un esempio usato per **vietare** un comportamento orienta l'output: erano le uniche due voci concrete nel prompt, e sono diventate la risposta. Per questo il fix precedente, che agiva solo sul testo delle istruzioni, non ha retto.

## Due interventi

**1. Il prompt non contiene più esempi di frase** né elenchi di dati "tipicamente mancanti". Le istruzioni restano astratte, e quando l'AI non è certa che un dato manchi le si chiede di commentare la **qualità** di ciò che è scritto invece di dichiarare una lacuna.

**2. Controllo deterministico lato server** (`services/trust/falseClaims.js`), che non dipende dal modello: ogni affermazione "manca X" viene confrontata con l'annuncio, e se X c'è la frase viene scartata. Vale sia per `textReason` sia per i `suggestedFixes`.

## Sopprimere, non correggere

Una spiegazione **falsa** è peggio di nessuna spiegazione: manda l'utente a sistemare qualcosa che è già a posto e gli fa credere che sia l'app a sbagliare — che è esattamente quello che è successo qui.

Non si riscrive la frase perché non si può sapere quale motivo *vero* l'AI avrebbe dovuto dare al suo posto: inventarlo sarebbe lo stesso errore, al contrario.

**Resta un compromesso, e va detto:** CLAUDE.md chiede che il perché del punteggio sia sempre visibile, e con questa modifica a volte non lo sarà. È l'intervento 1 a dover ridurre la frequenza; l'intervento 2 è la rete che impedisce il danno peggiore.

I suggerimenti si filtrano **uno per uno**, non in blocco: gli altri restano utili.

## Il rischio opposto, e come l'ho limitato

Un riconoscitore troppo largo sopprimerebbe segnalazioni **vere**. Per questo il numero del treno non è "una qualsiasi cifra": anni (`2026`) e importi (`1200 euro`, `€1500`) sono esclusi esplicitamente, e ci sono test dedicati a questi falsi positivi.

## Verifiche

- `cd server && node --test` → **232/232 verdi** (erano 221, +11 nuovi)
- nuovo `server/test/falseClaims.test.js`: il caso reale viene soppresso; una spiegazione **vera** passa intatta (4 varianti); il numero del treno è riconosciuto in 7 forme d'uso (`treno 546`, `FR 9512`, `IC 546`, `REG 12345`…); un anno o un importo **non** vengono scambiati per numero di treno; orario, prezzo e data si verificano anche sui campi strutturati; senza testo non si sopprime nulla; input vuoti o non validi non fanno esplodere niente
- provato con le stringhe **esatte** degli screenshot, non con parafrasi: `textReason → null`, suggerimento → scartato
- nessuna modifica lato client, bundle web non toccato

Nessuna migration in questa PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_