### PR TITLE
Test funzionale: traduzione on-demand con cache (checklist #15)

### DIFF
--- a/travelswap_ai/travelswapai/__tests__/listingTranslationCache.test.js
+++ b/travelswap_ai/travelswapai/__tests__/listingTranslationCache.test.js
@@ -1,0 +1,53 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 8 "Funzionalità collaterali", step 37 "Traduzione on-demand"):
+// riaprendo lo stesso annuncio, la seconda richiesta di traduzione deve
+// arrivare dalla cache in-memory (nessuna nuova chiamata di rete).
+//
+// useListingTranslation() è un hook React (lib/useListingTranslation.js):
+// serve renderHook di @testing-library/react-native invece di un mock
+// diretto del client Supabase — qui non c'è Supabase in mezzo, la
+// traduzione passa dal backend (GET /api/listings/:id/translate), quindi
+// si mocka fetchJson (lib/backendApi.js).
+const mockFetchJson = jest.fn();
+
+jest.mock("../lib/backendApi", () => ({
+  fetchJson: (...args) => mockFetchJson(...args),
+}));
+
+import { renderHook, act } from "@testing-library/react-native";
+import { useListingTranslation } from "../lib/useListingTranslation";
+
+test("Traduzione on-demand: la seconda richiesta usa la cache in-memory", async () => {
+  mockFetchJson.mockResolvedValueOnce({
+    title: "Room in Rome",
+    description: "Nice room, quiet street",
+    lang: "en",
+    originalLang: "it",
+    translated: true,
+    titleTranslated: true,
+    descriptionTranslated: true,
+    cached: false,
+  });
+
+  const { result } = renderHook(() => useListingTranslation());
+
+  let first;
+  await act(async () => {
+    first = await result.current.getTranslated("listing-1", "en");
+  });
+
+  expect(first.title).toBe("Room in Rome");
+  expect(first.translated).toBe(true);
+  expect(mockFetchJson).toHaveBeenCalledTimes(1);
+  expect(mockFetchJson).toHaveBeenCalledWith("/api/listings/listing-1/translate?lang=en", { method: "GET" });
+
+  let second;
+  await act(async () => {
+    second = await result.current.getTranslated("listing-1", "en");
+  });
+
+  // Stesso "atteso" della checklist manuale, step 37: nessuna nuova
+  // chiamata di rete, stesso risultato della prima volta.
+  expect(second).toEqual(first);
+  expect(mockFetchJson).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Causa

Automatizza il terzo ramo di Parte 8 "Funzionalità collaterali" della
checklist manuale (`docs/CHECKLIST_TEST_MANUALE.md`, step 37 "Traduzione
on-demand") — riaprendo lo stesso annuncio, la seconda richiesta di
traduzione deve arrivare dalla cache in-memory.

## Cosa aggiunge

`travelswap_ai/travelswapai/__tests__/listingTranslationCache.test.js`:
`useListingTranslation()` è un **hook React** (`lib/useListingTranslation.js`),
diverso dagli altri test di questa serie — qui non c'è Supabase in mezzo
(la traduzione passa dal backend, `GET /api/listings/:id/translate`),
quindi si mocka `fetchJson` (`lib/backendApi.js`) e si usa `renderHook` di
`@testing-library/react-native` (già installato per lo smoke test)
invece di un mock diretto del client Supabase.

Verifica: la prima richiesta chiama `fetchJson` una volta e ottiene il
risultato tradotto; la seconda richiesta con lo stesso `listingId`/`lang`
ritorna lo stesso risultato **senza** una seconda chiamata di rete
(`mockFetchJson` chiamato una sola volta in totale) — stesso "atteso"
della checklist manuale.

## Verifiche

- `npx jest` (app RN) → 15 suite / 18 test verdi.
- `cd server && node --experimental-test-module-mocks --test` → 286/286
  verdi, invariato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_