### PR TITLE
Test funzionali: cap annunci attivi e duplicato (checklist #10, #11)

### DIFF
--- a/travelswap_ai/travelswapai/__tests__/activeListingCap.test.js
+++ b/travelswap_ai/travelswapai/__tests__/activeListingCap.test.js
@@ -1,0 +1,40 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 6 "Rami alternativi", step 26 "Cap annunci attivi"): un account con
+// già 10 annunci attivi non può pubblicarne un 11°. Chiama
+// countMyActiveListings() reale in lib/db.js — il pre-check lato client
+// usato da CreateListingScreen prima di permettere "Pubblica" — con un mock
+// completo del client Supabase, stesso approccio dei test precedenti.
+//
+// Il backstop vero è il trigger Postgres enforce_active_listing_cap
+// (20260723110000_active_listing_cap.sql, cap = 10 hardcoded, stesso
+// valore di ACTIVE_LISTING_CAP qui): un mock non lo esercita, resta
+// coperto dalla checklist manuale (l'unico modo per provare davvero un
+// INSERT respinto dal DB).
+import { countMyActiveListings, ACTIVE_LISTING_CAP } from "../lib/db";
+
+jest.mock("../lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: async () => ({ data: { session: { user: { id: "88888888-8888-4888-8888-888888888888" } } }, error: null }),
+      getUser: async () => ({ data: { user: { id: "88888888-8888-4888-8888-888888888888" } }, error: null }),
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => Promise.resolve({ count: 10, error: null }),
+        }),
+      }),
+    }),
+  },
+}));
+
+test("Cap annunci attivi: 10 annunci attivi raggiungono il tetto", async () => {
+  expect(ACTIVE_LISTING_CAP).toBe(10);
+
+  const activeCount = await countMyActiveListings();
+
+  // Stesso "atteso" della checklist manuale, step 26: al decimo annuncio
+  // attivo il tetto è già raggiunto, un undicesimo va bloccato.
+  expect(activeCount).toBe(10);
+  expect(activeCount >= ACTIVE_LISTING_CAP).toBe(true);
+});

--- a/travelswap_ai/travelswapai/__tests__/duplicateListing.test.js
+++ b/travelswap_ai/travelswapai/__tests__/duplicateListing.test.js
@@ -1,0 +1,99 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 6 "Rami alternativi", step 27 "Duplicato"): pubblicare due annunci
+// con stessa tratta/data/prezzo sullo stesso account — il secondo deve
+// essere bloccato o segnalato come "molto simile".
+//
+// findMyDuplicateActiveListing() in lib/db.js fa tutto il confronto in
+// JS (non solo un wrapper RPC come gli altri test di questa serie): legge
+// gli annunci attivi dello stesso tipo dell'account e classifica il
+// candidato come "exact" (stessa tratta/data/prezzo — vero duplicato) o
+// "similar" (stessa tratta ma data/prezzo diversi). Mock completo del
+// client Supabase, stesso approccio dei test precedenti.
+const EXISTING_LISTING = {
+  id: "99999999-9999-4999-8999-999999999999",
+  title: "Roma → Milano, Frecciarossa 9506",
+  type: "train",
+  location: null,
+  route_from: "Roma",
+  route_to: "Milano",
+  depart_at: "2026-08-05T09:00:00Z",
+  check_in: null,
+  price: 45,
+  status: "active",
+};
+
+jest.mock("../lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: async () => ({ data: { session: { user: { id: "88888888-8888-4888-8888-888888888888" } } }, error: null }),
+      getUser: async () => ({ data: { user: { id: "88888888-8888-4888-8888-888888888888" } }, error: null }),
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            eq: async () => ({
+              data: [{
+                id: "99999999-9999-4999-8999-999999999999",
+                title: "Roma → Milano, Frecciarossa 9506",
+                type: "train",
+                location: null,
+                route_from: "Roma",
+                route_to: "Milano",
+                depart_at: "2026-08-05T09:00:00Z",
+                check_in: null,
+                price: 45,
+                status: "active",
+              }],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+import { findMyDuplicateActiveListing } from "../lib/db";
+
+test("Duplicato: stessa tratta, stessa data, stesso prezzo -> exact", async () => {
+  const result = await findMyDuplicateActiveListing({
+    type: "train",
+    route_from: "Roma",
+    route_to: "Milano",
+    depart_at: "2026-08-05T10:30:00Z", // stesso giorno, ora diversa: sameDay confronta solo la data
+    price: 45,
+  });
+
+  // Stesso "atteso" della checklist manuale, step 27: vero duplicato.
+  expect(result.exact).toBeTruthy();
+  expect(result.exact.id).toBe(EXISTING_LISTING.id);
+  expect(result.similar).toBeNull();
+});
+
+test("Duplicato: stessa tratta ma data/prezzo diversi -> similar, non exact", async () => {
+  const result = await findMyDuplicateActiveListing({
+    type: "train",
+    route_from: "Roma",
+    route_to: "Milano",
+    depart_at: "2026-08-12T09:00:00Z", // giorno diverso
+    price: 60, // prezzo diverso
+  });
+
+  expect(result.exact).toBeNull();
+  expect(result.similar).toBeTruthy();
+  expect(result.similar.id).toBe(EXISTING_LISTING.id);
+});
+
+test("Nessun duplicato: tratta diversa -> né exact né similar", async () => {
+  const result = await findMyDuplicateActiveListing({
+    type: "train",
+    route_from: "Napoli",
+    route_to: "Bari",
+    depart_at: "2026-08-05T09:00:00Z",
+    price: 45,
+  });
+
+  expect(result.exact).toBeNull();
+  expect(result.similar).toBeNull();
+});


### PR DESCRIPTION
## Causa

Completa Parte 6 "Rami alternativi" della checklist manuale
(`docs/CHECKLIST_TEST_MANUALE.md`) con gli ultimi due rami rimasti: step 26
"Cap annunci attivi" e step 27 "Duplicato".

## Cosa aggiunge

- `activeListingCap.test.js`: `countMyActiveListings()` reale in
  `lib/db.js` (il pre-check lato client usato da `CreateListingScreen`
  prima di permettere "Pubblica"), con un mock completo del client
  Supabase. Il backstop vero è il trigger Postgres
  `enforce_active_listing_cap` (`20260723110000_active_listing_cap.sql`,
  cap=10 hardcoded — stesso valore di `ACTIVE_LISTING_CAP` lato client,
  nessun disallineamento trovato) — non esercitato da un mock, resta
  coperto dalla checklist manuale.

- `duplicateListing.test.js`: `findMyDuplicateActiveListing()` reale in
  `lib/db.js` — a differenza degli altri test di questa serie fa **tutta
  la classificazione in JS** (non solo un wrapper RPC), quindi qui il mock
  esercita davvero la logica applicativa: stessa tratta+data+prezzo →
  `exact` (vero duplicato), stessa tratta ma data/prezzo diversi →
  `similar`, tratta diversa → nessuno dei due.

Con questi due si chiude l'intera Parte 6 della checklist (rifiuto,
annullamento, contestazione, prenotazione scaduta, cap, duplicato — PR
#195-199 + questa).

## Verifiche

- `npx jest` (app RN) → 11 suite / 13 test verdi.
- `cd server && node --experimental-test-module-mocks --test` → 286/286
  verdi, invariato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_