### PR TITLE
Test funzionale: annullamento post-accettazione (checklist #7)

### DIFF
--- a/travelswap_ai/travelswapai/__tests__/offerCancelAccepted.test.js
+++ b/travelswap_ai/travelswapai/__tests__/offerCancelAccepted.test.js
@@ -1,0 +1,46 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 6 "Rami alternativi", step 23 "Annullamento post-accettazione"):
+// dopo aver accettato un'offerta, PRIMA che qualcuno confermi, una delle due
+// parti annulla ("Annulla scambio"). Chiama cancelAcceptedOffer() reale in
+// lib/offers.js (chiama la RPC cancel_accepted_offer_any), con un mock
+// completo del client Supabase — stesso approccio dei test precedenti.
+//
+// Fuori scope qui: il rilascio effettivo degli annunci (listings.status
+// torna 'active') vive dentro la RPC Postgres — un mock non lo esercita,
+// resta coperto dalla checklist manuale. L'unica definizione
+// (20260721190000_two_sided_exchange_confirmation.sql) lo fa con
+// un'UPDATE ... WHERE status = 'reserved' unica, atomica: nessun rischio
+// di leggere uno stato superato come nella race già corretta altrove
+// (release_my_stale_reservations).
+const OFFER_ID = "66666666-6666-4666-8666-666666666666";
+
+const mockRpc = jest.fn(async (fn, params) => {
+  if (fn === "cancel_accepted_offer_any") {
+    return {
+      data: {
+        id: params.offer_id_text,
+        status: "cancelled",
+        owner_confirmed_at: null,
+        proposer_confirmed_at: null,
+      },
+      error: null,
+    };
+  }
+  return { data: null, error: null };
+});
+
+jest.mock("../lib/supabase", () => ({
+  supabase: { rpc: (...args) => mockRpc(...args) },
+}));
+
+import { cancelAcceptedOffer } from "../lib/offers";
+
+test("Annullamento post-accettazione: prima di qualunque conferma", async () => {
+  const cancelled = await cancelAcceptedOffer(OFFER_ID);
+
+  // Stesso "atteso" della checklist manuale, step 23.
+  expect(cancelled.status).toBe("cancelled");
+  expect(cancelled.owner_confirmed_at).toBeNull();
+  expect(cancelled.proposer_confirmed_at).toBeNull();
+  expect(mockRpc).toHaveBeenCalledWith("cancel_accepted_offer_any", { offer_id_text: String(OFFER_ID) });
+});


### PR DESCRIPTION
## Causa

Automatizza il secondo ramo alternativo della checklist manuale
(`docs/CHECKLIST_TEST_MANUALE.md`, Parte 6 "Rami alternativi", step 23
"Annullamento post-accettazione") — dopo aver accettato un'offerta, prima
che qualcuno confermi, una delle due parti annulla ("Annulla scambio").

## Cosa aggiunge

`travelswap_ai/travelswapai/__tests__/offerCancelAccepted.test.js`: chiama
`cancelAcceptedOffer()` reale in `lib/offers.js` (chiama la RPC
`cancel_accepted_offer_any`), con un mock completo del client Supabase —
stesso approccio dei test precedenti.

Verifica: `status='cancelled'`, `owner_confirmed_at`/`proposer_confirmed_at`
azzerati — stesso "atteso" della checklist manuale.

**Fuori scope**: il rilascio effettivo degli annunci (`listings.status`
torna `active`) vive dentro la RPC Postgres, non esercitato da un mock —
resta coperto dalla checklist manuale.

Notato leggendo l'unica definizione
(`20260721190000_two_sided_exchange_confirmation.sql`), non un bug: il
rilascio usa una singola `UPDATE ... WHERE status = 'reserved'` atomica,
diversa dal pattern che aveva causato la race in
`release_my_stale_reservations` (lì il problema era una `SELECT` separata
prima del lock) — nessun rischio analogo qui.

## Verifiche

- `npx jest` (app RN) → 7/7 verdi.
- `cd server && node --experimental-test-module-mocks --test` → 285/285
  verdi, invariato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_