### PR TITLE
Fix vero: family:4 non aveva alcun effetto su nodemailer, l'IPv6 tornava a caso

### DIFF
--- a/server/src/lib/mailer.js
+++ b/server/src/lib/mailer.js
@@ -9,38 +9,59 @@
 //   SMTP_PASS  app password (per Gmail: Account Google → Sicurezza → Password per le app)
 //   REPORT_NOTIFY_TO  indirizzo che riceve le notifiche (può essere lo stesso di SMTP_USER)
 import nodemailer from "nodemailer";
+import dns from "node:dns";
 
 const HOST = (process.env.SMTP_HOST || "").trim();
 const PORT = Number(process.env.SMTP_PORT || 465);
 const USER = (process.env.SMTP_USER || "").trim();
 const PASS = (process.env.SMTP_PASS || "").trim();
 
-const transporter = HOST && USER && PASS
-  ? nodemailer.createTransport({
-      host: HOST,
-      port: PORT,
-      secure: PORT === 465, // 465 = SSL; 587 = STARTTLS
-      auth: { user: USER, pass: PASS },
-      // Bug reale in produzione (Render): smtp.gmail.com risolve anche su
-      // IPv6, ma il container non ha connettività IPv6 in uscita — il
-      // tentativo falliva subito con "connect ENETUNREACH <indirizzo
-      // IPv6>", ancora prima di arrivare a un controllo delle credenziali.
-      // family:4 forza la risoluzione DNS su IPv4, che invece funziona.
-      family: 4,
-    })
-  : null;
-
 export function mailerConfigured() {
-  return !!transporter;
+  return !!(HOST && USER && PASS);
+}
+
+// Bug reale in produzione (Render): nodemailer (v9) risolve SEMPRE sia
+// l'indirizzo IPv4 sia quello IPv6 dell'host SMTP, poi ne sceglie UNO A
+// CASO dalla lista combinata (node_modules/nodemailer/lib/shared/index.js,
+// funzione resolveHostname — Math.random() alla riga 83). Un'opzione
+// "family" passata a createTransport() NON viene mai letta da questo
+// percorso: non ha alcun effetto, a differenza di quanto normalmente ci si
+// aspetterebbe da altre librerie di rete. Se il container non ha
+// connettività IPv6 in uscita (come su Render), ogni volta che la
+// selezione casuale cade su un indirizzo IPv6 la connessione fallisce con
+// "connect ENETUNREACH" — capita a intermittenza, non sempre.
+//
+// Fix: risolviamo l'host NOI STESSI con dns.resolve4 (garantito solo IPv4)
+// e passiamo l'indirizzo IP letterale a nodemailer come "host" — a quel
+// punto nodemailer riconosce che è già un IP (net.isIP) e salta del tutto
+// la propria risoluzione DNS interna, quindi anche la scelta casuale.
+// tls.servername resta l'hostname vero, altrimenti la verifica del
+// certificato TLS (SNI) fallirebbe contro un IP nudo.
+async function resolveIPv4(hostname) {
+  try {
+    const addresses = await dns.promises.resolve4(hostname);
+    return addresses?.[0] || null;
+  } catch (e) {
+    console.warn("[mailer] risoluzione IPv4 fallita, ripiego sull'hostname:", e?.message || e);
+    return null;
+  }
 }
 
 /** Invia una mail. Ritorna true/false, non lancia mai. */
 export async function sendMail({ to, subject, text }) {
-  if (!transporter) {
+  if (!mailerConfigured()) {
     console.warn("[mailer] SMTP non configurato (SMTP_HOST/USER/PASS): mail non inviata:", subject);
     return false;
   }
   try {
+    const ipv4Host = await resolveIPv4(HOST);
+    const transporter = nodemailer.createTransport({
+      host: ipv4Host || HOST,
+      port: PORT,
+      secure: PORT === 465, // 465 = SSL; 587 = STARTTLS
+      auth: { user: USER, pass: PASS },
+      tls: { servername: HOST },
+    });
     await transporter.sendMail({
       from: `"TravelSwapAI" <${USER}>`,
       to,

--- a/server/test/mailerIPv4.test.js
+++ b/server/test/mailerIPv4.test.js
@@ -1,42 +1,81 @@
-// Bug reale in produzione (Render): smtp.gmail.com risolve anche su IPv6,
-// ma il container non ha connettività IPv6 in uscita — sendMail falliva
-// sempre con "connect ENETUNREACH <indirizzo IPv6>", ancora prima di un
-// controllo delle credenziali (nessuna email è mai partita). Fix: forzare
-// family:4 (IPv4) nella configurazione del transporter nodemailer.
+// Bug reale in produzione (Render), in due tempi:
 //
-// Non testiamo una connessione SMTP reale (impossibile in CI, e non è il
-// bug in sé): verifichiamo solo che family:4 resti sempre nella
-// configurazione passata a nodemailer.createTransport, così un futuro
-// refactor non lo perda per distrazione com'è successo la prima volta.
-import { test, mock } from 'node:test';
+// 1) Un primo tentativo di fix aggiungeva family:4 a
+//    nodemailer.createTransport(), assumendo (erroneamente) che nodemailer
+//    onorasse quell'opzione per limitare la risoluzione DNS a IPv4. Non è
+//    così: leggendo node_modules/nodemailer/lib/shared/index.js
+//    (resolveHostname) si vede che nodemailer risolve SEMPRE sia IPv4 sia
+//    IPv6 e sceglie un indirizzo A CASO dalla lista combinata
+//    (Math.random(), riga 83) — "family" non viene mai letto. L'email
+//    continuava a fallire a intermittenza con "connect ENETUNREACH
+//    <indirizzo IPv6>" ogni volta che il sorteggio cadeva su IPv6 (il
+//    container Render non ha connettività IPv6 in uscita).
+//
+// 2) Fix vero: risolvere l'host NOI STESSI con dns.resolve4 (garantito
+//    solo IPv4) e passare l'indirizzo letterale a nodemailer come "host"
+//    — a quel punto nodemailer riconosce che è già un IP (net.isIP) e
+//    salta del tutto la propria risoluzione interna. tls.servername
+//    preserva l'hostname vero per la verifica SNI/certificato.
+//
+// Non testiamo una vera connessione SMTP (impossibile in CI, e non è il
+// bug in sé): verifichiamo solo che sendMail() risolva l'host in IPv4 e lo
+// passi a nodemailer.createTransport, con servername corretto — e che in
+// caso di risoluzione fallita ripieghi sull'hostname originale invece di
+// esplodere.
+//
+// Un solo mock.module + import per file (pattern già verificato sicuro in
+// questa sessione contro la staleness ESM): il comportamento di
+// dns.resolve4 è delegato a una variabile mutabile che ogni test riassegna.
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 
-test('mailer: forza IPv4 nella connessione SMTP (fix ENETUNREACH su IPv6 rotto)', async () => {
-  process.env.SMTP_HOST = 'smtp.gmail.com';
-  process.env.SMTP_PORT = '465';
-  process.env.SMTP_USER = 'test@example.com';
-  process.env.SMTP_PASS = 'secret';
+process.env.SMTP_HOST = 'smtp.gmail.com';
+process.env.SMTP_PORT = '465';
+process.env.SMTP_USER = 'test@example.com';
+process.env.SMTP_PASS = 'secret';
 
-  let capturedOptions = null;
-  mock.module('nodemailer', {
-    defaultExport: {
-      createTransport: (opts) => {
-        capturedOptions = opts;
-        return { sendMail: async () => {} };
-      },
+let resolve4Impl = async () => ['142.250.1.109'];
+mock.module('node:dns', {
+  namedExports: {
+    promises: { resolve4: (...args) => resolve4Impl(...args) },
+  },
+});
+
+let capturedOptions = null;
+let capturedMail = null;
+mock.module('nodemailer', {
+  defaultExport: {
+    createTransport: (opts) => {
+      capturedOptions = opts;
+      return { sendMail: async (mail) => { capturedMail = mail; } };
     },
-  });
+  },
+});
 
-  const { mailerConfigured } = await import('../src/lib/mailer.js');
+const { mailerConfigured, sendMail } = await import('../src/lib/mailer.js');
 
+test('mailer: risolve l\'host in IPv4 e lo passa a nodemailer, preservando servername per il TLS', async () => {
+  resolve4Impl = async () => ['142.250.1.109'];
   assert.equal(mailerConfigured(), true);
-  assert.ok(capturedOptions, 'nodemailer.createTransport non è mai stato chiamato');
-  assert.equal(capturedOptions.family, 4, 'manca family:4 — il transporter tornerebbe a provare anche IPv6');
-  assert.equal(capturedOptions.host, 'smtp.gmail.com');
-  assert.equal(capturedOptions.secure, true);
 
-  delete process.env.SMTP_HOST;
-  delete process.env.SMTP_PORT;
-  delete process.env.SMTP_USER;
-  delete process.env.SMTP_PASS;
+  const ok = await sendMail({ to: 'dest@example.com', subject: 'Ciao', text: 'corpo' });
+  assert.equal(ok, true);
+
+  // L'host passato a nodemailer è l'IP risolto, NON l'hostname — così
+  // nodemailer salta la propria (difettosa) risoluzione DNS interna.
+  assert.equal(capturedOptions.host, '142.250.1.109');
+  // servername resta l'hostname vero: altrimenti il TLS/SNI verificherebbe
+  // il certificato contro un IP nudo e fallirebbe.
+  assert.equal(capturedOptions.tls.servername, 'smtp.gmail.com');
+  assert.equal(capturedOptions.secure, true);
+  assert.equal(capturedMail.to, 'dest@example.com');
+});
+
+test('mailer: se la risoluzione IPv4 fallisce, ripiega sull\'hostname invece di esplodere', async () => {
+  resolve4Impl = async () => { throw new Error('ENOTFOUND'); };
+
+  const ok = await sendMail({ to: 'dest@example.com', subject: 'Ciao', text: 'corpo' });
+  assert.equal(ok, true);
+  assert.equal(capturedOptions.host, 'smtp.gmail.com');
 });


### PR DESCRIPTION
## Causa

Il fix precedente (#224, `family:4` su `nodemailer.createTransport`) non
ha funzionato: stesso errore `ENETUNREACH`, su un diverso indirizzo IPv6
Gmail. Leggendo il sorgente di nodemailer
(`node_modules/nodemailer/lib/shared/index.js`, funzione
`resolveHostname`): nodemailer risolve **sempre** sia IPv4 sia IPv6
dell'host SMTP e sceglie un indirizzo **a caso** dalla lista combinata
(`Math.random()`, riga 83). `family` non viene mai letto da questo
percorso — passarlo non ha alcun effetto (assunzione sbagliata nel fix
precedente, mai verificata contro il sorgente reale). Il container
Render non ha connettività IPv6 in uscita, quindi ogni volta che il
sorteggio cadeva su IPv6 la connessione falliva — a intermittenza, non
sempre, il che spiegava perché sembrava "quasi" funzionare.

## Fix

Risolviamo l'host **noi stessi** con `dns.resolve4` (garantito solo
IPv4, Node nativo) e passiamo l'indirizzo IP letterale a nodemailer come
`host` — a quel punto nodemailer riconosce che è già un IP (`net.isIP`)
e salta del tutto la propria risoluzione DNS interna. `tls.servername`
resta l'hostname vero (`smtp.gmail.com`), altrimenti la verifica del
certificato TLS (SNI) fallirebbe contro un IP nudo. Se `dns.resolve4`
fallisce, si ripiega sull'hostname originale invece di esplodere.

`mailerConfigured()` ora è un controllo puro sulle variabili d'ambiente,
non più legato a un transporter costruito una sola volta al load del
modulo: `sendMail()` costruisce il transporter ad ogni chiamata, dopo
aver risolto l'host fresco (Gmail può cambiare IP nel tempo, un processo
Render può girare per giorni).

## Verifiche

- `mailerIPv4.test.js` riscritto con 2 casi: risoluzione riuscita → host
  letterale + servername corretto passati a nodemailer; risoluzione
  fallita → ripiega sull'hostname.
- `node --experimental-test-module-mocks --test`: 324 test backend,
  verificati **sia su Node 22 sia su Node 20**, tutti verdi.
- Nessun file RN toccato: bundle web non ricompilato (non necessario).

Nessuna migration in questa PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_