### PR TITLE
Fix: le email non partivano mai (ENETUNREACH IPv6 su Render)

### DIFF
--- a/server/src/lib/mailer.js
+++ b/server/src/lib/mailer.js
@@ -21,6 +21,12 @@ const transporter = HOST && USER && PASS
       port: PORT,
       secure: PORT === 465, // 465 = SSL; 587 = STARTTLS
       auth: { user: USER, pass: PASS },
+      // Bug reale in produzione (Render): smtp.gmail.com risolve anche su
+      // IPv6, ma il container non ha connettività IPv6 in uscita — il
+      // tentativo falliva subito con "connect ENETUNREACH <indirizzo
+      // IPv6>", ancora prima di arrivare a un controllo delle credenziali.
+      // family:4 forza la risoluzione DNS su IPv4, che invece funziona.
+      family: 4,
     })
   : null;
 

--- a/server/test/mailerIPv4.test.js
+++ b/server/test/mailerIPv4.test.js
@@ -1,0 +1,42 @@
+// Bug reale in produzione (Render): smtp.gmail.com risolve anche su IPv6,
+// ma il container non ha connettività IPv6 in uscita — sendMail falliva
+// sempre con "connect ENETUNREACH <indirizzo IPv6>", ancora prima di un
+// controllo delle credenziali (nessuna email è mai partita). Fix: forzare
+// family:4 (IPv4) nella configurazione del transporter nodemailer.
+//
+// Non testiamo una connessione SMTP reale (impossibile in CI, e non è il
+// bug in sé): verifichiamo solo che family:4 resti sempre nella
+// configurazione passata a nodemailer.createTransport, così un futuro
+// refactor non lo perda per distrazione com'è successo la prima volta.
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('mailer: forza IPv4 nella connessione SMTP (fix ENETUNREACH su IPv6 rotto)', async () => {
+  process.env.SMTP_HOST = 'smtp.gmail.com';
+  process.env.SMTP_PORT = '465';
+  process.env.SMTP_USER = 'test@example.com';
+  process.env.SMTP_PASS = 'secret';
+
+  let capturedOptions = null;
+  mock.module('nodemailer', {
+    defaultExport: {
+      createTransport: (opts) => {
+        capturedOptions = opts;
+        return { sendMail: async () => {} };
+      },
+    },
+  });
+
+  const { mailerConfigured } = await import('../src/lib/mailer.js');
+
+  assert.equal(mailerConfigured(), true);
+  assert.ok(capturedOptions, 'nodemailer.createTransport non è mai stato chiamato');
+  assert.equal(capturedOptions.family, 4, 'manca family:4 — il transporter tornerebbe a provare anche IPv6');
+  assert.equal(capturedOptions.host, 'smtp.gmail.com');
+  assert.equal(capturedOptions.secure, true);
+
+  delete process.env.SMTP_HOST;
+  delete process.env.SMTP_PORT;
+  delete process.env.SMTP_USER;
+  delete process.env.SMTP_PASS;
+});


### PR DESCRIPTION
## Causa

Dopo aver configurato SMTP per la prima volta (`SMTP_HOST`/`PORT`/`USER`/
`PASS` + `REPORT_NOTIFY_TO`), nessuna email arrivava. Log di produzione:

```
[mailer] invio fallito: connect ENETUNREACH 2607:f8b0:400e:c1e::6c:465 - Local (:::0)
```

Non è un problema di credenziali: `smtp.gmail.com` risolve anche su un
indirizzo IPv6, ma il container Render **non ha connettività IPv6 in
uscita** — il tentativo di connessione falliva subito con
`ENETUNREACH`, ancora prima che nodemailer arrivasse a un controllo di
user/password. Nessuna email è mai partita, non solo quelle di
segnalazione ma **anche le notifiche offerta ricevuta/accettata** (stesso
transporter condiviso).

## Fix

Aggiunto `family: 4` alla configurazione di
`nodemailer.createTransport` (`server/src/lib/mailer.js`), che forza la
risoluzione DNS su IPv4 — `smtp.gmail.com` risponde correttamente anche
su IPv4.

## Verifiche

- Non è possibile testare una vera connessione SMTP in CI (e non è il
  bug in sé): nuovo `mailerIPv4.test.js` verifica solo che `family:4`
  resti sempre nella configurazione passata a
  `nodemailer.createTransport` (mockato), così un futuro refactor non lo
  perda per distrazione.
- `node --experimental-test-module-mocks --test`: 323 test backend,
  verificati **sia su Node 22 sia su Node 20**, tutti verdi.
- Nessun file RN toccato: bundle web non ricompilato (non necessario).

Nessuna migration in questa PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_