### PR TITLE
Test funzionale: stima prezzo in creazione annuncio (checklist #16)

### DIFF
--- a/travelswap_ai/travelswapai/__tests__/priceSuggestion.test.js
+++ b/travelswap_ai/travelswapai/__tests__/priceSuggestion.test.js
@@ -1,0 +1,46 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 8 "Funzionalità collaterali", step 38 "Stima prezzo AI"): in
+// creazione annuncio, tocca "Analisi prezzo con AI" → deve proporre un
+// numero sensato per la tratta/data.
+//
+// Nota importante: nonostante l'etichetta, questa NON è una vera analisi
+// AI — è un calcolo deterministico locale basato solo sulla durata
+// (screens/CreateListingScreen.js: "Simulazione di analisi AI locale"),
+// diverso dal pulsante con LO STESSO testo "Analisi prezzo con AI" in
+// ListingDetailScreen (usePriceCheck), che invece chiama davvero il
+// backend. Estratto qui in lib/priceSuggestion.js (prima viveva solo
+// dentro lo screen) per poterlo testare senza montare l'intera schermata;
+// il parsing delle date resta nello screen, immutato.
+import { suggestListingPrice } from "../lib/priceSuggestion";
+
+test("Stima prezzo: treno, durata nota -> ore * 12€, arrotondato a 5", () => {
+  const suggestion = suggestListingPrice({
+    type: "train",
+    departDate: new Date("2026-08-05T09:00:00Z"),
+    arriveDate: new Date("2026-08-05T12:30:00Z"), // 3h30 -> arrotondato a 4h
+  });
+
+  // 4h * 12€ = 48 -> arrotondato ai 5€ più vicini = 50.
+  expect(suggestion).toBe(50);
+});
+
+test("Stima prezzo: hotel, notti note -> notti * 80€, con tetto a 400", () => {
+  const suggestion = suggestListingPrice({
+    type: "hotel",
+    checkInDate: new Date("2026-08-05"),
+    checkOutDate: new Date("2026-08-12"), // 7 notti
+  });
+
+  // 7 notti * 80€ = 560 -> oltre il tetto di 400.
+  expect(suggestion).toBe(400);
+});
+
+test("Stima prezzo: senza date valide usa il default (2h treno / 1 notte hotel)", () => {
+  const train = suggestListingPrice({ type: "train", departDate: null, arriveDate: null });
+  // 2h default * 12€ = 24 -> arrotondato ai 5€ più vicini = 25.
+  expect(train).toBe(25);
+
+  const hotel = suggestListingPrice({ type: "hotel", checkInDate: null, checkOutDate: null });
+  // 1 notte default * 80€ = 80, già multiplo di 5, tetto minimo 40 non tocca.
+  expect(hotel).toBe(80);
+});

--- a/travelswap_ai/travelswapai/lib/priceSuggestion.js
+++ b/travelswap_ai/travelswapai/lib/priceSuggestion.js
@@ -1,0 +1,33 @@
+// lib/priceSuggestion.js — suggerimento di prezzo in creazione annuncio.
+//
+// Il pulsante dice "Analisi prezzo con AI" ma NON chiama nessuna AI: è un
+// calcolo deterministico basato solo sulla durata (notti per hotel, ore di
+// viaggio per treno). Stesso identico testo del pulsante "Analisi prezzo
+// con AI" in ListingDetailScreen (usePriceCheck/checkPrice), che invece
+// chiama davvero il backend (GET /api/listings/:id/price-check) — due
+// funzionalità diverse dietro la stessa etichetta.
+//
+// Il parsing delle date resta nello screen (parseISODate/parseISODateTime,
+// più severi di un semplice `new Date()`): qui arrivano già Date o null.
+export function suggestListingPrice({ type, checkInDate, checkOutDate, departDate, arriveDate }) {
+  if (type === "hotel") {
+    const nights = (checkInDate && checkOutDate)
+      ? Math.max(1, Math.round((checkOutDate - checkInDate) / (1000 * 60 * 60 * 24)))
+      : 1;
+    const basePerNight = 80; // eur
+    return round5(clamp(nights * basePerNight, 40, 400));
+  }
+  const hours = (departDate && arriveDate)
+    ? Math.max(1, Math.round((arriveDate - departDate) / (1000 * 60 * 60)))
+    : 2;
+  const perHour = 12; // eur
+  return round5(clamp(hours * perHour, 10, 120));
+}
+
+function clamp(n, min, max) {
+  return Math.max(min, Math.min(max, n));
+}
+
+function round5(n) {
+  return Math.round(n / 5) * 5;
+}

--- a/travelswap_ai/travelswapai/screens/CreateListingScreen.js
+++ b/travelswap_ai/travelswapai/screens/CreateListingScreen.js
@@ -32,6 +32,7 @@ import { parseListingFromTextAI, parseListingFromPdfAI } from "../lib/descriptio
 import { Image } from "react-native";
 import { listImages, uploadImage, deleteImage } from "../lib/listingImages";
 import { parseLocalizedNumber } from "../lib/number";
+import { suggestListingPrice } from "../lib/priceSuggestion";
 import { isConcludedStatus } from "../lib/listingStatus";
 import StationAutocomplete from "../components/StationAutocomplete";
 // Regole testuali (CERCO/VENDO, tratte, date, PNR, "sembrano due biglietti"):
@@ -1553,24 +1554,15 @@ const initialJsonRef = useRef(null);
     try {
       setPriceLoading(true);
       // Simulazione di analisi AI locale: stima semplice basata su durata
-      let suggestion = parseLocalizedNumber(form.price) ?? 0;
-      if (!Number.isFinite(suggestion) || suggestion <= 0) suggestion = 0;
-
-      if (form.type === "hotel") {
-        const a = parseISODate(form.checkIn);
-        const b = parseISODate(form.checkOut);
-        const nights = (a && b) ? Math.max(1, Math.round((b - a) / (1000 * 60 * 60 * 24))) : 1;
-        const basePerNight = 80; // eur
-        suggestion = Math.max(40, Math.min(400, nights * basePerNight));
-      } else {
-        const da = parseISODateTime(form.departAt);
-        const ar = parseISODateTime(form.arriveAt);
-        const hours = (da && ar) ? Math.max(1, Math.round((ar - da) / (1000 * 60 * 60))) : 2;
-        const perHour = 12; // eur
-        suggestion = Math.max(10, Math.min(120, hours * perHour));
-      }
-      // arrotonda a 5€
-      suggestion = Math.round(suggestion / 5) * 5;
+      // (nessuna chiamata di rete). Calcolo puro in lib/priceSuggestion.js,
+      // testabile da solo; il parsing delle date resta qui.
+      const suggestion = suggestListingPrice({
+        type: form.type,
+        checkInDate: form.type === "hotel" ? parseISODate(form.checkIn) : null,
+        checkOutDate: form.type === "hotel" ? parseISODate(form.checkOut) : null,
+        departDate: form.type !== "hotel" ? parseISODateTime(form.departAt) : null,
+        arriveDate: form.type !== "hotel" ? parseISODateTime(form.arriveAt) : null,
+      });
 
       update({ price: String(suggestion) });
       Alert.alert(


### PR DESCRIPTION
## Causa

Automatizza il quarto ramo di Parte 8 "Funzionalità collaterali" della
checklist manuale (`docs/CHECKLIST_TEST_MANUALE.md`, step 38 "Stima
prezzo AI") — in creazione annuncio, tocca "Analisi prezzo con AI" → deve
proporre un numero sensato per la tratta/data.

## 🔎 Cosa ho trovato

Nonostante l'etichetta, questa **non è una vera analisi AI**: è un calcolo
deterministico locale basato solo sulla durata (il commento nel codice di
`CreateListingScreen.js` dice già *"Simulazione di analisi AI locale"*) —
nessuna chiamata di rete, nessun costo OpenAI.

Curiosità: **lo stesso identico testo del pulsante** ("Analisi prezzo con
AI", stessa chiave i18n `aiPriceCta`) esiste anche in
`ListingDetailScreen.js` (`usePriceCheck`/`checkPrice`), che invece chiama
**davvero** il backend (`GET /api/listings/:id/price-check`). Stessa
etichetta, due funzionalità diverse dietro — non l'ho toccato (è un
dettaglio di copy/UX, non un bug funzionale), solo segnalato.

## Cosa aggiunge

- `lib/priceSuggestion.js` (nuovo): estratto il **calcolo puro** (prima
  viveva solo dentro `CreateListingScreen.js`, non testabile senza montare
  l'intera schermata) — `nights`/`hours` → prezzo clampato (40-400€ hotel,
  10-120€ treno) e arrotondato a 5€. Il parsing delle date
  (`parseISODate`/`parseISODateTime`, più severo di un `new Date()`
  semplice) resta nello screen, **invariato** — nessun cambio di
  comportamento, solo la parte di calcolo è stata resa importabile.
  Rimossa anche un'inizializzazione morta
  (`parseLocalizedNumber(form.price)` come suggestion iniziale, sempre
  sovrascritta in entrambi i rami hotel/treno, mai realmente usata).
- `__tests__/priceSuggestion.test.js`: verifica treno (durata nota →
  ore×12€), hotel (notti note → notti×80€, col tetto a 400€ testato) e il
  fallback di default (2h/1 notte) quando le date non sono valide.

## Verifiche

- `npx jest` (app RN) → 16 suite / 21 test verdi.
- Parse-check su `CreateListingScreen.js` → OK.
- `cd server && node --experimental-test-module-mocks --test` → 286/286
  verdi, invariato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_