### PR TITLE
Endpoint per risolvere una disputa aperta (nessuna via esisteva prima)

### DIFF
--- a/docs/FUNCTIONAL_OVERVIEW.md
+++ b/docs/FUNCTIONAL_OVERVIEW.md
@@ -246,7 +246,8 @@ Ricostruito dalle query nel codice; i tipi sono dedotti.
 | `FB_VERIFY_TOKEN`, `FB_APP_SECRET`, `FB_PAGE_ACCESS_TOKEN` | webhook + Send API Messenger |
 | `ALLOW_UNVERIFIED_WEBHOOK` | ⚠️ bypass verifica firma FB |
 | `DEFAULT_LISTING_OWNER_ID` | owner degli annunci importati da FB |
-| `CHAIN_CRON_SECRET` | secret condiviso (header `X-Cron-Secret`) per gli endpoint cron-only `/api/chains/recompute` e `/api/saved-searches/recompute`; fail-closed (503) se assente |
+| `CHAIN_CRON_SECRET` | secret condiviso (header `X-Cron-Secret`) per gli endpoint cron-only `/api/chains/recompute`, `/api/saved-searches/recompute` e `/api/offers/recompute`; fail-closed (503) se assente |
+| `ADMIN_ACTION_SECRET` | secret condiviso (header `X-Admin-Secret`, distinto da `CHAIN_CRON_SECRET`) per azioni amministrative manuali — oggi solo `/api/disputes/resolve`, per risolvere una contestazione aperta da `report_exchange_problem` (nessun concetto di ruolo admin nel DB); fail-closed (503) se assente |
 | `PORT` (default 8080), `NODE_ENV` | runtime |
 
 ### Variabili d'ambiente — app

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -32,6 +32,7 @@ import { translateListingsRouter } from "./routes/translateListings.js";
 import { priceCheckRouter } from "./routes/priceCheck.js";
 import { reportsNotifyRouter } from './routes/reportsNotify.js';
 import { notifyRouter } from './routes/notify.js';
+import { disputesRouter } from './routes/disputes.js';
 import { requireAuth } from './middleware/requireAuth.js';
 import { rateLimitParse } from './middleware/rateLimit.js';
 
@@ -103,6 +104,7 @@ app.use('/api/listing-questions', listingQuestionsRouter);
 app.use('/api/fb-link', fbLinkRouter);
 app.use('/api/reports', reportsNotifyRouter);
 app.use('/api/notify', notifyRouter);
+app.use('/api/disputes', disputesRouter);
 
 // --- Versione web dell'app (build Expo committata in server/public/app) ---
 // Permette di provare l'app da qualsiasi browser senza installare nulla

--- a/server/src/middleware/rateLimit.js
+++ b/server/src/middleware/rateLimit.js
@@ -101,3 +101,8 @@ export const rateLimitPings = makeRateLimiter({ windowMs: 10 * 60 * 1000, max: 2
 // (una per persona per annuncio), quindi il tetto serve solo a impedire che
 // qualcuno le sparpagli su decine di annunci diversi in pochi minuti.
 export const rateLimitQuestions = makeRateLimiter({ windowMs: 10 * 60 * 1000, max: 20, name: 'domande' });
+
+// Risoluzione dispute: protetto da requireAdminSecret (nessun concetto di
+// ruolo admin nel DB), azione manuale rara — il tetto è solo un backstop,
+// non ci si aspetta mai di avvicinarcisi in uso normale.
+export const rateLimitDisputes = makeRateLimiter({ windowMs: 10 * 60 * 1000, max: 20, name: 'risoluzione dispute' });

--- a/server/src/middleware/requireAdminSecret.js
+++ b/server/src/middleware/requireAdminSecret.js
@@ -1,0 +1,34 @@
+// server/src/middleware/requireAdminSecret.js
+// Protegge le azioni amministrative manuali (es. risolvere una
+// contestazione) con un secret condiviso invece del login utente — nessun
+// concetto di "ruolo admin" esiste ancora nel DB (verificato: profiles non
+// ha nessuna colonna is_admin/role). Secret DISTINTO da CHAIN_CRON_SECRET
+// (requireCronSecret.js): quello copre job periodici automatici, questo
+// azioni puntuali decise a mano da chi gestisce la piattaforma — ruotarne
+// uno non deve invalidare l'altro.
+//
+// Stessa logica fail-closed e confronto a tempo costante di
+// requireCronSecret.
+import crypto from "crypto";
+
+function timingSafeEqualStr(a, b) {
+  const bufA = Buffer.from(String(a));
+  const bufB = Buffer.from(String(b));
+  if (bufA.length !== bufB.length) {
+    crypto.timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+export function requireAdminSecret(req, res, next) {
+  const configured = process.env.ADMIN_ACTION_SECRET;
+  if (!configured) {
+    return res.status(503).json({ error: "ADMIN_ACTION_SECRET not configured" });
+  }
+  const provided = req.get("X-Admin-Secret") || "";
+  if (!timingSafeEqualStr(provided, configured)) {
+    return res.status(401).json({ error: "Invalid or missing X-Admin-Secret" });
+  }
+  next();
+}

--- a/server/src/routes/disputes.js
+++ b/server/src/routes/disputes.js
@@ -1,0 +1,33 @@
+// server/src/routes/disputes.js
+import express from "express";
+import { supabase } from "../db.js";
+import { requireAdminSecret } from "../middleware/requireAdminSecret.js";
+import { rateLimitDisputes } from "../middleware/rateLimit.js";
+
+export const disputesRouter = express.Router();
+
+// Protetto da secret condiviso (requireAdminSecret), non dal login utente:
+// nessun concetto di ruolo admin esiste nel DB. Threat-modeling fase
+// post-transazione, sezione A punto 1 — prima non esisteva NESSUNA via per
+// risolvere una contestazione aperta con report_exchange_problem, l'unica
+// uscita era annullare con cancel_accepted_offer_any (che ignora
+// disputed_at e non lascia traccia della disputa).
+disputesRouter.post("/resolve", rateLimitDisputes, requireAdminSecret, async (req, res) => {
+  try {
+    if (!supabase) throw new Error("Supabase client not configured");
+    const { offerId, outcome, note } = req.body || {};
+    if (!offerId || !outcome) {
+      return res.status(400).json({ error: "offerId e outcome sono obbligatori" });
+    }
+    const { data, error } = await supabase.rpc("resolve_exchange_dispute", {
+      p_offer_id_text: String(offerId),
+      p_outcome: String(outcome),
+      p_note: note ? String(note).slice(0, 1000) : null,
+    });
+    if (error) throw error;
+    return res.status(200).json({ ok: true, offer: data });
+  } catch (e) {
+    console.error("[disputes/resolve] error:", e);
+    return res.status(500).json({ error: 'Errore interno' });
+  }
+});

--- a/server/test/disputesResolve.test.js
+++ b/server/test/disputesResolve.test.js
@@ -1,0 +1,111 @@
+// Test funzionale: analisi threat-modeling fase post-transazione (sezione A,
+// punto 1). Prima non esisteva NESSUNA via per risolvere una disputa aperta
+// da report_exchange_problem — l'unica uscita era annullare con
+// cancel_accepted_offer_any, che ignora disputed_at e non lascia traccia
+// della disputa. POST /api/disputes/resolve (server/src/routes/disputes.js)
+// chiama la nuova RPC resolve_exchange_dispute, protetto da requireAdminSecret
+// (secret condiviso, nessun concetto di ruolo admin nel DB — decisione presa
+// con l'utente).
+//
+// mock.module()+import() dinamico ripetuto nello stesso file può restituire
+// un modulo "stale" legato al PRIMO mock (già osservato in
+// askListingQuestion.test.js): qui si mocka db.js e si importa la route UNA
+// SOLA volta, delegando il comportamento della RPC a una variabile mutabile
+// che ogni test riassegna — nessun secondo import, nessun rischio di cache.
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireAdminSecret } from '../src/middleware/requireAdminSecret.js';
+
+const OFFER_ID = '55555555-5555-4555-8555-555555555555';
+
+let currentRpc = async () => ({ data: null, error: null });
+mock.module('../src/db.js', {
+  namedExports: {
+    supabase: { rpc: (...args) => currentRpc(...args) },
+  },
+});
+const { disputesRouter } = await import('../src/routes/disputes.js');
+
+function lastHandler(router, method, path) {
+  const layer = router.stack.find((l) => l.route?.path === path && l.route.methods[method]);
+  if (!layer) throw new Error(`route non trovata: ${method.toUpperCase()} ${path}`);
+  const stack = layer.route.stack;
+  return stack[stack.length - 1].handle;
+}
+const handler = lastHandler(disputesRouter, 'post', '/resolve');
+
+function fakeRes() {
+  const res = { statusCode: 200, body: null };
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.json = (payload) => { res.body = payload; return res; };
+  return res;
+}
+
+test('requireAdminSecret: nessun secret configurato -> 503 fail-closed', () => {
+  const prev = process.env.ADMIN_ACTION_SECRET;
+  delete process.env.ADMIN_ACTION_SECRET;
+  const req = { get: () => '' };
+  const res = fakeRes();
+  requireAdminSecret(req, res, () => { throw new Error('non deve chiamare next()'); });
+  assert.equal(res.statusCode, 503);
+  if (prev !== undefined) process.env.ADMIN_ACTION_SECRET = prev;
+});
+
+test('requireAdminSecret: secret sbagliato o mancante -> 401', () => {
+  process.env.ADMIN_ACTION_SECRET = 'il-vero-secret-admin';
+  const req = { get: () => 'secret-sbagliato' };
+  const res = fakeRes();
+  requireAdminSecret(req, res, () => { throw new Error('non deve chiamare next()'); });
+  assert.equal(res.statusCode, 401);
+});
+
+test('requireAdminSecret: secret corretto -> chiama next()', () => {
+  process.env.ADMIN_ACTION_SECRET = 'il-vero-secret-admin';
+  const req = { get: () => 'il-vero-secret-admin' };
+  const res = fakeRes();
+  let nextCalled = false;
+  requireAdminSecret(req, res, () => { nextCalled = true; });
+  assert.equal(nextCalled, true);
+});
+
+test('POST /disputes/resolve: 400 se manca offerId o outcome', async () => {
+  const res1 = fakeRes();
+  await handler({ body: { outcome: 'resume' } }, res1);
+  assert.equal(res1.statusCode, 400);
+
+  const res2 = fakeRes();
+  await handler({ body: { offerId: OFFER_ID } }, res2);
+  assert.equal(res2.statusCode, 400);
+});
+
+test('POST /disputes/resolve: chiama resolve_exchange_dispute coi parametri giusti', async () => {
+  const calls = [];
+  currentRpc = async (fn, params) => {
+    calls.push({ fn, params });
+    return { data: { id: OFFER_ID, status: 'cancelled' }, error: null };
+  };
+
+  const req = { body: { offerId: OFFER_ID, outcome: 'cancel_favor_proposer', note: 'Il venditore non ha più risposto' } };
+  const res = fakeRes();
+  await handler(req, res);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].fn, 'resolve_exchange_dispute');
+  assert.deepEqual(calls[0].params, {
+    p_offer_id_text: OFFER_ID,
+    p_outcome: 'cancel_favor_proposer',
+    p_note: 'Il venditore non ha più risposto',
+  });
+  assert.equal(res.body.ok, true);
+  assert.equal(res.body.offer.status, 'cancelled');
+});
+
+test('POST /disputes/resolve: propaga l\'errore della RPC come 500', async () => {
+  currentRpc = async () => ({ data: null, error: { message: 'Offer is not disputed' } });
+
+  const req = { body: { offerId: OFFER_ID, outcome: 'resume' } };
+  const res = fakeRes();
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 500);
+});

--- a/server/test/migrationsIntegrity.test.js
+++ b/server/test/migrationsIntegrity.test.js
@@ -271,6 +271,37 @@ test('notify_on_offer avvisa l\'altra parte quando un\'offerta accettata viene a
     `${file}: non notifica l'ALTRA parte rispetto a chi ha annullato`);
 });
 
+test('resolve_exchange_dispute richiede una disputa aperta e un esito valido', () => {
+  // Threat-modeling fase post-transazione (sezione A, punto 1): prima non
+  // esisteva NESSUNA RPC per risolvere una disputa aperta da
+  // report_exchange_problem — l'unica uscita era annullare con
+  // cancel_accepted_offer_any, che ignora disputed_at e non lascia traccia
+  // della disputa. Qui si verifica solo il testo (i test funzionali sulla
+  // logica reale vivono nella checklist manuale, come per le altre RPC).
+  const { file, body } = latestDefinitionOf('resolve_exchange_dispute');
+  assert.match(body, /if\s+p_outcome\s+not\s+in\s*\(\s*'resume'\s*,\s*'cancel_favor_proposer'\s*,\s*'cancel_favor_owner'\s*\)/i,
+    `${file}: manca la validazione dell'esito`);
+  assert.match(body, /if\s+v_offer\.disputed_at\s+is\s+null\s+then\s*\n?\s*raise\s+exception\s+'Offer is not disputed'/i,
+    `${file}: manca il controllo che l'offerta sia davvero contestata`);
+  assert.match(body, /set\s+disputed_at\s*=\s*null,\s*disputed_by\s*=\s*null,\s*dispute_reason\s*=\s*null/i,
+    `${file}: l'esito 'resume' non azzera più la disputa`);
+  assert.match(body, /cancel_reason\s*=\s*'dispute_resolved:'\s*\|\|\s*p_outcome/i,
+    `${file}: l'annullamento arbitrato non registra più l'esito in cancel_reason`);
+});
+
+test('resolve_exchange_dispute è chiamabile solo dal service_role, non dal client', () => {
+  // Nessun controllo "una delle due parti" al suo interno (è un'azione
+  // arbitrata dietro requireAdminSecret, non un'azione utente): non va MAI
+  // esposta come RPC pubblica al client mobile.
+  const sql = fs.readFileSync(
+    path.join(MIGRATIONS, '20260730140000_resolve_exchange_dispute.sql'), 'utf8',
+  );
+  assert.match(sql, /REVOKE ALL ON FUNCTION public\.resolve_exchange_dispute\(text,\s*text,\s*text\) FROM PUBLIC/i,
+    'manca il REVOKE su resolve_exchange_dispute');
+  assert.match(sql, /GRANT EXECUTE ON FUNCTION public\.resolve_exchange_dispute\(text,\s*text,\s*text\) TO service_role/i,
+    'manca il GRANT a service_role su resolve_exchange_dispute');
+});
+
 test('release_all_stale_reservations ed expire_old_offers sono chiamabili solo dal service_role, non dal client', () => {
   // Bug collaterale trovato scrivendo il test sopra: expire_old_offers non
   // ha mai avuto un REVOKE/GRANT esplicito, quindi eredita l'EXECUTE di

--- a/supabase/migrations/20260730140000_resolve_exchange_dispute.sql
+++ b/supabase/migrations/20260730140000_resolve_exchange_dispute.sql
@@ -1,0 +1,116 @@
+-- ============================================================
+-- Threat-modeling fase post-transazione (sezione A, punto 1):
+-- report_exchange_problem (20260721210000_exchange_dispute.sql) blocca la
+-- conferma impostando disputed_at, ma non esiste NESSUNA RPC per
+-- risolvere una disputa una volta aperta (confermato dal commento in
+-- 20260729150000_confirm_exchange_blocks_on_dispute.sql): l'unica via
+-- d'uscita era annullare con cancel_accepted_offer_any, che ignora del
+-- tutto disputed_at e non lascia alcuna traccia della disputa stessa.
+--
+-- Decisione presa con l'utente: nessun concetto di "ruolo admin" nel DB
+-- per ora — un endpoint protetto da secret condiviso (requireAdminSecret,
+-- stesso principio di requireCronSecret ma con un secret distinto),
+-- chiamabile solo da chi gestisce la piattaforma, non dal client mobile.
+--
+-- Tre esiti possibili:
+--   - 'resume': la disputa era infondata/si è risolta da sola (es. il
+--     biglietto è arrivato, era un problema di comunicazione) — si azzera
+--     disputed_at/disputed_by/dispute_reason, l'offerta resta 'accepted' e
+--     la conferma normale può riprendere.
+--   - 'cancel_favor_proposer' / 'cancel_favor_owner': la disputa era
+--     fondata — si forza l'annullamento (stessa liberazione annunci di
+--     cancel_accepted_offer_any), ma SENZA passare dal controllo
+--     "una delle due parti" (è un'azione amministrativa) e SENZA marcare
+--     cancelled_by/suspicious_cancel_at (quei campi tracciano annullamenti
+--     unilaterali di un utente, non una risoluzione arbitrata: qui la
+--     traccia è il fatto stesso che esista una riga di risoluzione).
+--     disputed_at/disputed_by/dispute_reason restano intatti come storico
+--     di cosa fosse la disputa, anche dopo l'annullamento.
+--
+-- In entrambi i casi si notificano ENTRAMBE le parti (prima: nessuna
+-- notifica esisteva per nessun esito di una disputa).
+-- ============================================================
+
+ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE public.notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type IN ('offer_received','offer_accepted','offer_declined','new_matches',
+                  'listing_ping','listing_question','listing_question_answered',
+                  'chain_canceled','offer_cancelled','dispute_resolved'));
+
+CREATE FUNCTION public.resolve_exchange_dispute(
+  p_offer_id_text text,
+  p_outcome text,
+  p_note text DEFAULT NULL
+) RETURNS public.offers
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+declare
+  v_offer public.offers;
+  v_owner uuid;
+  v_title text;
+  v_note text;
+begin
+  if p_outcome not in ('resume', 'cancel_favor_proposer', 'cancel_favor_owner') then
+    raise exception 'Invalid outcome: %', p_outcome;
+  end if;
+
+  select * into v_offer from public.offers where id::text = p_offer_id_text for update;
+  if not found then raise exception 'Offer not found'; end if;
+
+  if v_offer.disputed_at is null then
+    raise exception 'Offer is not disputed';
+  end if;
+
+  select l.user_id, l.title into v_owner, v_title from public.listings l where l.id = v_offer.to_listing_id;
+  v_note := nullif(trim(coalesce(p_note, '')), '');
+
+  if p_outcome = 'resume' then
+    update public.offers
+       set disputed_at = null, disputed_by = null, dispute_reason = null
+     where id = v_offer.id;
+  else
+    update public.listings set status = 'active'
+     where id::text in (v_offer.to_listing_id::text, coalesce(v_offer.from_listing_id::text, '____none____'))
+       and status = 'reserved';
+
+    update public.offers
+       set status = 'cancelled',
+           owner_confirmed_at = null,
+           proposer_confirmed_at = null,
+           cancel_reason = 'dispute_resolved:' || p_outcome || coalesce(': ' || v_note, '')
+     where id = v_offer.id;
+  end if;
+
+  select * into v_offer from public.offers where id = v_offer.id;
+
+  -- Notifica entrambe le parti dell'esito: prima nessuna notifica esisteva
+  -- per nessun esito di una disputa (né in caso di ripresa, né di
+  -- annullamento arbitrato).
+  insert into public.notifications (user_id, type, title, body, data)
+  select uid,
+    'dispute_resolved',
+    case when p_outcome = 'resume' then 'Contestazione risolta'
+         else 'Contestazione risolta: scambio annullato' end,
+    case when p_outcome = 'resume' then
+      coalesce('La contestazione sulla prenotazione «' || v_title || '» è stata risolta: puoi riprendere la conferma dello scambio.'
+               || coalesce(' ' || v_note, ''),
+               'La contestazione è stata risolta: puoi riprendere la conferma dello scambio.')
+    else
+      coalesce('La contestazione sulla prenotazione «' || v_title || '» è stata risolta annullando lo scambio.'
+               || coalesce(' ' || v_note, ''),
+               'La contestazione è stata risolta annullando lo scambio.')
+    end,
+    jsonb_build_object('offerId', v_offer.id, 'listingId', v_offer.to_listing_id, 'offerType', v_offer.type, 'outcome', p_outcome)
+  from (select v_owner as uid union select v_offer.proposer_id) as parties(uid)
+  where uid is not null;
+
+  return v_offer;
+end $$;
+
+-- Solo il server (client service-role, dietro requireAdminSecret) deve
+-- poterla chiamare: nessun controllo "una delle due parti" al suo interno
+-- (è un'azione arbitrata, non un'azione dell'utente), quindi non va MAI
+-- esposta come RPC pubblica al client mobile.
+REVOKE ALL ON FUNCTION public.resolve_exchange_dispute(text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.resolve_exchange_dispute(text, text, text) TO service_role;


### PR DESCRIPTION
## Causa

Threat-modeling fase post-transazione (sezione A, punto 1):
`report_exchange_problem` blocca la conferma impostando `disputed_at`, ma
**non esisteva nessuna RPC per risolverla** una volta aperta (già
documentato nel commento di
`20260729150000_confirm_exchange_blocks_on_dispute.sql`). L'unica via
d'uscita era annullare con `cancel_accepted_offer_any`, che ignora del
tutto `disputed_at` e non lascia alcuna traccia della disputa stessa.

## Fix (decisione presa con l'utente)

Nessun concetto di "ruolo admin" nel DB per ora: un endpoint protetto da
**secret condiviso** (`requireAdminSecret`, stesso principio di
`requireCronSecret` ma con secret **distinto** — `CHAIN_CRON_SECRET` copre
job periodici automatici, `ADMIN_ACTION_SECRET` azioni puntuali decise a
mano), non esposto al client mobile.

Nuova RPC `resolve_exchange_dispute(offerId, outcome, note)` con tre esiti:

- **`resume`**: la disputa era infondata — azzera `disputed_at`/
  `disputed_by`/`dispute_reason`, l'offerta resta `accepted` e la conferma
  normale può riprendere.
- **`cancel_favor_proposer`** / **`cancel_favor_owner`**: la disputa era
  fondata — forza l'annullamento (stessa liberazione annunci di
  `cancel_accepted_offer_any`) **senza** il controllo "una delle due
  parti" (è un'azione amministrativa) e **senza** marcare
  `cancelled_by`/`suspicious_cancel_at` (quei campi, aggiunti in #215,
  tracciano annullamenti unilaterali di un utente, non una risoluzione
  arbitrata).

In entrambi i casi notifica **entrambe le parti** dell'esito (prima:
nessuna notifica esisteva per nessun esito di una disputa).

Nuova route `POST /api/disputes/resolve`, montata in `index.js`, protetta
da `requireAdminSecret` + rate limit.

## ⚠️ Azione manuale

Nuova migration da applicare a mano:
`supabase/migrations/20260730140000_resolve_exchange_dispute.sql`.

Da configurare anche una nuova variabile d'ambiente server:
`ADMIN_ACTION_SECRET` (documentata in `docs/FUNCTIONAL_OVERVIEW.md`).

## Verifiche

- 2 nuovi test in `migrationsIntegrity.test.js`: validazione esito/stato,
  chiamabile solo dal `service_role`.
- 6 nuovi test in `disputesResolve.test.js`: `requireAdminSecret` come
  funzione pura, validazione 400 su parametri mancanti, chiamata RPC coi
  parametri giusti, propagazione errore come 500.
- `node --experimental-test-module-mocks --test`: 309 test backend, tutti
  verdi (301 preesistenti + 8 nuovi).
- Nessun file RN toccato: bundle web non ricompilato (non necessario).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_