### PR TITLE
Compila con AI: deduce l'operatore treno anche dal solo tipo di servizio

### DIFF
--- a/server/src/ai/descriptionParse.js
+++ b/server/src/ai/descriptionParse.js
@@ -60,7 +60,11 @@ Regole vincolanti:
 - Restituisci SOLO JSON (nessun testo extra). Nessuna chiave aggiuntiva rispetto allo schema.
 
 8) Fornitore
-- "provider": se il testo è chiaramente una conferma di prenotazione di un fornitore riconoscibile (es. "Booking.com", "Trenitalia", "Italo", "Ryanair", "EasyJet", "Airbnb", "Expedia", "Trainline"), indicalo col nome comune del fornitore. Se il testo non lo indica chiaramente, metti null: non inventare mai un fornitore.
+- "provider": indicalo col nome comune del fornitore (es. "Booking.com", "Trenitalia", "Italo", "Ryanair", "EasyJet", "Airbnb", "Expedia", "Trainline") quando è ragionevolmente deducibile dal testo, in due casi:
+  a) il testo è chiaramente una conferma di prenotazione o nomina il fornitore esplicitamente;
+  b) PER I TRENI, il testo nomina un servizio/marchio commerciale esclusivo di un operatore, anche senza dire il nome dell'azienda: "Frecciarossa", "Frecciargento", "Freccia Bianca"/"Frecciabianca", "Intercity", "Intercity Notte", "EuroCity", "Euronight" → "Trenitalia"; "Italo" (il treno stesso si chiama così) → "Italo".
+- "Regionale"/"Regionale Veloce" da soli NON bastano a dedurre l'operatore: sono gestiti da più aziende diverse a seconda della regione (Trenitalia, Trenord, TPER…) — lascia "provider" null a meno che il testo non nomini esplicitamente anche l'azienda.
+- Se resta ambiguo o non chiaro, metti null: non inventare mai un fornitore.
 `;
 
 // Schema con chiavi estese (origin, destination, route, imageUrl)


### PR DESCRIPTION
## Cosa cambia

Il campo "Operatore" (colonna `listings.operator`, testo libero, compilato solo dall'AI — mai richiesto a mano, vedi migration `20260721180000_listings_operator.sql`) veniva dedotto solo quando il testo era chiaramente una conferma di prenotazione o nominava esplicitamente il fornitore ("Trenitalia", "Italo"...). Se l'utente scriveva solo "Frecciarossa" o "Intercity" senza mai citare Trenitalia, il campo restava vuoto.

## Fix

Aggiunta un'euristica al prompt di `server/src/ai/descriptionParse.js` (punto 8, "Fornitore"): i marchi commerciali esclusivi di un operatore bastano da soli a dedurre `provider`, anche senza il nome dell'azienda nel testo:

- Frecciarossa / Frecciargento / Freccia Bianca (Frecciabianca) / Intercity / Intercity Notte / EuroCity / Euronight → **Trenitalia**
- Italo (il treno si chiama già così) → **Italo**

`Regionale`/`Regionale Veloce` restano volutamente **esclusi** dall'euristica: sono gestiti da aziende diverse a seconda della regione (Trenitalia, Trenord, TPER, ecc.) — indicare un operatore sbagliato sarebbe peggio che lasciarlo vuoto, quindi lì il campo resta `null` a meno che il testo non nomini esplicitamente anche l'azienda.

Stesso prompt è condiviso da "Compila con AI" (testo libero), import PDF biglietto e import da conferma incollata — la modifica copre tutti e tre i flussi.

## Verifiche

- Nessuna modifica di schema/DB: `operator` era già una colonna `text` libera.
- Test backend: 325/325 verdi (nessun test copre il testo esatto del prompt).
- Parse-check sul file toccato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_