### PR TITLE
Test funzionale: valutazione a stelle (checklist #5)

### DIFF
--- a/travelswap_ai/travelswapai/__tests__/rateTransaction.test.js
+++ b/travelswap_ai/travelswapai/__tests__/rateTransaction.test.js
@@ -1,0 +1,66 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 5 "Valutazione", step 17+19+20): dopo la finalizzazione, account A
+// vota, poi account B vota anche lui, poi A prova a rivotare con un valore
+// diverso (deve essere rifiutato: voto immutabile).
+//
+// Chiama rateTransaction()/getUserRating() reali in lib/ratingsApi.js
+// (chiamano le RPC rate_transaction/get_user_rating), con un mock completo
+// del client Supabase — stesso approccio dei test precedenti.
+//
+// Fuori scope qui: il double-blind e l'immutabilità sono applicati TUTTI
+// dentro le RPC Postgres (uniche a poter scrivere/leggere
+// transaction_ratings, la tabella non è raggiungibile direttamente) — un
+// mock simula solo le risposte, non esercita quella logica. Resta coperta
+// dalla checklist manuale. Step 18 (B non vede ancora il voto di A prima
+// che B stesso voti) e step 21 (stelle accanto al nome nel profilo) sono
+// verifiche di UI/DB reale, non coperte qui.
+const SELLER_A = "11111111-1111-4111-8111-111111111111";
+const OFFER_ID = 4242;
+
+const mockRpc = jest.fn();
+
+jest.mock("../lib/supabase", () => ({
+  supabase: {
+    rpc: (...args) => mockRpc(...args),
+  },
+}));
+
+import { rateTransaction, getUserRating } from "../lib/ratingsApi";
+
+test("Valutazione: A vota, B vota, il voto di A resta immutabile", async () => {
+  // Step 17: A vota 5 stelle sulla transazione conclusa.
+  mockRpc.mockResolvedValueOnce({
+    data: [{ offer_id: OFFER_ID, stars: 5, created_at: new Date().toISOString() }],
+    error: null,
+  });
+  const voteA = await rateTransaction(OFFER_ID, 5);
+  expect(voteA.stars).toBe(5);
+  expect(mockRpc).toHaveBeenCalledWith("rate_transaction", { p_offer_id: OFFER_ID, p_stars: 5 });
+
+  // Step 19: B vota anche lui (4 stelle su A) — ora l'aggregato di A si
+  // "rivela" (entrambe le parti hanno votato).
+  mockRpc.mockResolvedValueOnce({
+    data: [{ offer_id: OFFER_ID, stars: 4, created_at: new Date().toISOString() }],
+    error: null,
+  });
+  const voteB = await rateTransaction(OFFER_ID, 4);
+  expect(voteB.stars).toBe(4);
+
+  mockRpc.mockResolvedValueOnce({
+    data: [{ avg_stars: 4, ratings_count: 1 }],
+    error: null,
+  });
+  const ratingOfA = await getUserRating(SELLER_A);
+  expect(ratingOfA).toEqual({ avg: 4, count: 1 });
+  expect(mockRpc).toHaveBeenCalledWith("get_user_rating", { p_user_id: SELLER_A });
+
+  // Step 20: A prova a rivotare con un valore diverso (3 invece di 5): il DB
+  // rifiuta (voto immutabile), rateTransaction deve rilanciare l'errore.
+  mockRpc.mockResolvedValueOnce({
+    data: null,
+    error: { message: "Rating already given and cannot be changed" },
+  });
+  await expect(rateTransaction(OFFER_ID, 3)).rejects.toMatchObject({
+    message: "Rating already given and cannot be changed",
+  });
+});


### PR DESCRIPTION
## Causa

Automatizza il test #5 della checklist manuale
(`docs/CHECKLIST_TEST_MANUALE.md`, Parte 5 "Valutazione", step 17+19+20) —
dopo la finalizzazione, A vota, B vota anche lui, poi A prova a rivotare
con un valore diverso (deve essere rifiutato).

## Cosa aggiunge

`travelswap_ai/travelswapai/__tests__/rateTransaction.test.js`: chiama
`rateTransaction()`/`getUserRating()` reali in `lib/ratingsApi.js` (chiamano
le RPC `rate_transaction`/`get_user_rating`), con un mock completo del
client Supabase — stesso approccio dei test precedenti.

Verifica: il voto di A (5) e quello di B (4) vengono registrati con gli
`stars` corretti; l'aggregato di A via `getUserRating()` riflette il voto
rivelato (`avg`/`count` mappati correttamente dalle colonne
`avg_stars`/`ratings_count`); un secondo voto di A con un valore diverso
fa rilanciare l'errore del DB (voto immutabile).

**Fuori scope**: il double-blind e l'immutabilità sono applicati tutti
dentro le RPC Postgres (unica scrittura/lettura possibile su
`transaction_ratings`, tabella non raggiungibile direttamente — REVOKE ALL
su anon/authenticated) — un mock simula solo le risposte, non esercita
quella logica. Resta coperta dalla checklist manuale. Step 18 (B non vede
ancora il voto di A prima di votare lui stesso) e step 21 (stelle accanto
al nome nel profilo) sono verifiche di UI/DB reale, non coperte qui.

## Verifiche

- `npx jest` (app RN) → 5/5 verdi.
- `cd server && node --experimental-test-module-mocks --test` → 285/285
  verdi, invariato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_