### PR TITLE
Test funzionale: proposta e accettazione offerta (checklist #3)

### DIFF
--- a/travelswap_ai/travelswapai/__tests__/offerProposeAccept.test.js
+++ b/travelswap_ai/travelswapai/__tests__/offerProposeAccept.test.js
@@ -1,0 +1,65 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 3 "Proposta e accettazione", step 9+11): account B propone un
+// acquisto sull'annuncio di A, poi A accetta. Chiama le funzioni reali
+// dietro quei bottoni — createOfferBuy() e acceptOffer() in lib/offers.js
+// (non esiste una route server per le offerte: il client scrive/chiama RPC
+// direttamente su Supabase) — con un mock completo del client, stesso
+// approccio di listingPublish.test.js.
+//
+// Fuori scope qui: la logica di accettazione vera e propria (lock, calcolo
+// reservation_expires_at, declino delle altre proposte pending, stato degli
+// annunci) vive TUTTA dentro la RPC Postgres accept_offer_any — un mock non
+// la esercita, resta coperta solo da migrationsIntegrity.test.js e dalla
+// checklist manuale.
+const mockBuyerB = "22222222-2222-4222-8222-222222222222";
+const LISTING_ID = "33333333-3333-4333-8333-333333333333";
+
+const mockRpc = jest.fn(async (fn, params) => {
+  if (fn === "accept_offer_any") {
+    return {
+      data: {
+        id: params.offer_id_text,
+        status: "accepted",
+        reservation_expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+      error: null,
+    };
+  }
+  return { data: null, error: null };
+});
+
+jest.mock("../lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: async () => ({ data: { user: { id: "22222222-2222-4222-8222-222222222222" } }, error: null }),
+    },
+    from: () => ({
+      insert: (rows) => ({
+        select: () => ({
+          single: async () => ({ data: { id: "fake-offer-id-0001", ...rows[0] }, error: null }),
+        }),
+      }),
+    }),
+    rpc: (...args) => mockRpc(...args),
+  },
+}));
+
+import { createOfferBuy, acceptOffer } from "../lib/offers";
+
+test("Proposta e accettazione: B propone un acquisto, A accetta", async () => {
+  const offer = await createOfferBuy(LISTING_ID, { amount: 45, currency: "EUR" });
+
+  // Stesso "atteso" della checklist manuale, step 9.
+  expect(offer.status).toBe("pending");
+  expect(offer.type).toBe("buy");
+  expect(offer.to_listing_id).toBe(LISTING_ID);
+  expect(offer.proposer_id).toBe(mockBuyerB);
+  expect(offer.amount).toBe(45);
+
+  const accepted = await acceptOffer(offer.id);
+
+  // Stesso "atteso" della checklist manuale, step 11.
+  expect(accepted.status).toBe("accepted");
+  expect(new Date(accepted.reservation_expires_at).getTime()).toBeGreaterThan(Date.now());
+  expect(mockRpc).toHaveBeenCalledWith("accept_offer_any", { offer_id_text: String(offer.id) });
+});


### PR DESCRIPTION
## Causa

Automatizza il test #3 della checklist manuale
(`docs/CHECKLIST_TEST_MANUALE.md`, Parte 3 "Proposta e accettazione",
step 9+11) — account B propone un acquisto sull'annuncio di A, poi A
accetta.

## Cosa aggiunge

`travelswap_ai/travelswapai/__tests__/offerProposeAccept.test.js`: chiama
`createOfferBuy()` e `acceptOffer()` reali in `lib/offers.js` — non esiste
una route server per le offerte, il client scrive direttamente su Supabase
(propone) e chiama la RPC `accept_offer_any` (accetta) — con un mock
completo del client, stesso approccio del test #1.

Verifica: la proposta nasce `pending`/`buy` con `to_listing_id`/
`proposer_id`/`amount` corretti; dopo l'accettazione lo stato è `accepted`
con `reservation_expires_at` nel futuro, e la RPC riceve l'id offerta
giusto.

**Fuori scope**: la logica di accettazione vera e propria (lock,
`reservation_expires_at`, declino delle altre proposte pending, stato
annunci) vive dentro la RPC Postgres `accept_offer_any` — un mock non la
esercita, resta coperta da `migrationsIntegrity.test.js` e dalla checklist
manuale.

## 🔎 Comportamento sospetto trovato leggendo `accept_offer_any` (ultima
versione, `20260726120000_data_integrity_hardening.sql:295-304`)

Quando si accetta un'offerta di **scambio** (swap), la funzione marca
`reserved` **sia** `to_listing_id` **sia** `from_listing_id` (l'annuncio
ceduto in cambio), ma la query che declina le altre proposte pending sullo
stesso annuncio filtra **solo** su `to_listing_id`:

```sql
update public.offers set status = 'declined'
 where to_listing_id::text = v_offer.to_listing_id::text
   and id <> v_offer.id and status = 'pending';
```

Se un terzo utente aveva un'offerta pending verso `from_listing_id` (il
listing appena riservato come "dato in cambio"), quella riga **non** viene
declinata: resta `pending` a tempo indeterminato invece di ricevere subito
la notifica di rifiuto. Non è una corruzione di dati — il controllo
`v_unavailable` più sopra nella stessa funzione la fa scadere
silenziosamente (`expired`) se qualcuno la accetta più tardi — ma
l'esperienza è comunque sbagliata: quel terzo utente non viene mai
avvisato che la sua proposta è morta, e la vede ancora "in sospeso" nella
sua Attività finché non prova (invano) ad agirci sopra. Segnalo, non
corretto qui: tocca la RPC di accettazione, fuori scope per una PR di test.

## Verifiche

- `npx jest` (app RN) → 3/3 verdi.
- `cd server && node --experimental-test-module-mocks --test` → 284/284
  verdi, invariato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_