### PR TITLE
Documenta le variabili SMTP e REPORT_NOTIFY_TO mancanti

### DIFF
--- a/docs/FUNCTIONAL_OVERVIEW.md
+++ b/docs/FUNCTIONAL_OVERVIEW.md
@@ -248,6 +248,8 @@ Ricostruito dalle query nel codice; i tipi sono dedotti.
 | `DEFAULT_LISTING_OWNER_ID` | owner degli annunci importati da FB |
 | `CHAIN_CRON_SECRET` | secret condiviso (header `X-Cron-Secret`) per gli endpoint cron-only `/api/chains/recompute`, `/api/saved-searches/recompute` e `/api/offers/recompute`; fail-closed (503) se assente |
 | `ADMIN_ACTION_SECRET` | secret condiviso (header `X-Admin-Secret`, distinto da `CHAIN_CRON_SECRET`) per azioni amministrative manuali — oggi solo `/api/disputes/resolve`, per risolvere una contestazione aperta da `report_exchange_problem` (nessun concetto di ruolo admin nel DB); fail-closed (503) se assente |
+| `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` | credenziali SMTP per le email di servizio (`server/src/lib/mailer.js`) — offerta ricevuta/accettata (`routes/notify.js`) e notifica segnalazioni (`routes/reportsNotify.js`); se assenti `mailerConfigured()` è `false` e ogni invio è un no-op silenzioso (nessuna feature si rompe, l'email semplicemente non parte) |
+| `REPORT_NOTIFY_TO` | indirizzo che riceve l'email quando arriva una nuova segnalazione (`/api/reports/notify`) — senza questa variabile (o senza SMTP configurato) la segnalazione resta comunque salvata nella tabella `reports`, ma nessuno viene avvisato: va controllata a mano nel Table Editor di Supabase (non esiste ancora una schermata admin in-app) |
 | `PORT` (default 8080), `NODE_ENV` | runtime |
 
 ### Variabili d'ambiente — app


### PR DESCRIPTION
## Causa

Rispondendo a una domanda dell'utente su "cosa succede dopo aver segnalato
un annuncio", ho verificato che `SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/
`SMTP_PASS` e `REPORT_NOTIFY_TO` (`server/src/lib/mailer.js`,
`server/src/routes/reportsNotify.js`) non erano mai state documentate
nella tabella delle variabili d'ambiente, a differenza di
`CHAIN_CRON_SECRET`/`ADMIN_ACTION_SECRET`.

## Fix

Aggiunte in `docs/FUNCTIONAL_OVERVIEW.md`, con la stessa nota onesta già
data all'utente in chat: senza `REPORT_NOTIFY_TO` la segnalazione resta
salvata a DB ma nessuno viene avvisato (nessuna schermata admin in-app
esiste ancora, va controllata a mano su Supabase).

Nessun codice toccato: l'impostazione effettiva della variabile va fatta
dall'utente sul pannello Render (fuori dal repo).

## Verifiche

Solo documentazione — nessun test da rilanciare, nessun bundle da
ricompilare.

Nessuna migration in questa PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_