### PR TITLE
Disattiva il workflow CI Build Android APK (falliva sempre)

### DIFF
--- a/.github/workflows/Build-Android.yml.disabled
+++ b/.github/workflows/Build-Android.yml.disabled
@@ -1,3 +1,11 @@
+# DISATTIVATO (rinominato da .yml a .yml.disabled, non viene più letto da
+# GitHub Actions): falliva ad ogni push su main perché il progetto è Expo
+# managed puro — non esiste una cartella android/ committata nel repo, quindi
+# `cd android && ./gradlew assembleDebug` non ha mai potuto funzionare. Per
+# riattivare una build Android reale, il percorso corretto per un progetto
+# Expo managed è EAS Build (eas-cli ed eas.json sono già nel repo): serve un
+# token del proprio account Expo (EXPO_TOKEN) come secret GitHub, poi un job
+# che lancia `eas build --platform android --profile <profilo> --non-interactive`.
 name: Build Android APK
 
 on:


### PR DESCRIPTION
## Causa

Verificando lo stato della CI per rispondere a una domanda sulla readiness
dell'app, ho scoperto che il workflow **"Build Android APK"** fallisce ad
ogni push su `main` — l'ho controllato sulla storia delle run ed è così da
prima di questa sessione, senza che nessuno se ne accorgesse.

Il workflow fa `npm install` nella radice del repo e poi
`cd android && ./gradlew assembleDebug`, ma questo progetto è **Expo managed
puro**: non esiste (e non è mai esistita) una cartella `android/` committata
nel repo. Non è un problema di working directory sbagliato — quello step
non ha mai potuto funzionare.

## Fix

Rinominato `Build-Android.yml` → `Build-Android.yml.disabled` (GitHub
Actions smette di leggerlo, il contenuto resta a disposizione per dopo)
invece di cancellarlo, con un commento che spiega perché e qual è il
percorso corretto per riattivarlo: il progetto ha già `eas-cli` ed
`eas.json`, quindi la strada giusta per una build Android reale è **EAS
Build** (`eas build --platform android ...`), che richiede un token del
proprio account Expo come secret GitHub — scelta lasciata all'utente per
quando servirà davvero generare un APK.

Il workflow **"Node.js CI"** (test del backend, `server/`) non era
coinvolto: resta verde su ogni PR come sempre.

## Verifiche

- Nessun codice applicativo toccato, solo configurazione CI: nessun test da
  rilanciare, nessun bundle da ricompilare.

Nessuna migration in questa PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_