### PR TITLE
Test funzionale: pubblicazione annuncio account A (checklist #1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ treno e prenotazioni hotel non utilizzati. Monorepo con due progetti:
 
 | Cosa | Comando |
 |---|---|
-| Test backend | `cd server && node --test` (282 test, devono passare tutti) |
+| Test backend | `cd server && node --experimental-test-module-mocks --test` (283 test, devono passare tutti; il flag serve a `mock.module()`, usato per i test che sostituiscono il client Supabase) |
 | Test app RN/Expo | `cd travelswap_ai/travelswapai && npx jest` (Jest + jest-expo + Testing Library; per ora solo lo smoke test `__tests__/App.smoke.test.js`) |
 | Syntax check file server | `node --check <file>` |
 | Parse-check file RN (JSX) | `node -e "require('@babel/parser').parse(require('fs').readFileSync('<file>','utf8'),{sourceType:'module',plugins:['jsx']})"` |

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "NODE_ENV=development nodemon --watch src --ext js --exec node src/index.js",
     "start": "node src/index.js",
-    "test": "node --test"
+    "test": "node --experimental-test-module-mocks --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.55.0",

--- a/server/test/createListingPublish.test.js
+++ b/server/test/createListingPublish.test.js
@@ -1,0 +1,85 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 1 "Pubblicazione annuncio (account A)", step 1+3): account A crea a
+// mano un annuncio treno VENDO con tratta reale, data futura e prezzo, poi
+// pubblica. Verifica lo stesso esito atteso dalla checklist manuale
+// (`select status, trust_score, cerco_vendo, ... from listings ...`), ma
+// chiamando la funzione reale dietro "Pubblica" (POST /api/listings →
+// createListing) invece di leggere da un database vero: niente Supabase
+// live in CI (stessa filosofia di computeTrustScoreDuration.test.js), il
+// client viene sostituito con un fake che cattura l'insert.
+//
+// Fuori scope qui (richiede un DB reale, coperto solo dalla checklist
+// manuale): trigger Postgres (enforce_active_listing_cap, whitelist tratte,
+// update_listing_trust_score) e il Check AI, che gira lato client separato
+// da createListing().
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+const ACCOUNT_A = '11111111-1111-4111-8111-111111111111';
+
+function buildFakeSupabase(capturedInserts) {
+  return {
+    from(table) {
+      return {
+        insert(payload) {
+          capturedInserts.push({ table, payload });
+          return {
+            select() {
+              return {
+                async single() {
+                  return {
+                    data: { id: 'fake-listing-id-0001', ...payload },
+                    error: null,
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('Pubblicazione annuncio (account A): treno VENDO, tratta reale, data futura, prezzo', async () => {
+  const capturedInserts = [];
+  const fakeSupabase = buildFakeSupabase(capturedInserts);
+
+  mock.module('../src/db.js', {
+    namedExports: { supabase: fakeSupabase },
+  });
+  const { createListing } = await import('../src/models/listings.js');
+
+  const departAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(); // +7 giorni
+  const arriveAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000).toISOString(); // +3h di viaggio
+
+  const listing = await createListing(ACCOUNT_A, {
+    title: 'Roma → Milano, Frecciarossa 9506',
+    type: 'train',
+    cerco_vendo: 'VENDO',
+    route_from: 'Roma',
+    route_to: 'Milano',
+    depart_at: departAt,
+    arrive_at: arriveAt,
+    price: 45,
+  });
+
+  // Stesso "atteso" della checklist manuale, step 3: status active (nessuno
+  // stato esplicito passato → default), cerco_vendo/type/tratta coerenti.
+  assert.equal(listing.status, 'active');
+  assert.equal(listing.cerco_vendo, 'VENDO');
+  assert.equal(listing.type, 'train');
+  assert.equal(listing.route_from, 'Roma');
+  assert.equal(listing.route_to, 'Milano');
+  assert.equal(listing.price, 45);
+  assert.equal(listing.user_id, ACCOUNT_A);
+
+  // L'insert deve arrivare sulla tabella giusta, con published_at valorizzato
+  // (la checklist non lo controlla via SQL ma è ciò che rende l'annuncio
+  // "appena pubblicato" invece che una bozza).
+  assert.equal(capturedInserts.length, 1);
+  assert.equal(capturedInserts[0].table, 'listings');
+  assert.ok(capturedInserts[0].payload.published_at, 'published_at deve essere valorizzato alla pubblicazione');
+
+  mock.reset();
+});


### PR DESCRIPTION
## Causa

Su richiesta: automatizzare il test #1 della checklist manuale
(`docs/CHECKLIST_TEST_MANUALE.md`, Parte 1 "Pubblicazione annuncio (account
A)") — account A crea a mano un treno VENDO con tratta reale, data futura e
prezzo, poi pubblica.

## Cosa aggiunge

`server/test/createListingPublish.test.js`: chiama la funzione reale dietro
il tasto "Pubblica" — `createListing()` in `server/src/models/listings.js`,
la stessa usata da `POST /api/listings` — e verifica lo stesso esito atteso
nella checklist manuale (step 3): `status='active'`, `cerco_vendo='VENDO'`,
`type`, tratta, prezzo e `user_id` coerenti, `published_at` valorizzato.

Niente Supabase live in CI (stessa filosofia degli altri test del
progetto, es. `computeTrustScoreDuration.test.js`): il client viene
sostituito con un fake che cattura l'insert, tramite `mock.module()` di
`node:test`. Questo richiede il flag `--experimental-test-module-mocks`,
aggiunto allo script `test` di `server/package.json` e al comando
documentato in `CLAUDE.md` — **verificato che non cambia nulla sugli altri
282 test** (283/283 verdi con e senza il nuovo test).

**Fuori scope** (serve un DB reale, resta coperto solo dalla checklist
manuale): trigger Postgres (whitelist tratte, cap 10 annunci attivi,
calcolo `trust_score`) e il Check AI, che gira lato client separato da
`createListing()`.

## Verifiche

- `cd server && node --experimental-test-module-mocks --test` → 283/283
  verdi.
- Nessun file RN toccato, nessuna migration, nessuna modifica bundle web.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_