### PR TITLE
Analisi prezzo: passa a un modello di punta (gpt-4.1) come default

### DIFF
--- a/docs/FUNCTIONAL_OVERVIEW.md
+++ b/docs/FUNCTIONAL_OVERVIEW.md
@@ -255,6 +255,8 @@ Ricostruito dalle query nel codice; i tipi sono dedotti.
 | `OPENAI_API_KEY` | tutte le funzioni AI |
 | `MATCH_AI_MODEL` (default `gpt-4o-mini`), `MATCH_AI_TEMP`, `MATCH_AI_TOP_P`, `MATCH_AI_BATCH`, `MATCH_AI_TIMEOUT_MS`, `MATCH_AI_CONCURRENCY`, `MATCH_AI_DETERMINISTIC`, `MATCH_AI_SEED_MODE`, `MATCH_INSERT_CHUNK` | tuning matching |
 | `OPENAI_TRUST_MODEL` | modello per il TrustScore |
+| `OPENAI_PRICE_MODEL` (default `gpt-4.1`) | modello per l'analisi prezzo. È l'unica funzione AI che parte da un modello di punta invece che dal "mini": non estrae né classifica, deve *sapere* quanto vale una tratta in un certo periodo — conoscenza del mondo e giudizio, dove il divario tra i due tier è massimo. Costa poco alzarlo perché è una chiamata sola con prompt breve, al contrario del matching (`MATCH_AI_MODEL`), che resta apposta sul modello economico avendo il volume di token più alto e il compito più ristretto |
+| `CHAIN_AI_MODEL` | modello per gli scambi a 3 (`chainMatch`/`chainExplain`); se assente ricade su `MATCH_AI_MODEL` |
 | `FB_VERIFY_TOKEN`, `FB_APP_SECRET`, `FB_PAGE_ACCESS_TOKEN` | webhook + Send API Messenger |
 | `ALLOW_UNVERIFIED_WEBHOOK` | ⚠️ bypass verifica firma FB |
 | `DEFAULT_LISTING_OWNER_ID` | owner degli annunci importati da FB |

--- a/server/src/ai/priceCheck.js
+++ b/server/src/ai/priceCheck.js
@@ -6,7 +6,20 @@ import { createOpenAIClient } from "../lib/openaiClient.js";
 
 const client = createOpenAIClient();
 
-const MODEL = process.env.OPENAI_PRICE_MODEL || "gpt-4o-mini";
+// A differenza delle altre funzioni AI, qui il modello NON deve estrarre né
+// classificare: deve SAPERE quanto vale un Frecciarossa Roma-Milano un venerdì
+// di agosto. È conoscenza del mondo più giudizio, cioè esattamente ciò che
+// distingue un modello di punta da uno "mini" — che su questo compito tende a
+// stime generiche e prudenti. Ed è anche la funzione dove alzare il modello
+// costa meno: una sola chiamata per richiesta, con un prompt breve, contro i
+// batch da 40 candidati del matching (che resta apposta sul modello economico,
+// vedi MATCH_AI_MODEL: lì il compito è deliberatamente ristretto a
+// tipo/complementarità/tratta).
+//
+// Resta sovrascrivibile da OPENAI_PRICE_MODEL: se il modello qui sotto non è
+// abilitato sull'account, l'errore ora è visibile (niente più risposte vuote
+// mascherate) e basta puntare la variabile a un altro modello.
+const MODEL = process.env.OPENAI_PRICE_MODEL || "gpt-4.1";
 
 const LOCALE_LANG_NAME = { it: "italiano", en: "English", es: "español" };
 


### PR DESCRIPTION
## Cosa cambia

Una riga: il default di `OPENAI_PRICE_MODEL` passa da `gpt-4o-mini` a `gpt-4.1`. Solo l'analisi prezzo — tutte le altre funzioni AI restano invariate.

## Perché proprio questa funzione

Delle cinque funzioni AI del progetto, l'analisi prezzo è l'unica dove il salto di modello si ripaga:

- **Non deve estrarre né classificare**, deve *sapere* quanto vale un Frecciarossa Roma-Milano un venerdì di agosto. È conoscenza del mondo più giudizio — esattamente ciò che separa un modello di punta da uno "mini", che su questo compito tende a stime generiche e prudenti. Il prompt gli chiede già di ragionare esplicitamente su stagionalità, giorno della settimana e classe: sono istruzioni che un modello più capace sfrutta davvero.
- **È anche la più economica da alzare**: una sola chiamata per richiesta, con un prompt breve.

## Perché il matching resta sul "mini"

`MATCH_AI_MODEL` non viene toccato di proposito. Ha il volume di token di gran lunga più alto (batch da 40 candidati per ogni annuncio sorgente, fino a 500 candidati) e il compito più ristretto: il suo prompt **vieta esplicitamente** di valutare data e prezzo, e ha pure un fallback deterministico che lo approssima. Sarebbe il premio più caro pagato sul compito che ne ha meno bisogno.

## Rischi

Nessuno sui parametri: la chiamata usa `chat.completions` con `response_format: json_object` e `temperature: 0.3`, tutti supportati da questo modello. (Attenzione invece se un domani si prova un modello della famiglia "reasoning": diversi rifiutano `temperature` e la chiamata fallirebbe.)

Il default resta sovrascrivibile con `OPENAI_PRICE_MODEL` su Render. Se il modello non fosse abilitato sull'account, l'errore ora è **visibile** e non più mascherato da una risposta vuota — grazie al fix di stamattina sul mascheramento degli errori AI.

## Documentazione

Aggiunte alla tabella delle variabili d'ambiente `OPENAI_PRICE_MODEL` e `CHAIN_AI_MODEL`, che non erano elencate.

## Verifiche

- Test backend: **349/349** verdi.
- Parse-check sul file toccato.
- Nessuna modifica client: bundle web invariato, non ricompilato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_