### PR TITLE
Test funzionale: contestazione scambio (checklist #8)

### DIFF
--- a/travelswap_ai/travelswapai/__tests__/offerReportProblem.test.js
+++ b/travelswap_ai/travelswapai/__tests__/offerReportProblem.test.js
@@ -1,0 +1,58 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 6 "Rami alternativi", step 24 "Contestazione"): una delle due parti
+// segnala un problema su una prenotazione accettata ("biglietto non
+// ricevuto", ecc.). Chiama reportExchangeProblem() reale in lib/offers.js
+// (chiama la RPC report_exchange_problem), con un mock completo del client
+// Supabase — stesso approccio dei test precedenti.
+//
+// Fuori scope qui: la parte "blocca la conferma finché non si risolve" NON
+// è verificabile da un mock (vive, o dovrebbe vivere, dentro
+// confirm_exchange_any) — vedi nota importante sotto.
+const OFFER_ID = "77777777-7777-4777-8777-777777777777";
+
+const mockRpc = jest.fn(async (fn, params) => {
+  if (fn === "report_exchange_problem") {
+    return {
+      data: {
+        id: params.offer_id_text,
+        status: "accepted",
+        disputed_at: new Date().toISOString(),
+        dispute_reason: params.reason_text,
+      },
+      error: null,
+    };
+  }
+  return { data: null, error: null };
+});
+
+jest.mock("../lib/supabase", () => ({
+  supabase: { rpc: (...args) => mockRpc(...args) },
+}));
+
+import { reportExchangeProblem } from "../lib/offers";
+
+test("Contestazione: segnala un problema su una prenotazione accettata", async () => {
+  const disputed = await reportExchangeProblem(OFFER_ID, "Biglietto non ricevuto");
+
+  // Stesso "atteso" della checklist manuale, step 24 (la parte "resta
+  // contestata"): status invariato (accepted), disputed_at valorizzato.
+  expect(disputed.status).toBe("accepted");
+  expect(disputed.disputed_at).toBeTruthy();
+  expect(disputed.dispute_reason).toBe("Biglietto non ricevuto");
+  expect(mockRpc).toHaveBeenCalledWith("report_exchange_problem", {
+    offer_id_text: String(OFFER_ID),
+    reason_text: "Biglietto non ricevuto",
+  });
+});
+
+// NON testato qui (richiede un DB reale, vedi PR): la checklist manuale
+// aspetta che "Prova a confermare da entrambi i lati: deve restare bloccato
+// finché non risolvete". Letta l'ultima versione di confirm_exchange_any
+// (supabase/migrations/20260726120000_data_integrity_hardening.sql) — e le
+// due precedenti — NESSUNA controlla offers.disputed_at prima di finalizzare:
+// un'offerta contestata può comunque essere confermata da entrambe le parti
+// e finalizzarsi normalmente (transactions create, listing venduto/scambiato),
+// nonostante il commento di 20260721210000_exchange_dispute.sql dica
+// esplicitamente "la conferma viene bloccata per entrambi finché non si
+// risolve". Sembra un gap reale, non solo un limite di questo test: senza
+// una modifica alla RPC non c'è nulla da verificare qui lato client.


### PR DESCRIPTION
## Causa

Automatizza il terzo ramo alternativo della checklist manuale
(`docs/CHECKLIST_TEST_MANUALE.md`, Parte 6 "Rami alternativi", step 24
"Contestazione") — una delle due parti segnala un problema su una
prenotazione accettata.

## Cosa aggiunge

`travelswap_ai/travelswapai/__tests__/offerReportProblem.test.js`: chiama
`reportExchangeProblem()` reale in `lib/offers.js` (chiama la RPC
`report_exchange_problem`), con un mock completo del client Supabase —
stesso approccio dei test precedenti.

Verifica: `disputed_at`/`dispute_reason` valorizzati, `status` invariato
(`accepted`) — stesso "atteso" della checklist manuale.

## 🔎 Bug reale trovato (non corretto qui, solo segnalato)

Leggendo `confirm_exchange_any` per capire come dovrebbe comportarsi la
seconda parte dello step 24 ("Prova a confermare da entrambi i lati: deve
restare bloccato finché non risolvete"), ho controllato **tutte e 3** le
riscritture della funzione
(`20260721190000_two_sided_exchange_confirmation.sql`,
`20260723130000_fix_double_commit_listing_race.sql`,
`20260726120000_data_integrity_hardening.sql`, quest'ultima la versione in
uso): **nessuna delle tre controlla mai `offers.disputed_at`** prima di
marcare `owner_confirmed_at`/`proposer_confirmed_at` e finalizzare.

Risultato: una prenotazione contestata può comunque essere confermata da
entrambe le parti e finalizzarsi normalmente (`transactions` create,
annuncio marcato venduto/scambiato) — **nonostante il commento in testa a
`20260721210000_exchange_dispute.sql` dica esplicitamente** *"la conferma
viene bloccata per entrambi finché non si risolve"*. Quel blocco non
esiste da nessuna parte nel codice: sembra un gap reale (la funzionalità
descritta non è mai stata implementata, o è andata persa in una delle
riscritture successive), non solo un limite di questo test — un mock non
può dimostrarlo, serve la RPC reale.

Non l'ho corretto qui (PR di soli test) — fammi sapere se vuoi che
aggiunga il controllo `disputed_at` a `confirm_exchange_any`.

## Verifiche

- `npx jest` (app RN) → 8/8 verdi.
- `cd server && node --experimental-test-module-mocks --test` → 285/285
  verdi, invariato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_