### PR TITLE
La tratta valida non può più essere messa in dubbio nella spiegazione

### DIFF
--- a/server/src/services/trust/falseClaims.js
+++ b/server/src/services/trust/falseClaims.js
@@ -20,9 +20,69 @@
 // Non si riscrive la frase perché non si può sapere quale motivo VERO l'AI
 // avrebbe dovuto dare al suo posto: inventarlo sarebbe lo stesso errore.
 
+import { isKnownRailCity } from './heuristics.js';
+
 /** Testo su cui l'AI ha giudicato: titolo + descrizione. */
 function listingText(listing) {
   return [listing?.title, listing?.description].filter(Boolean).join(' \n ');
+}
+
+// ----------------------------------------------------------------------
+// Tratta messa in dubbio
+//
+// computeTrustScore scarta già il flag IMPLAUSIBLE_ROUTE dell'AI quando
+// origine e destinazione sono entrambe nell'allow-list delle città su rotaia.
+// Quella soppressione però copriva SOLO il flag: la stessa identica obiezione
+// scritta in prosa dentro 'textReason' passava intatta.
+//
+// Caso reale: tratta Palermo → Mazara, flag correttamente scartato (punteggio
+// 90, non il tetto di 35), ma la spiegazione diceva comunque "la tratta
+// Palermo → Mazara non è segnalata come valida per il treno". È una linea
+// regionale che esiste, e l'allow-list lo sa: la frase contraddice la
+// decisione che il sistema ha già preso.
+//
+// Le frasi arrivano nella lingua dell'utente (it/en/es), quindi i pattern
+// coprono le tre lingue.
+const ROUTE_MENTION_RE = /\b(tratta|percorso|collegamento|route|trayecto|recorrido|conexi[oó]n)\b/i;
+const ROUTE_DOUBT_RE = new RegExp(
+  [
+    // italiano
+    'non\\s+(?:è|e\')\\s+(?:segnalat|indicat|riconosciut|valid|percorribil|servit|copert|disponibil)\\w*',
+    'non\\s+(?:risulta|esiste|sembra|pare|appare)',
+    'potrebbe\\s+non\\s+essere',
+    '(?:tratta|percorso|collegamento)\\s+(?:non\\s+valid|dubbi|incert|sospett)\\w*',
+    'verificare\\s+se\\s+la\\s+tratta',
+    // inglese
+    'not\\s+(?:a\\s+)?(?:valid|recognized|recognised|served|listed|available)',
+    'does\\s+not\\s+(?:appear|exist|seem)',
+    // spagnolo
+    'no\\s+(?:es|est[aá])\\s+(?:v[aá]lid|reconocid|indicad|disponible)\\w*',
+    'no\\s+(?:figura|existe|parece)',
+  ].join('|'),
+  'i',
+);
+
+/**
+ * Vero se la frase mette in dubbio una tratta che il sistema considera
+ * percorribile. La prova è la stessa usata da computeTrustScore per scartare
+ * il flag: entrambi i capi nell'allow-list delle città servite dal treno.
+ */
+function questionsAValidRoute(sentence, listing) {
+  const tipo = String(listing?.type || '').toLowerCase();
+  if (tipo !== 'train' && tipo !== 'treno') return false;
+  if (!isKnownRailCity(listing?.origin) || !isKnownRailCity(listing?.destination)) return false;
+
+  const s = String(sentence || '');
+  if (!ROUTE_DOUBT_RE.test(s)) return false;
+  // "non ci sono treni DIRETTI" è un'altra affermazione, e può essere vera:
+  // l'allow-list dice che la tratta è percorribile sulla rete, non che si
+  // faccia senza cambi. Non è nostro compito zittirla.
+  if (/\b(dirett[oiae]|direct|directo)\b/i.test(s)) return false;
+  // Il dubbio deve riguardare la tratta, non un altro dato: o la frase nomina
+  // la tratta, o nomina entrambe le città.
+  if (ROUTE_MENTION_RE.test(s)) return true;
+  const citta = [listing.origin, listing.destination].map((c) => String(c || '').trim()).filter(Boolean);
+  return citta.length === 2 && citta.every((c) => new RegExp(`\\b${c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i').test(s));
 }
 
 // Verbi con cui si afferma che un dato è assente.
@@ -103,14 +163,23 @@ const CLAIMABLE_ITEMS = [
 export function falseMissingClaims(sentence, listing) {
   const s = String(sentence || '');
   if (!s.trim()) return [];
-  if (!MISSING_CLAIM_RE.test(s)) return [];   // non afferma che manchi nulla
 
-  const text = listingText(listing);
-  if (!text.trim()) return [];                // niente con cui confrontare
+  const contraddette = [];
 
-  return CLAIMABLE_ITEMS
-    .filter((item) => item.named.test(s) && item.isPresent(text, listing))
-    .map((item) => item.id);
+  // Tratta messa in dubbio: si verifica sull'allow-list, non sul testo
+  // dell'annuncio, quindi vale anche quando titolo e descrizione sono vuoti.
+  if (questionsAValidRoute(s, listing)) contraddette.push('tratta_valida');
+
+  if (MISSING_CLAIM_RE.test(s)) {
+    const text = listingText(listing);
+    if (text.trim()) {                        // senza testo non c'è confronto
+      for (const item of CLAIMABLE_ITEMS) {
+        if (item.named.test(s) && item.isPresent(text, listing)) contraddette.push(item.id);
+      }
+    }
+  }
+
+  return contraddette;
 }
 
 /**
@@ -122,7 +191,7 @@ export function falseMissingClaims(sentence, listing) {
 export function reasonWithoutFalseClaims(reason, listing) {
   const bad = falseMissingClaims(reason, listing);
   if (!bad.length) return reason ?? null;
-  console.warn(`[trustscore] textReason soppresso, dichiara mancanti dati presenti: ${bad.join(', ')} — "${reason}"`);
+  console.warn(`[trustscore] textReason soppresso, contraddetto su: ${bad.join(', ')} — "${reason}"`);
   return null;
 }
 
@@ -143,7 +212,7 @@ export function fixesWithoutFalseClaims(fixes, listing) {
       : testo;
     const bad = falseMissingClaims(comeAssenza, listing);
     if (bad.length) {
-      console.warn(`[trustscore] suggerimento soppresso, dati già presenti: ${bad.join(', ')} — "${testo}"`);
+      console.warn(`[trustscore] suggerimento soppresso, contraddetto su: ${bad.join(', ')} — "${testo}"`);
       return false;
     }
     return true;

--- a/server/test/falseClaims.test.js
+++ b/server/test/falseClaims.test.js
@@ -119,6 +119,57 @@ test('i suggerimenti si filtrano uno per uno, non in blocco', () => {
   assert.ok(out.every((f) => !/numero del treno/i.test(f.suggestion)));
 });
 
+/* ===== Tratta messa in dubbio quando l'allow-list dice che è percorribile ===== */
+
+test('la tratta valida non può essere messa in dubbio in prosa', () => {
+  // computeTrustScore scartava già il FLAG IMPLAUSIBLE_ROUTE su questa tratta
+  // (punteggio 90, non il tetto di 35), ma la stessa obiezione scritta a
+  // parole passava intatta: stessa decisione, canale diverso.
+  const frase = 'Punteggio non massimo: La durata del viaggio è plausibile, ma la tratta Palermo → Mazara non è segnalata come valida per il treno.';
+  assert.deepEqual(falseMissingClaims(frase, ANNUNCIO), ['tratta_valida']);
+  assert.equal(reasonWithoutFalseClaims(frase, ANNUNCIO), null);
+
+  const fixes = [{ field: 'route', suggestion: "Verificare se la tratta è corretta o se esiste un'alternativa valida." }];
+  assert.deepEqual(fixesWithoutFalseClaims(fixes, ANNUNCIO), []);
+});
+
+test('il dubbio sulla tratta si sopprime anche in inglese e spagnolo', () => {
+  // Le frasi arrivano nella lingua dell'utente: coprire solo l'italiano
+  // lascerebbe passare lo stesso errore a chi usa en/es.
+  for (const frase of [
+    'The Palermo → Mazara route is not a valid train connection.',
+    'El trayecto Palermo → Mazara no es válido para el tren.',
+  ]) {
+    assert.equal(reasonWithoutFalseClaims(frase, ANNUNCIO), null, frase);
+  }
+});
+
+test('una tratta davvero impossibile resta segnalata', () => {
+  // Il punto delicato: se sopprimessimo anche questa, nasconderemmo un
+  // problema vero. Pantelleria è un'isola, non è nell'allow-list.
+  const isola = { ...ANNUNCIO, destination: 'Pantelleria' };
+  const frase = 'La tratta Palermo → Pantelleria non è valida per il treno.';
+  assert.deepEqual(falseMissingClaims(frase, isola), []);
+  assert.equal(reasonWithoutFalseClaims(frase, isola), frase);
+});
+
+test('"non ci sono treni diretti" è un\'altra affermazione e resta', () => {
+  // L'allow-list dice che la tratta è percorribile sulla rete, non che si
+  // faccia senza cambi: quella frase può essere vera e non va zittita.
+  for (const frase of [
+    'La tratta non è servita da treni diretti.',
+    'There is no direct train on this route.',
+  ]) {
+    assert.equal(reasonWithoutFalseClaims(frase, ANNUNCIO), frase, frase);
+  }
+});
+
+test('il dubbio su un hotel non viene trattato come dubbio di tratta', () => {
+  const hotel = { title: 'Hotel', description: 'Camera doppia', type: 'hotel', location: 'Firenze' };
+  const frase = 'La struttura non è indicata con chiarezza.';
+  assert.equal(reasonWithoutFalseClaims(frase, hotel), frase);
+});
+
 test('fixesWithoutFalseClaims regge input non validi', () => {
   assert.deepEqual(fixesWithoutFalseClaims(null, ANNUNCIO), []);
   assert.deepEqual(fixesWithoutFalseClaims(undefined, ANNUNCIO), []);


### PR DESCRIPTION
Tratta Palermo → Mazara, punteggio 90:

> La durata del viaggio è plausibile, ma la tratta Palermo → Mazara non è segnalata come valida per il treno.

È una linea regionale che esiste, e **il sistema lo sa già**.

## Causa: la soppressione copriva un canale solo

`computeTrustScore` scarta il flag `IMPLAUSIBLE_ROUTE` dell'AI quando origine e destinazione sono entrambe nell'allow-list delle città su rotaia. Su questo annuncio la soppressione **ha funzionato** — il punteggio è 90, non il tetto di 35 previsto per quel flag.

Ma copriva solo il *flag*: la stessa identica obiezione, scritta in prosa dentro `textReason` e dentro un suggerimento, passava intatta. Il sistema contraddiceva una decisione che aveva già preso.

È lo stesso difetto della correzione precedente — un controllo applicato a un canale e non al suo gemello.

## Fix

Il controllo su `textReason` e suggerimenti ora verifica anche le frasi che mettono in dubbio la validità di una tratta, con la **stessa prova** usata da `computeTrustScore` per scartare il flag: entrambi i capi nell'allow-list.

I pattern coprono **italiano, inglese e spagnolo**, perché la frase arriva nella lingua dell'utente e coprire il solo italiano avrebbe lasciato passare lo stesso errore a chi usa en/es.

## Due cose che NON vengono soppresse, di proposito

Un riconoscitore troppo largo qui nasconderebbe problemi reali, quindi due esclusioni esplicite con test dedicati:

- **Una tratta davvero impossibile** — Palermo → Pantelleria, isola fuori dall'allow-list: la segnalazione è vera e resta.
- **"Non ci sono treni diretti"** — è un'altra affermazione, e può essere vera. L'allow-list dice che la tratta è percorribile sulla rete, non che si faccia senza cambi.

## Verifiche

- `cd server && node --test` → **237/237 verdi** (erano 232, +5 nuovi)
- provato con le stringhe **esatte** dello screenshot: `textReason → null`, suggerimento → scartato
- i due casi da non sopprimere verificati con test dedicati
- coperto anche il caso hotel, che non deve entrare nella logica di tratta
- nessuna modifica lato client, bundle web non toccato

Nessuna migration in questa PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_