### PR TITLE
Documentazione: scambi a 3, valutazioni, domande pre-offerta, race fix

### DIFF
--- a/APP_OVERVIEW.md
+++ b/APP_OVERVIEW.md
@@ -329,21 +329,35 @@ Hai anche due vie d'uscita:
 
 ## 9. Scambi a 3
 
-A volte due persone non si incastrano, ma tre sì: tu dai a Anna, Anna dà a
-Marco, Marco dà a te. L'app cerca questi **anelli chiusi** da sola e te li
-propone nella schermata "Scambi a 3".
+A volte due persone non si incastrano, ma tre sì: tu dai a qualcuno, quella
+persona dà a un'altra, che dà a te. L'app cerca questi **anelli chiusi** da
+sola, in automatico e in background **ogni 15 minuti** — non devi attivare
+nulla, e funziona anche se hai più di un annuncio in vendita
+contemporaneamente.
 
-Ogni proposta mostra chi dà cosa a chi e quante persone hanno già confermato
-(«2 di 3 hanno confermato»). Puoi **confermare**, **ritirare la conferma**
-finché lo scambio non è chiuso, oppure rifiutare.
+Ogni proposta mostra subito, in due riquadri ben distinti, **cosa cedi** e
+**cosa ricevi**. Il meccanismo completo — chi dà cosa a chi, in che ordine —
+resta disponibile aprendo "Vedi i dettagli del cerchio", per chi vuole
+capire come si chiude il giro prima di fidarsi. Un indicatore a pallini
+mostra quanti dei 3 partecipanti hanno già confermato.
 
-Quando tutti e tre confermano, lo scambio è fatto e lo ritrovi nello storico.
+Puoi **confermare**, **ritirare la conferma** finché lo scambio non è
+chiuso, oppure rifiutare: in quel caso la catena decade per tutti e 3, senza
+che nessuno perda l'annuncio.
+
+Quando tutti e tre confermano, lo scambio è concluso — lo ritrovi nello
+storico — e si apre una **chat dedicata fra i 3 partecipanti** per
+organizzare la consegna dei biglietti. Si apre solo a scambio concluso, mai
+prima: finché manca anche una sola conferma il giro può ancora saltare.
+
+Mentre l'app sta cercando in background uno scambio a 3 che ti riguarda,
+l'icona della sezione Attività cambia temporaneamente (diventa l'icona a 3
+nodi) per segnalartelo.
 
 ### Limite da conoscere
 
-Nella versione attuale partecipa **solo chi ha esattamente un annuncio in
-vendita**. Se ne hai due o più attivi contemporaneamente, resti fuori dalle
-catene: l'app non saprebbe quale dei tuoi stai offrendo.
+Le valutazioni a stelle (§8) oggi coprono solo gli scambi 1:1: uno scambio a
+3 concluso non genera ancora un voto per i partecipanti.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,25 @@ bundle finale per `debug-user` / `DEBUG_MOCK` deve dare 0).
   modifica invalida il Check AI precedente: va rilanciato prima di salvare.
 - **Ciclo di vita annuncio**: `active ⇄ paused` è reversibile; `deleted` è
   **terminale** (mai riattivabile — altrimenti equivarrebbe a "paused").
+- **Scambio a catena (a 3)**: quando due utenti non si incastrano ma tre sì
+  (A dà a B, B dà a C, C dà ad A), il matching li trova da solo e li propone
+  in "Scambi a 3" — ricalcolo cron-only ogni 15 min
+  (`POST /api/chains/recompute`, `server/src/models/chains.js`). Un utente
+  con più annunci VENDO attivi partecipa comunque: ogni arco del grafo di
+  desiderio sceglie l'annuncio specifico con punteggio migliore, non esclude
+  l'utente. Si chiude solo quando TUTTI E 3 confermano
+  (`confirm_chain_participant`); da quel momento hanno una chat dedicata
+  (`chain_messages`, RLS aperta solo a catena `completed` — mai prima, il
+  giro può ancora decadere).
+- **Valutazioni**: a transazione 1:1 conclusa, 1-5 stelle doppio cieco
+  (`transaction_ratings`, RPC `rate_transaction`/`get_user_rating`): il
+  proprio voto resta nascosto finché anche l'altra parte vota o passano 14
+  giorni; sotto 3 voti rivelati si mostra "Nuovo", mai una media; voto
+  immutabile. **Non copre ancora gli scambi a 3**: quelle transazioni non
+  hanno una riga in `offers`, quindi `rate_transaction` non si applica.
+- **Domande a risposta chiusa pre-offerta**: catalogo treno/hotel
+  (`lib/listingQuestions.mjs`) mostrato prima di proporre un'offerta, per
+  ridurre lo scambio di contatti fuori app in chat.
 
 ## Migration: workflow manuale
 

--- a/docs/FUNCTIONAL_OVERVIEW.md
+++ b/docs/FUNCTIONAL_OVERVIEW.md
@@ -101,6 +101,12 @@ TravelSwapAi_Rep/
 - i18n con dizionari **it / en / es** (`lib/i18n`), default italiano, fallback e interpolazione variabili.
 - **Traduzione on-demand degli annunci** nella lingua dell'utente via backend (`useListingTranslation` → `GET /api/listings/:id/translate?lang=xx`), con cache su DB.
 
+### 3.6 Swap a catena, valutazioni, domande pre-offerta
+- **Swap a 3** (`server/src/models/chains.js`, `ai/chainMatch.js`, `ai/chainExplain.js`): trova cicli chiusi di 3 utenti tra gli annunci attivi (`findAndProposeChains`, cron-only `POST /api/chains/recompute`, ogni 15 min). Un utente con più annunci VENDO attivi partecipa comunque: ogni arco del grafo di desiderio sceglie l'annuncio specifico con punteggio migliore (non esclude l'utente, comportamento della v1). Si chiude con `confirm_chain_participant` (lock ordinato sui 3 annunci prima di riservarli) solo quando tutti e 3 confermano; da quel momento chat dedicata (`chain_messages`, RLS aperta solo a catena `completed`).
+- **Valutazioni 1-5 stelle** (`transaction_ratings`, RPC `rate_transaction`/`get_user_rating`): solo per scambi 1:1 (i chain-swap non hanno una riga in `offers`, quindi non sono ancora votabili). Doppio cieco — voto nascosto finché anche l'altra parte vota o passano 14 giorni — e immutabile.
+- **Domande a risposta chiusa pre-offerta** (`lib/listingQuestions.mjs`): catalogo treno/hotel mostrato prima di proporre un'offerta, per ridurre lo scambio di contatti fuori app in chat.
+- **Race condition corrette** (`supabase/migrations/20260726120000`, `20260729120000`): lock ordinato su `accept_offer_any`/`confirm_exchange_any`/`confirm_chain_participant` e ricontrollo di stato in `release_my_stale_reservations`, per evitare che una pulizia lazy o una conferma concorrente sovrascrivano uno scambio appena concluso.
+
 ---
 
 ## 4. Funzionalità — Backend
@@ -276,7 +282,7 @@ Ricostruito dalle query nel codice; i tipi sono dedotti.
 
 ### P2 — Qualità e prodotto
 
-16. ✅ **Test e CI presenti** — `server/test/` (96 test, `node --test`), pipeline `.github/workflows/node.js.yml` (push/PR su `main`, Node 20.x/22.x).
+16. ✅ **Test e CI presenti** — `server/test/` (281 test, `node --test`), pipeline `.github/workflows/node.js.yml` (push/PR su `main`, Node 20.x/22.x).
 17. ✅ **Codice morto/duplicato rimosso** — vedi P1.15; route `parseTwo` consolidata in `ai/descriptionParse.js` (vedi §4.3).
 18. ✅ **Migrazioni DB versionate** — vedi P0.7.
 19. **TypeScript** — il tsconfig c'è ma il codice è ancora tutto JS; una migrazione graduale (prima `lib/`, poi screens) resta da fare.


### PR DESCRIPTION
Solo documentazione, nessun codice toccato. `CLAUDE.md` e `APP_OVERVIEW.md` non riflettevano il lavoro delle ultime sessioni.

## `CLAUDE.md`
Aggiunte le regole di dominio mancanti — nessuna menzionava ancora scambi a 3, valutazioni o domande pre-offerta:
- Scambio a catena: ora multi-annuncio (v2), chat dedicata solo a catena `completed`.
- Valutazioni 1-5 stelle doppio cieco, **non ancora estese agli scambi a 3** (nessuna riga in `offers`).
- Domande a risposta chiusa pre-offerta.

## `APP_OVERVIEW.md` §9 (Scambi a 3)
Rimosso il limite **"partecipa solo chi ha un solo annuncio"** — ormai falso da PR #175. Aggiunti: chat post-scambio tra i 3 partecipanti, cadenza di ricerca automatica (15 min), icona del tab Attività che cambia quando c'è una catena da confermare, nota sul gap valutazioni.

## `docs/FUNCTIONAL_OVERVIEW.md`
Nuova §3.6 con le funzionalità recenti (swap a catena, valutazioni, domande, le due race condition corrette in #182). Conteggio test aggiornato (96 → 281, era una foto vecchia).

`docs/matching.md` non toccato: descrive solo il matching 1:1 (Livello 1/2/3), gli scambi a catena sono un algoritmo separato (`chainMatch.js`) fuori dal suo scope dichiarato.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_