### PR TITLE
Rilascio prenotazioni scadute su cron server-side, non solo client

### DIFF
--- a/server/src/routes/offers.js
+++ b/server/src/routes/offers.js
@@ -12,12 +12,20 @@ export const offersRouter = express.Router();
 // 20260718110001_offers_timeout.sql). Facoltativo: la scadenza pigra già
 // applicata da accept/decline_offer_any e dalle liste di Attività basta
 // per la correttezza anche se questo endpoint non viene mai chiamato.
+//
+// release_all_stale_reservations (20260730120000): stessa logica ma per le
+// offerte 'accepted' con reservation_expires_at scaduta (7 giorni). Prima
+// esisteva solo release_my_stale_reservations, scoped ad auth.uid() e
+// chiamata solo dal client al mount di AttivitaScreen — se nessuna delle
+// due parti riapriva l'app, la prenotazione restava bloccata per sempre.
 offersRouter.post("/recompute", rateLimitOffers, requireCronSecret, async (req, res) => {
   try {
     if (!supabase) throw new Error("Supabase client not configured");
-    const { data, error } = await supabase.rpc("expire_old_offers");
-    if (error) throw error;
-    return res.status(200).json({ expired: data ?? 0 });
+    const { data: expired, error: e1 } = await supabase.rpc("expire_old_offers");
+    if (e1) throw e1;
+    const { data: releasedStale, error: e2 } = await supabase.rpc("release_all_stale_reservations");
+    if (e2) throw e2;
+    return res.status(200).json({ expired: expired ?? 0, releasedStale: releasedStale ?? 0 });
   } catch (e) {
     console.error("[offers/recompute] error:", e);
     return res.status(500).json({ error: 'Errore interno' });

--- a/server/test/migrationsIntegrity.test.js
+++ b/server/test/migrationsIntegrity.test.js
@@ -226,3 +226,37 @@ test('notify_on_chain_canceled avvisa gli altri partecipanti quando la catena de
   assert.match(body, /non ti scoraggiare/i,
     `${file}: manca il messaggio di incoraggiamento`);
 });
+
+test('release_all_stale_reservations copre TUTTI gli utenti, non solo chi è loggato, e blocca la riga prima di scriverla', () => {
+  // Analisi threat-modeling fase post-transazione (sezione A, punto 4):
+  // release_my_stale_reservations è scoped ad auth.uid() e chiamata solo dal
+  // client al mount di AttivitaScreen — se nessuna delle due parti riapre
+  // l'app dopo la scadenza della prenotazione, gli annunci restano
+  // bloccati su 'reserved' per sempre. Questa versione batch deve avere lo
+  // stesso fix del lock (release_my_stale_reservations) ma SENZA il filtro
+  // auth.uid(), altrimenti da un cron server-side non troverebbe mai
+  // nessuna riga (auth.uid() è null fuori da un contesto utente loggato).
+  const { file, body } = latestDefinitionOf('release_all_stale_reservations');
+  assert.match(body, /select\s+\*\s+into\s+v_offer\s+from\s+public\.offers\s+where\s+id\s*=\s*r\.id\s+for\s+update/i,
+    `${file}: manca il lock sulla riga prima della scrittura`);
+  assert.match(body, /if\s+v_offer\.status\s*<>\s*'accepted'\s+then\s+continue/i,
+    `${file}: manca il ricontrollo dello stato dopo il lock`);
+  assert.doesNotMatch(body, /auth\.uid\(\)/i,
+    `${file}: filtra per auth.uid(), un cron server-side non troverebbe mai righe da processare`);
+});
+
+test('release_all_stale_reservations ed expire_old_offers sono chiamabili solo dal service_role, non dal client', () => {
+  // Bug collaterale trovato scrivendo il test sopra: expire_old_offers non
+  // ha mai avuto un REVOKE/GRANT esplicito, quindi eredita l'EXECUTE di
+  // default su PUBLIC di Postgres — chiamabile via supabase.rpc(...)
+  // direttamente dal client, bypassando il secret di requireCronSecret.
+  const sql = fs.readFileSync(
+    path.join(MIGRATIONS, '20260730120000_release_all_stale_reservations_cron.sql'), 'utf8',
+  );
+  for (const fn of ['release_all_stale_reservations', 'expire_old_offers']) {
+    assert.match(sql, new RegExp(`REVOKE ALL ON FUNCTION public\\.${fn}\\(\\) FROM PUBLIC`, 'i'),
+      `manca il REVOKE su ${fn}`);
+    assert.match(sql, new RegExp(`GRANT EXECUTE ON FUNCTION public\\.${fn}\\(\\) TO service_role`, 'i'),
+      `manca il GRANT a service_role su ${fn}`);
+  }
+});

--- a/server/test/offersRecompute.test.js
+++ b/server/test/offersRecompute.test.js
@@ -1,0 +1,84 @@
+// Test funzionale: analisi threat-modeling fase post-transazione (sezione A,
+// punto 4). POST /api/offers/recompute (server/src/routes/offers.js) ora
+// chiama ANCHE release_all_stale_reservations, oltre a expire_old_offers —
+// prima le prenotazioni 'accepted' scadute (7 giorni) venivano rilasciate
+// solo se una delle due parti riapriva l'app (release_my_stale_reservations,
+// scoped ad auth.uid()), senza nessun cron server-side di backstop.
+//
+// Stesso approccio dei test di server/src/routes/notify.js: si isola
+// l'handler finale della route e lo si chiama con un req/res fittizio, mock
+// completo di Supabase — nessuna chiamata di rete vera. Il gate
+// requireCronSecret è testato separatamente come funzione pura.
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireCronSecret } from '../src/middleware/requireCronSecret.js';
+
+function lastHandler(router, method, path) {
+  const layer = router.stack.find((l) => l.route?.path === path && l.route.methods[method]);
+  if (!layer) throw new Error(`route non trovata: ${method.toUpperCase()} ${path}`);
+  const stack = layer.route.stack;
+  return stack[stack.length - 1].handle;
+}
+
+function fakeRes() {
+  const res = { statusCode: 200, body: null };
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.json = (payload) => { res.body = payload; return res; };
+  return res;
+}
+
+test('requireCronSecret: nessun secret configurato -> 503 fail-closed', () => {
+  const prev = process.env.CHAIN_CRON_SECRET;
+  delete process.env.CHAIN_CRON_SECRET;
+  const req = { get: () => '' };
+  const res = fakeRes();
+  requireCronSecret(req, res, () => { throw new Error('non deve chiamare next()'); });
+  assert.equal(res.statusCode, 503);
+  if (prev !== undefined) process.env.CHAIN_CRON_SECRET = prev;
+});
+
+test('requireCronSecret: secret sbagliato o mancante -> 401', () => {
+  process.env.CHAIN_CRON_SECRET = 'il-vero-secret';
+  const req = { get: () => 'secret-sbagliato' };
+  const res = fakeRes();
+  requireCronSecret(req, res, () => { throw new Error('non deve chiamare next()'); });
+  assert.equal(res.statusCode, 401);
+});
+
+test('requireCronSecret: secret corretto -> chiama next()', () => {
+  process.env.CHAIN_CRON_SECRET = 'il-vero-secret';
+  const req = { get: () => 'il-vero-secret' };
+  const res = fakeRes();
+  let nextCalled = false;
+  requireCronSecret(req, res, () => { nextCalled = true; });
+  assert.equal(nextCalled, true);
+});
+
+test('POST /offers/recompute: scade le offerte pending E rilascia le prenotazioni scadute di TUTTI', async () => {
+  const calledRpc = [];
+  mock.module('../src/db.js', {
+    namedExports: {
+      supabase: {
+        rpc: async (fn) => {
+          calledRpc.push(fn);
+          if (fn === 'expire_old_offers') return { data: 3, error: null };
+          if (fn === 'release_all_stale_reservations') return { data: 2, error: null };
+          return { data: null, error: null };
+        },
+      },
+    },
+  });
+
+  const { offersRouter } = await import('../src/routes/offers.js');
+  const handler = lastHandler(offersRouter, 'post', '/recompute');
+
+  const req = {};
+  const res = fakeRes();
+  await handler(req, res);
+
+  assert.deepEqual(calledRpc, ['expire_old_offers', 'release_all_stale_reservations']);
+  assert.equal(res.body.expired, 3);
+  assert.equal(res.body.releasedStale, 2);
+
+  mock.reset();
+});

--- a/supabase/migrations/20260730120000_release_all_stale_reservations_cron.sql
+++ b/supabase/migrations/20260730120000_release_all_stale_reservations_cron.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- Analisi threat-modeling fase post-transazione (sezione A, punto 4):
+-- release_my_stale_reservations() esiste solo con scope auth.uid() (versione
+-- più recente: 20260729120000_race_reservations_and_chain_locks.sql) ed è
+-- chiamata SOLO dal client (travelswap_ai/travelswapai/screens/
+-- AttivitaScreen.js al mount). Se NESSUNA delle due parti di uno scambio
+-- riapre l'app dopo la scadenza della prenotazione (7 giorni,
+-- reservation_expires_at, vedi 20260721200000_reservation_timeout.sql), gli
+-- annunci restano bloccati su 'reserved' indefinitamente: nessun cron
+-- server-side copre oggi questo caso (expire_old_offers copre solo le
+-- offerte 'pending' scadute, non le 'accepted' con prenotazione scaduta).
+--
+-- Fix: versione batch non filtrata per auth.uid(), stesso schema di
+-- expire_old_offers()/expire_old_chain_proposals() — pensata per essere
+-- chiamata da /api/offers/recompute (già protetto da requireCronSecret,
+-- già usato per expire_old_offers), non dal client mobile.
+--
+-- Corpo copiato da release_my_stale_reservations() (versione più recente,
+-- col fix del lock FOR UPDATE prima di scrivere), tolto solo il filtro
+-- "and (o.proposer_id = auth.uid() or tl.user_id = auth.uid())" per
+-- coprire TUTTI gli utenti, non solo chi è loggato.
+-- ============================================================
+
+CREATE FUNCTION public.release_all_stale_reservations() RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+declare
+  r record;
+  v_offer public.offers;
+  n int := 0;
+begin
+  for r in
+    select o.id, o.to_listing_id, o.from_listing_id
+    from public.offers o
+    where o.status = 'accepted'
+      and o.reservation_expires_at is not null
+      and o.reservation_expires_at < now()
+  loop
+    -- Stesso fix di release_my_stale_reservations: rilegge e blocca la riga
+    -- PRIMA di scrivere, altrimenti una finalizzazione concorrente
+    -- (confirm_exchange_any) può committare 'finalized' dopo lo snapshot.
+    select * into v_offer from public.offers where id = r.id for update;
+    if v_offer.status <> 'accepted' then
+      continue;
+    end if;
+
+    update public.listings set status = 'active'
+     where id in (r.to_listing_id, coalesce(r.from_listing_id, r.to_listing_id))
+       and status = 'reserved';
+
+    update public.offers
+       set status = 'cancelled', owner_confirmed_at = null, proposer_confirmed_at = null
+     where id = v_offer.id
+       and status = 'accepted';
+    n := n + 1;
+  end loop;
+  return n;
+end $$;
+
+-- Solo il server (client service-role) deve poterla chiamare: opera su
+-- TUTTI gli utenti, non va esposta come RPC pubblica al client mobile.
+REVOKE ALL ON FUNCTION public.release_all_stale_reservations() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.release_all_stale_reservations() TO service_role;
+
+-- Bug collaterale trovato controllando il pattern giusto per la funzione
+-- sopra: expire_old_offers (20260718110001_offers_timeout.sql) non ha MAI
+-- avuto un REVOKE/GRANT esplicito, quindi eredita l'EXECUTE di default su
+-- PUBLIC di Postgres — in teoria chiamabile con
+-- supabase.rpc('expire_old_offers') direttamente dal client (anon/
+-- authenticated), bypassando del tutto il secret di requireCronSecret lato
+-- Express. Impatto pratico basso (tocca solo offerte già scadute da sole),
+-- ma è la stessa disattenzione che qui vogliamo evitare: chiuso anche per
+-- coerenza con expire_old_chain_proposals, che il GRANT a service_role ce
+-- l'ha già.
+REVOKE ALL ON FUNCTION public.expire_old_offers() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.expire_old_offers() TO service_role;


### PR DESCRIPTION
## Causa

Threat-modeling sulla fase post-transazione (sezione A, punto 4): ho
verificato che `release_my_stale_reservations()` esiste solo con scope
`auth.uid()` ed è chiamata **solo dal client** (`AttivitaScreen.js` al
mount). Se nessuna delle due parti di uno scambio riapre l'app dopo la
scadenza della prenotazione (7 giorni, `reservation_expires_at`), gli
annunci restano bloccati su `reserved` **indefinitamente** — nessun cron
server-side copre questo caso (`expire_old_offers` copre solo le offerte
`pending` scadute, non le `accepted` con prenotazione scaduta).

## Fix

- Nuova `release_all_stale_reservations()`: stessa logica di
  `release_my_stale_reservations` (stesso fix del lock `FOR UPDATE` prima
  di scrivere), ma **senza** il filtro `auth.uid()` — pensata per un
  contesto server/cron, non per l'utente loggato.
- Agganciata a `POST /api/offers/recompute`, endpoint **già esistente**,
  già protetto da `requireCronSecret`, già usato per `expire_old_offers` —
  nessun nuovo endpoint da esporre.
- Il rilascio client-side resta come livello aggiuntivo (copre il caso in
  cui l'utente riapre l'app prima che giri il cron), non sostituito.

**Bug collaterale trovato scrivendo il fix**: `expire_old_offers` non ha
mai avuto un `REVOKE`/`GRANT` esplicito, quindi eredita l'`EXECUTE` di
default su `PUBLIC` di Postgres — in teoria chiamabile con
`supabase.rpc('expire_old_offers')` direttamente dal client (anon/
authenticated), bypassando del tutto il secret di `requireCronSecret` lato
Express. Impatto pratico basso (tocca solo offerte già scadute da sole),
ma stessa disattenzione da evitare anche per la nuova funzione — chiuso
per entrambe con `REVOKE ALL FROM PUBLIC` + `GRANT ... TO service_role`,
come già fatto per `expire_old_chain_proposals`.

## ⚠️ Azione manuale

Nuova migration da applicare a mano nel SQL Editor di Supabase:
`supabase/migrations/20260730120000_release_all_stale_reservations_cron.sql`.

## Verifiche

- Nuovo test in `migrationsIntegrity.test.js`: lock + ricontrollo stato,
  nessun filtro `auth.uid()`, `REVOKE`/`GRANT` corretti su entrambe le
  funzioni.
- Nuovo `server/test/offersRecompute.test.js`: `requireCronSecret` come
  funzione pura (503 senza secret configurato, 401 con secret sbagliato,
  passa con secret corretto) + handler della route che chiama entrambe le
  RPC e combina i risultati.
- `node --experimental-test-module-mocks --test`: 299 test, tutti verdi
  (293 preesistenti + 6 nuovi).
- Nessun file RN toccato: bundle web non ricompilato (non necessario).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_