### PR TITLE
Check AI: passa a un modello di punta (gpt-4.1) come default

### DIFF
--- a/docs/FUNCTIONAL_OVERVIEW.md
+++ b/docs/FUNCTIONAL_OVERVIEW.md
@@ -254,7 +254,7 @@ Ricostruito dalle query nel codice; i tipi sono dedotti.
 | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` | accesso DB con privilegi elevati |
 | `OPENAI_API_KEY` | tutte le funzioni AI |
 | `MATCH_AI_MODEL` (default `gpt-4o-mini`), `MATCH_AI_TEMP`, `MATCH_AI_TOP_P`, `MATCH_AI_BATCH`, `MATCH_AI_TIMEOUT_MS`, `MATCH_AI_CONCURRENCY`, `MATCH_AI_DETERMINISTIC`, `MATCH_AI_SEED_MODE`, `MATCH_INSERT_CHUNK` | tuning matching |
-| `OPENAI_TRUST_MODEL` | modello per il TrustScore |
+| `OPENAI_TRUST_MODEL` (default `gpt-4.1`) | modello per il TrustScore. Come l'analisi prezzo parte da un modello di punta: qui non si estrae un campo, si dà un giudizio su cosa è plausibile e cosa somiglia a una truffa, testo e foto insieme — ed è la funzione con le conseguenze più visibili quando sbaglia. **Deve supportare la visione** (le immagini viaggiano come `image_url`, `detail: "low"`) |
 | `OPENAI_PRICE_MODEL` (default `gpt-4.1`) | modello per l'analisi prezzo. È l'unica funzione AI che parte da un modello di punta invece che dal "mini": non estrae né classifica, deve *sapere* quanto vale una tratta in un certo periodo — conoscenza del mondo e giudizio, dove il divario tra i due tier è massimo. Costa poco alzarlo perché è una chiamata sola con prompt breve, al contrario del matching (`MATCH_AI_MODEL`), che resta apposta sul modello economico avendo il volume di token più alto e il compito più ristretto |
 | `CHAIN_AI_MODEL` | modello per gli scambi a 3 (`chainMatch`/`chainExplain`); se assente ricade su `MATCH_AI_MODEL` |
 | `FB_VERIFY_TOKEN`, `FB_APP_SECRET`, `FB_PAGE_ACCESS_TOKEN` | webhook + Send API Messenger |

--- a/server/src/services/trust/aiTrust.js
+++ b/server/src/services/trust/aiTrust.js
@@ -196,7 +196,17 @@ export async function aiTrustReview(listing, heur = {}, locale = 'it') {
 
   try {
     const completion = await openai.chat.completions.create({
-      model: process.env.OPENAI_TRUST_MODEL || "gpt-4o-mini",
+      // Modello di punta come per l'analisi prezzo (OPENAI_PRICE_MODEL), e per
+      // ragioni simili: qui non si estrae un campo, si dà un GIUDIZIO su cosa
+      // è plausibile e cosa puzza di truffa, guardando testo e foto insieme.
+      // È anche la funzione con le conseguenze più visibili quando sbaglia —
+      // un punteggio ingiusto danneggia un venditore onesto, uno generoso
+      // lascia passare un annuncio fasullo. Deve supportare la visione: le
+      // immagini viaggiano come image_url con detail "low".
+      // Volume contenuto (una chiamata per Check AI, foto a bassa risoluzione),
+      // quindi il costo in più resta modesto — al contrario del matching, che
+      // per questo resta sul modello economico (MATCH_AI_MODEL).
+      model: process.env.OPENAI_TRUST_MODEL || "gpt-4.1",
       response_format: { type: "json_object" }, // forza JSON
       // temperature 0: massima consistenza tra check ripetuti sullo stesso
       // annuncio (un punteggio di rischio non deve ballare a ogni click).


### PR DESCRIPTION
## Cosa cambia

Il default di `OPENAI_TRUST_MODEL` passa da `gpt-4o-mini` a `gpt-4.1`. È il secondo e ultimo dei due passaggi previsti dall'analisi (dopo l'analisi prezzo in #242).

## Perché

Stesse ragioni dell'analisi prezzo, aggravate:

- **Qui non si estrae un campo, si dà un giudizio**: cosa è plausibile e cosa somiglia a una truffa, valutando testo e foto *insieme*.
- **È la funzione con le conseguenze più visibili quando sbaglia**: un punteggio ingiusto danneggia un venditore onesto, uno troppo generoso lascia passare un annuncio fasullo.
- **C'è già una prova che il modello attuale faticava**: `falseClaims.js` esiste perché il modello affermava che mancava un dato che invece c'era, e serviva un backstop deterministico a valle. Quel backstop resta (è comunque la difesa giusta), ma un modello più capace dovrebbe farlo scattare meno spesso.

## Compatibilità verificata

La chiamata usa `chat.completions` con `response_format: json_object`, `temperature: 0` e le immagini come `image_url` con `detail: "low"`. Il modello scelto supporta tutto, **visione inclusa** — requisito non negoziabile qui, a differenza dell'analisi prezzo.

Il volume resta contenuto (una chiamata per Check AI, foto a bassa risoluzione ≈ costo fisso per immagine), quindi il costo in più è modesto.

## Cosa NON cambia

`MATCH_AI_MODEL` (matching) resta sul modello economico: volume di token di gran lunga più alto, compito deliberatamente ristretto a tipo/complementarità/tratta, e fallback deterministico già presente.

## Verifiche

- Test backend: **349/349** verdi.
- Parse-check sul file toccato.
- Nessuna modifica client: bundle web invariato, non ricompilato.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_