### PR TITLE
Aggiunge una vera AI alla stima prezzo in creazione annuncio

### DIFF
--- a/server/src/ai/priceCheck.js
+++ b/server/src/ai/priceCheck.js
@@ -76,6 +76,80 @@ function describeListing(listing) {
   return extra.length ? `${base}\n${extra.join("\n")}` : base;
 }
 
+function suggestSystemPromptFor(locale, hasPurchaseCap) {
+  const langName = LOCALE_LANG_NAME[locale] || LOCALE_LANG_NAME.it;
+  return (
+    "Sei un valutatore prezzi per un marketplace dove privati rivendono " +
+    "biglietti treno e prenotazioni hotel non più utilizzabili (mercato italiano). Il venditore " +
+    "non ha ancora scelto un prezzo: suggerisci TU un valore plausibile in EUR, basato sulla tua " +
+    "conoscenza generale dei prezzi tipici in Italia — non hai accesso a dati di mercato in tempo " +
+    "reale, quindi resta prudente se l'informazione è insufficiente.\n" +
+    "Ragiona sugli stessi fattori di sempre quando la data è nota: stagionalità/giorno della " +
+    "settimana per un hotel, classe/tipologia di servizio per un treno. Se titolo/descrizione non " +
+    "specificano questi dettagli, NON assumere silenziosamente la fascia più economica: suggerisci " +
+    "un valore prudente e segnala nella spiegazione che l'assenza di dettagli rende la stima meno precisa.\n" +
+    (hasPurchaseCap
+      ? "- Tetto anti-bagarinaggio: ti viene indicato il prezzo di acquisto originale dichiarato dal " +
+        "venditore. Su questa piattaforma il prezzo di rivendita NON PUÒ MAI superarlo: è un vincolo " +
+        "tecnico bloccante lato server, non un consiglio. Non suggerire mai un prezzo più alto di quel " +
+        "tetto, anche se stimi che il valore di mercato sarebbe superiore — in quel caso proponi il " +
+        "tetto stesso (o poco sotto) e spiegalo brevemente.\n"
+      : "") +
+    "Rispondi SOLO con JSON valido: " +
+    `{ "suggestedPrice": number, "explanation": string } — explanation in ${langName}, max 2 frasi.`
+  );
+}
+
+/**
+ * Suggerisce un prezzo di partenza per un annuncio ancora in bozza (nessun
+ * id: non esiste come riga finché non si pubblica) — a differenza di
+ * checkPriceWithAI, che GIUDICA un prezzo già scelto su un annuncio già
+ * pubblicato, questa PROPONE un numero da zero.
+ *
+ * @param {object} draft - stessi campi di "listing" sopra, ma price è ignorato anche se presente
+ * @param {string} locale - "it" | "en" | "es"
+ * @returns {Promise<{available:true, suggestedPrice:number, explanation:string} | {available:false, reason:string}>}
+ */
+export async function suggestPriceWithAI(draft, locale = "it") {
+  if (!client) {
+    return { available: false, reason: "OPENAI_API_KEY non configurata sul server" };
+  }
+
+  const context = describeListing(draft);
+  const purchaseCap = Number(draft?.purchase_price);
+  const hasPurchaseCap = Number.isFinite(purchaseCap) && purchaseCap > 0;
+  const user = `${context}\nIl venditore non ha ancora indicato un prezzo: suggerisci tu un valore plausibile per la rivendita.`;
+
+  try {
+    const completion = await client.chat.completions.create({
+      model: MODEL,
+      response_format: { type: "json_object" },
+      temperature: 0.3,
+      messages: [
+        { role: "system", content: suggestSystemPromptFor(locale, hasPurchaseCap) },
+        { role: "user", content: user },
+      ],
+    });
+
+    const raw = completion?.choices?.[0]?.message?.content || "{}";
+    let parsed = {};
+    try { parsed = JSON.parse(raw); } catch { parsed = {}; }
+
+    const suggestedPrice = Number(parsed.suggestedPrice);
+    if (!Number.isFinite(suggestedPrice) || suggestedPrice <= 0) {
+      return { available: false, reason: "Suggerimento non valido" };
+    }
+    const explanation = (typeof parsed.explanation === "string" && parsed.explanation.trim())
+      ? parsed.explanation.trim()
+      : (FALLBACK_EXPLANATION[locale] || FALLBACK_EXPLANATION.it);
+
+    return { available: true, suggestedPrice: Math.round(suggestedPrice), explanation };
+  } catch (e) {
+    console.error("[suggestPriceWithAI] error:", e?.message || e);
+    return { available: false, reason: "Analisi non riuscita al momento" };
+  }
+}
+
 /**
  * @param {object} listing - riga della tabella listings (type, price, currency, location, route_from, route_to, check_in, check_out, depart_at, arrive_at, title, description, purchase_price)
  * @param {string} locale - "it" | "en" | "es", lingua della spiegazione restituita

--- a/server/src/routes/priceCheck.js
+++ b/server/src/routes/priceCheck.js
@@ -1,11 +1,43 @@
 // server/src/routes/priceCheck.js
 import express from "express";
 import { supabase } from "../db.js";
-import { checkPriceWithAI } from "../ai/priceCheck.js";
+import { checkPriceWithAI, suggestPriceWithAI } from "../ai/priceCheck.js";
 import { requireAuth } from "../middleware/requireAuth.js";
 import { rateLimitPriceCheck } from "../middleware/rateLimit.js";
 
 export const priceCheckRouter = express.Router();
+
+// POST /api/listings/price-suggest — bozza in creazione, PRIMA di pubblicare:
+// l'annuncio non esiste ancora come riga (nessun id), quindi a differenza di
+// /price-check qui sotto i dati arrivano nel body, non da una select per id.
+// Stesso limite di frequenza di /price-check: stesso budget OpenAI, stessa
+// categoria di funzionalità ("analisi prezzo").
+priceCheckRouter.post("/api/listings/price-suggest", requireAuth, rateLimitPriceCheck, async (req, res) => {
+  try {
+    const b = req.body || {};
+    const type = b.type === "hotel" ? "hotel" : "train";
+    const locale = ["it", "en", "es"].includes(b.locale) ? b.locale : "it";
+    const draft = {
+      type,
+      currency: b.currency || "EUR",
+      location: b.location || null,
+      route_from: b.routeFrom || null,
+      route_to: b.routeTo || null,
+      depart_at: b.departAt || null,
+      arrive_at: b.arriveAt || null,
+      check_in: b.checkIn || null,
+      check_out: b.checkOut || null,
+      title: b.title || null,
+      description: b.description || null,
+      purchase_price: b.purchasePrice ?? null,
+    };
+    const result = await suggestPriceWithAI(draft, locale);
+    return res.json(result);
+  } catch (e) {
+    console.error("[price-suggest][server] error", e);
+    return res.status(500).json({ available: false, reason: "server_error" });
+  }
+});
 
 // GET /api/listings/:id/price-check
 priceCheckRouter.get("/api/listings/:id/price-check", requireAuth, rateLimitPriceCheck, async (req, res) => {

--- a/server/test/suggestPriceWithAI.test.js
+++ b/server/test/suggestPriceWithAI.test.js
@@ -1,0 +1,33 @@
+// Test della nuova funzionalità "Analisi prezzo con AI in creazione"
+// (checklist manuale, Parte 8, step 38): suggerisce un prezzo di partenza
+// per un annuncio ancora in bozza (nessun listing.id, a differenza di
+// checkPriceWithAI che giudica un prezzo su un annuncio già pubblicato).
+//
+// Nessuna chiave OPENAI_API_KEY in CI: suggestPriceWithAI ricade sempre sul
+// ramo "AI non disponibile" (client === null), esattamente come tutte le
+// altre funzioni AI di questo repo (computeTrustScoreDuration.test.js,
+// score.js) — è il percorso deterministico che deve reggersi da solo
+// quando l'AI non risponde, e non richiede una vera chiave per essere
+// testato.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { suggestPriceWithAI } from '../src/ai/priceCheck.js';
+
+test('suggestPriceWithAI: senza OPENAI_API_KEY ritorna available=false con motivo leggibile', async () => {
+  assert.equal(process.env.OPENAI_API_KEY, undefined, 'questo test presume nessuna chiave in CI');
+
+  const draft = {
+    type: 'train',
+    currency: 'EUR',
+    route_from: 'Roma',
+    route_to: 'Milano',
+    depart_at: '2026-08-05T09:00:00Z',
+    arrive_at: '2026-08-05T12:30:00Z',
+    title: 'Frecciarossa 9506',
+  };
+
+  const result = await suggestPriceWithAI(draft, 'it');
+
+  assert.equal(result.available, false);
+  assert.match(result.reason, /OPENAI_API_KEY/i);
+});

--- a/travelswap_ai/travelswapai/__tests__/priceSuggestAI.test.js
+++ b/travelswap_ai/travelswapai/__tests__/priceSuggestAI.test.js
@@ -1,0 +1,57 @@
+// Test funzionale del checklist manuale (docs/CHECKLIST_TEST_MANUALE.md,
+// Parte 8 "Funzionalità collaterali", step 38 "Stima prezzo AI") — parte
+// lato client della vera AI aggiunta in creazione annuncio (prima era solo
+// una formula locale, vedi priceSuggestion.test.js): POST
+// /api/listings/price-suggest su una bozza senza ancora un listing.id.
+//
+// usePriceSuggestAI() è un hook React (come useListingTranslation): si
+// mocka fetchJson (lib/backendApi.js) e si usa renderHook, non un mock
+// diretto del client Supabase (qui non c'è Supabase in mezzo).
+const mockFetchJson = jest.fn();
+
+jest.mock("../lib/backendApi", () => ({
+  fetchJson: (...args) => mockFetchJson(...args),
+}));
+
+import { renderHook, act } from "@testing-library/react-native";
+import { usePriceSuggestAI } from "../lib/usePriceSuggestAI";
+
+test("Stima prezzo AI (creazione): propone un prezzo con spiegazione", async () => {
+  mockFetchJson.mockResolvedValueOnce({
+    available: true,
+    suggestedPrice: 55,
+    explanation: "Frecciarossa in alta velocità, tratta breve: prezzo in linea con il mercato.",
+  });
+
+  const { result } = renderHook(() => usePriceSuggestAI());
+
+  let res;
+  await act(async () => {
+    res = await result.current.suggestPriceAI(
+      { type: "train", routeFrom: "Roma", routeTo: "Milano", departAt: "2026-08-05T09:00:00Z", arriveAt: "2026-08-05T12:30:00Z" },
+      "it"
+    );
+  });
+
+  expect(res.available).toBe(true);
+  expect(res.suggestedPrice).toBe(55);
+  expect(mockFetchJson).toHaveBeenCalledWith("/api/listings/price-suggest", {
+    method: "POST",
+    body: { type: "train", routeFrom: "Roma", routeTo: "Milano", departAt: "2026-08-05T09:00:00Z", arriveAt: "2026-08-05T12:30:00Z", locale: "it" },
+  });
+});
+
+test("Stima prezzo AI (creazione): se il backend non è disponibile, torna available=false", async () => {
+  mockFetchJson.mockRejectedValueOnce(new Error("rate_limited"));
+
+  const { result } = renderHook(() => usePriceSuggestAI());
+
+  let res;
+  await act(async () => {
+    res = await result.current.suggestPriceAI({ type: "hotel", location: "Roma" }, "it");
+  });
+
+  // Il chiamante (analyzePriceAI in CreateListingScreen) usa questo per
+  // decidere se ricadere sulla formula locale in lib/priceSuggestion.js.
+  expect(res.available).toBe(false);
+});

--- a/travelswap_ai/travelswapai/lib/i18n/translations.js
+++ b/travelswap_ai/travelswapai/lib/i18n/translations.js
@@ -743,6 +743,7 @@ export const translations = {
 
       priceSuggestionTitle: "Suggerimento prezzo",
       priceSuggestionMsg: "In base ai dati inseriti, potresti proporre circa {price}€.\nÈ solo un consiglio: sentiti libero di adattarlo.",
+      priceSuggestionMsgAI: "Potresti proporre circa {price}€. {explanation}\nÈ solo un consiglio: sentiti libero di adattarlo.",
       priceEstimateErrorMsg: "Impossibile stimare il prezzo al momento.",
 
       checkAiAutoFailedTitle: "Verifica non riuscita",
@@ -1945,6 +1946,7 @@ export const translations = {
 
       priceSuggestionTitle: "Price suggestion",
       priceSuggestionMsg: "Based on the entered data, you could ask around {price}€.\nIt's just a suggestion: feel free to adjust it.",
+      priceSuggestionMsgAI: "You could ask around {price}€. {explanation}\nIt's just a suggestion: feel free to adjust it.",
       priceEstimateErrorMsg: "Couldn't estimate the price right now.",
 
       checkAiAutoFailedTitle: "Verification failed",
@@ -3013,6 +3015,7 @@ export const translations = {
 
       priceSuggestionTitle: "Sugerencia de precio",
       priceSuggestionMsg: "Según los datos introducidos, podrías pedir unos {price}€.\nEs solo un consejo: siéntete libre de ajustarlo.",
+      priceSuggestionMsgAI: "Podrías pedir unos {price}€. {explanation}\nEs solo un consejo: siéntete libre de ajustarlo.",
       priceEstimateErrorMsg: "No se pudo estimar el precio en este momento.",
 
       checkAiAutoFailedTitle: "Verificación fallida",

--- a/travelswap_ai/travelswapai/lib/usePriceSuggestAI.js
+++ b/travelswap_ai/travelswapai/lib/usePriceSuggestAI.js
@@ -1,0 +1,36 @@
+// lib/usePriceSuggestAI.js
+import { useCallback, useState } from "react";
+import { fetchJson } from "./backendApi";
+
+/**
+ * Hook per il suggerimento di prezzo con AI VERA in creazione annuncio,
+ * su una bozza senza ancora un listing.id:
+ * POST /api/listings/price-suggest
+ *
+ * Diverso da usePriceCheck (che GIUDICA un prezzo già scelto su un annuncio
+ * già pubblicato, verdict low/fair/high): questo PROPONE un numero da zero.
+ *
+ * Ritorna: { suggestPriceAI, loading }
+ * - suggestPriceAI(draft, locale) -> { available:true, suggestedPrice, explanation } | { available:false, reason }
+ */
+export function usePriceSuggestAI() {
+  const [loading, setLoading] = useState(false);
+
+  const suggestPriceAI = useCallback(async (draft, locale = "it") => {
+    setLoading(true);
+    try {
+      const res = await fetchJson("/api/listings/price-suggest", {
+        method: "POST",
+        body: { ...draft, locale },
+      });
+      return res || { available: false, reason: "empty_response" };
+    } catch (e) {
+      console.log("[priceSuggestAI][client] error =", e);
+      return { available: false, reason: e?.message || String(e) };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { suggestPriceAI, loading };
+}

--- a/travelswap_ai/travelswapai/screens/CreateListingScreen.js
+++ b/travelswap_ai/travelswapai/screens/CreateListingScreen.js
@@ -9,6 +9,7 @@ import { recomputeAIAndSnapshot, propagateListing } from "../lib/backendApi";
 import { theme } from "../lib/theme";
 import TrustScoreBadge from '../components/TrustScoreBadge';
 import { useTrustScore } from '../lib/useTrustScore';
+import { usePriceSuggestAI } from '../lib/usePriceSuggestAI';
 import TrustInfo from '../components/TrustInfo';
 import {
   View, Text, TextInput, TouchableOpacity, ScrollView,
@@ -425,6 +426,7 @@ export default function CreateListingScreen({
 
   // TrustScore hook + UI state
   const { loading: trustLoading, data: trustData, error: trustError, evaluate, reset: resetTrust } = useTrustScore();
+  const { suggestPriceAI } = usePriceSuggestAI();
   const [splitDetected, setSplitDetected] = useState(false);
   const [splitReason, setSplitReason] = useState("");
 
@@ -1553,25 +1555,60 @@ const initialJsonRef = useRef(null);
   const analyzePriceAI = async () => {
     try {
       setPriceLoading(true);
-      // Simulazione di analisi AI locale: stima semplice basata su durata
-      // (nessuna chiamata di rete). Calcolo puro in lib/priceSuggestion.js,
-      // testabile da solo; il parsing delle date resta qui.
-      const suggestion = suggestListingPrice({
+
+      // Prova prima l'AI vera (POST /api/listings/price-suggest): a
+      // differenza del Check AI, qui l'annuncio non esiste ancora come riga
+      // (nessun id), quindi i dati della bozza viaggiano nel body.
+      const draft = {
         type: form.type,
-        checkInDate: form.type === "hotel" ? parseISODate(form.checkIn) : null,
-        checkOutDate: form.type === "hotel" ? parseISODate(form.checkOut) : null,
-        departDate: form.type !== "hotel" ? parseISODateTime(form.departAt) : null,
-        arriveDate: form.type !== "hotel" ? parseISODateTime(form.arriveAt) : null,
-      });
+        currency: "EUR",
+        location: form.type === "hotel" ? (form.location || null) : null,
+        routeFrom: form.type !== "hotel" ? (form.routeFrom || null) : null,
+        routeTo: form.type !== "hotel" ? (form.routeTo || null) : null,
+        departAt: form.type !== "hotel" ? (form.departAt || null) : null,
+        arriveAt: form.type !== "hotel" ? (form.arriveAt || null) : null,
+        checkIn: form.type === "hotel" ? (form.checkIn || null) : null,
+        checkOut: form.type === "hotel" ? (form.checkOut || null) : null,
+        title: form.title || null,
+        description: form.description || null,
+        purchasePrice: form.purchasePrice ? parseLocalizedNumber(form.purchasePrice) : null,
+      };
+      const aiRes = await suggestPriceAI(draft, locale);
+      const aiPrice = Number(aiRes?.suggestedPrice);
+
+      let suggestion;
+      let explanation = null;
+      if (aiRes?.available && Number.isFinite(aiPrice) && aiPrice > 0) {
+        suggestion = Math.round(aiPrice);
+        explanation = aiRes.explanation || null;
+      } else {
+        // Fallback deterministico locale se l'AI non è disponibile (nessuna
+        // chiave OpenAI, rete assente, rate limit): stessa formula usata
+        // prima che esistesse una vera AI qui — calcolo puro in
+        // lib/priceSuggestion.js, il parsing delle date resta qui.
+        suggestion = suggestListingPrice({
+          type: form.type,
+          checkInDate: form.type === "hotel" ? parseISODate(form.checkIn) : null,
+          checkOutDate: form.type === "hotel" ? parseISODate(form.checkOut) : null,
+          departDate: form.type !== "hotel" ? parseISODateTime(form.departAt) : null,
+          arriveDate: form.type !== "hotel" ? parseISODateTime(form.arriveAt) : null,
+        });
+      }
 
       update({ price: String(suggestion) });
       Alert.alert(
         t("createListing.priceSuggestionTitle", "Suggerimento prezzo"),
-        t(
-          "createListing.priceSuggestionMsg",
-          `In base ai dati inseriti, potresti proporre circa ${suggestion}€.\nÈ solo un consiglio: sentiti libero di adattarlo.`,
-          { price: suggestion }
-        )
+        explanation
+          ? t(
+              "createListing.priceSuggestionMsgAI",
+              `Potresti proporre circa ${suggestion}€. ${explanation}\nÈ solo un consiglio: sentiti libero di adattarlo.`,
+              { price: suggestion, explanation }
+            )
+          : t(
+              "createListing.priceSuggestionMsg",
+              `In base ai dati inseriti, potresti proporre circa ${suggestion}€.\nÈ solo un consiglio: sentiti libero di adattarlo.`,
+              { price: suggestion }
+            )
       );
     } catch {
       Alert.alert(t("common.error", "Errore"), t("createListing.priceEstimateErrorMsg", "Impossibile stimare il prezzo al momento."));


### PR DESCRIPTION
## Causa

Come emerso nel test #16 (PR #205): "Analisi prezzo con AI" in creazione
era solo una formula locale, nessuna vera chiamata AI — a differenza dello
stesso identico testo del pulsante in `ListingDetailScreen` (`usePriceCheck`),
che giudica davvero con GPT-4o-mini un prezzo già scelto su un annuncio
già pubblicato.

Il motivo tecnico: l'endpoint esistente (`GET /api/listings/:id/price-check`)
legge l'annuncio dal DB per `id`, e in creazione l'annuncio non esiste
ancora come riga — nessun `id` da passare.

## Cosa aggiunge

Un endpoint nuovo, pensato per una bozza senza `id`:

- `server/src/ai/priceCheck.js` — nuova `suggestPriceWithAI(draft, locale)`:
  a differenza di `checkPriceWithAI` (giudica un prezzo dato:
  low/fair/high), questa **propone un numero da zero**
  (`{ suggestedPrice, explanation }`), stesso modello/stile di prompt,
  stesso rispetto del tetto anti-bagarinaggio se il prezzo di acquisto è
  già noto.
- `server/src/routes/priceCheck.js` — `POST /api/listings/price-suggest`,
  riceve i campi della bozza nel body (non un `id`), stesso
  `rateLimitPriceCheck` del `/price-check` esistente (stesso budget
  OpenAI, stessa categoria di funzionalità).
- `lib/usePriceSuggestAI.js` (nuovo) — hook client, stesso schema di
  `useListingTranslation`/`usePriceCheck`.
- `CreateListingScreen.js` — `analyzePriceAI` ora prova prima l'AI vera, e
  ricade sulla formula locale (`lib/priceSuggestion.js`, introdotta nel
  test #16) **solo** se l'AI non è disponibile (nessuna chiave, rete
  assente, rate limit) — stesso pattern AI+fallback deterministico già
  documentato in CLAUDE.md per il matching.
- i18n: nuova chiave `priceSuggestionMsgAI` (it/en/es, parità 976 chiavi)
  per mostrare la spiegazione dell'AI quando disponibile.

## Verifiche

- `suggestPriceWithAI.test.js`: nessuna `OPENAI_API_KEY` in CI, verifica
  il ramo deterministico "AI non disponibile" — stesso approccio di
  `computeTrustScoreDuration.test.js`.
- `priceSuggestAI.test.js`: hook client, mock di `fetchJson`, sia il caso
  disponibile sia il fallback.
- `npx jest` (app RN) → 17 suite / 23 test verdi.
- `cd server && node --experimental-test-module-mocks --test` → 287/287
  verdi.
- Parse-check su `CreateListingScreen.js` → OK. Parità i18n invariata
  (976 chiavi/lingua).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_