### PR TITLE
Privacy: i luoghi di trattamento non erano più quelli veri

### DIFF
--- a/server/public/legal/privacy.html
+++ b/server/public/legal/privacy.html
@@ -86,22 +86,21 @@
 <table>
   <tr><th>Fornitore</th><th>Cosa fa</th><th>Dove</th></tr>
   <tr><td>Supabase</td><td>Database, autenticazione e archiviazione delle immagini</td><td>Europa (Zurigo, Svizzera)</td></tr>
-  <tr><td>Render</td><td>Server applicativo</td><td>Stati Uniti (Oregon)</td></tr>
+  <tr><td>Render</td><td>Server applicativo</td><td>Unione Europea (Francoforte, Germania)</td></tr>
   <tr><td>OpenAI</td><td>Analisi dei testi e delle foto degli annunci, stima dei prezzi, traduzioni</td><td>Stati Uniti</td></tr>
-  <tr><td>Resend</td><td>Invio delle email di servizio</td><td>Stati Uniti / Unione Europea</td></tr>
+  <tr><td>Resend</td><td>Invio delle email di servizio</td><td>Unione Europea (Irlanda)</td></tr>
   <tr><td>Meta (Messenger)</td><td>Solo se colleghi il tuo account al bot Messenger</td><td>Stati Uniti</td></tr>
 </table>
 <p>
-  Nessuno di questi fornitori si trova nell'Unione Europea, e i due casi vanno distinti.
+  Il server dell'applicazione e l'invio delle email restano dentro l'Unione Europea. Per gli altri due casi
+  la situazione va distinta.
 </p>
 <ul>
   <li><strong>Svizzera</strong> (database e archiviazione, Supabase): la Commissione europea ha riconosciuto alla
       Svizzera un livello di protezione adeguato, quindi il trasferimento è lecito senza ulteriori garanzie.</li>
-  <li><strong>Stati Uniti</strong> (server applicativo su Render, in Oregon; analisi AI su OpenAI; invio email
-      su Resend): il trasferimento avviene sulla base delle clausole contrattuali standard approvate dalla
-      Commissione europea. <strong>Poiché il server dell'applicazione si trova negli Stati Uniti, tutti i dati
-      che passano dall'app vi transitano e vi vengono elaborati</strong>, non solo quelli inviati ai servizi di
-      intelligenza artificiale.</li>
+  <li><strong>Stati Uniti</strong> (analisi AI su OpenAI; Meta, solo se colleghi Messenger): il trasferimento
+      avviene sulla base delle clausole contrattuali standard approvate dalla Commissione europea. Riguarda
+      soltanto i dati effettivamente inviati a quei servizi — non l'insieme dei dati che passano dall'app.</li>
 </ul>
 <p>
   <strong>Ciò che viene inviato a OpenAI è il contenuto dell'annuncio</strong> (testo, prezzo, tratta, date, foto):


### PR DESCRIPTION
L'informativa dichiarava il server applicativo negli Stati Uniti (Render, Oregon) e Resend fra "Stati Uniti / Unione Europea". Da quando il server è su Francoforte (#252) e Resend è configurato su `eu-west-1` (Irlanda) è semplicemente falso — e in un documento che dichiara dove finiscono i dati personali è il genere di dettaglio che non può restare approssimativo, tanto più andando in revisione da un avvocato.

## Cosa cambia

| Fornitore | Prima | Ora |
|---|---|---|
| Render | Stati Uniti (Oregon) | Unione Europea (Francoforte) |
| Resend | Stati Uniti / Unione Europea | Unione Europea (Irlanda) |

Il quadro migliora, e ora si può dire: server applicativo e invio email dentro l'Unione Europea, database in Svizzera (decisione di adeguatezza), e i trasferimenti verso gli Stati Uniti ridotti a OpenAI e a Meta — quest'ultimo solo per chi collega Messenger.

Cade di conseguenza la frase più pesante del paragrafo, che descriveva l'architettura precedente:

> **Poiché il server dell'applicazione si trova negli Stati Uniti, tutti i dati che passano dall'app vi transitano e vi vengono elaborati**, non solo quelli inviati ai servizi di intelligenza artificiale.

sostituita dalla precisazione che il trasferimento riguarda soltanto i dati effettivamente inviati a quei servizi.

Modificato anche l'attacco del paragrafo, che diceva "Nessuno di questi fornitori si trova nell'Unione Europea" — non più vero.

## Verifiche

Solo testo di un documento statico: nessun codice toccato, nessuna stringa dell'app, nessun test coinvolto.

## Nota

Resend è ancora in stato *Pending*: la regione (Irlanda) è già scelta e non cambia con la verifica, che riguarda solo i record DNS del dominio mittente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_