### PR TITLE
Credito OpenAI esaurito: riconoscerlo, non ritentarlo, non raccontarlo

### DIFF
--- a/server/src/ai/descriptionParse.js
+++ b/server/src/ai/descriptionParse.js
@@ -1,6 +1,6 @@
 // server/src/ai/descriptionParse.js
 import { toFile } from "openai";
-import { createOpenAIClient } from "../lib/openaiClient.js";
+import { createOpenAIClient, isQuotaExhausted, userFacingAIError } from "../lib/openaiClient.js";
 
 const MODEL = process.env.MATCH_AI_MODEL || "gpt-4o-mini";
 const TEMPERATURE = Number(process.env.MATCH_AI_TEMP ?? 0);
@@ -339,6 +339,10 @@ const MAX_PDF_BASE64_CHARS = 8_000_000;
  */
 export async function withOpenAIRetry(fn, { what = "richiesta" } = {}) {
   const transient = (e) => {
+    // Credito esaurito: è un 429 come il limite di frequenza, ma non passa
+    // aspettando. Ritentarlo raddoppia solo l'attesa prima di dire la
+    // stessa cosa.
+    if (isQuotaExhausted(e)) return false;
     const s = Number(e?.status);
     return !Number.isFinite(s) || s >= 500 || s === 429;
   };
@@ -474,11 +478,16 @@ export function mountParseDescriptionRoute(app, requireAuth) {
       const data = await parseTicketPdfWithAI(pdfBase64, locale);
       return res.json({ ok: true, data });
     } catch (err) {
+      // Nei log il messaggio ORIGINALE, senza filtri: è quello che serve a
+      // noi per capire. All'utente va invece una frase comprensibile —
+      // "aggiungi credito su platform.openai.com" non gli dice niente, e
+      // intanto gli racconta con che fornitore lavoriamo e che abbiamo il
+      // conto scoperto.
       console.error("[/ai/parse-ticket-pdf] error:", err?.message || err);
-      const status = err?.status || 502;
+      const status = isQuotaExhausted(err) ? 503 : (err?.status || 502);
       return res.status(status).json({
         ok: false,
-        error: err?.message || "Lettura del PDF non riuscita.",
+        error: userFacingAIError(err) || "Lettura del PDF non riuscita.",
       });
     }
   });

--- a/server/src/lib/openaiClient.js
+++ b/server/src/lib/openaiClient.js
@@ -32,3 +32,35 @@ export function createOpenAIClient({ timeoutMs, maxRetries } = {}) {
     maxRetries: Number.isFinite(maxRetries) ? maxRetries : DEFAULT_MAX_RETRIES,
   });
 }
+
+/**
+ * Il credito dell'account OpenAI è finito?
+ *
+ * Arriva come 429, cioè lo stesso codice del limite di frequenza, ma le due
+ * cose non si somigliano per niente: un limite di frequenza passa da solo
+ * aspettando, il credito esaurito no — ritentare significa solo aspettare
+ * il doppio per ricevere lo stesso rifiuto. Osservato in produzione il 4
+ * agosto: "429 You have no credits remaining".
+ */
+export function isQuotaExhausted(err) {
+  if (Number(err?.status) !== 429) return false;
+  const code = String(err?.code || err?.error?.code || "");
+  if (code === "insufficient_quota") return true;
+  return /no credits remaining|exceeded your current quota|billing/i.test(String(err?.message || ""));
+}
+
+/**
+ * Messaggio da mostrare all'utente per un guasto del servizio AI.
+ *
+ * Il dettaglio tecnico è prezioso per noi e va nei log, ma NON deve
+ * arrivare a chi usa l'app: davanti a "add credits at
+ * platform.openai.com/settings/organization/billing" una persona non capisce
+ * niente, e intanto le stiamo dicendo con quale fornitore lavoriamo e che
+ * abbiamo il conto scoperto.
+ */
+export function userFacingAIError(err) {
+  if (isQuotaExhausted(err)) {
+    return "Il servizio AI non è disponibile in questo momento. Riprova più tardi o compila i campi a mano.";
+  }
+  return err?.message || "Servizio AI non disponibile.";
+}

--- a/server/test/openaiQuota.test.js
+++ b/server/test/openaiQuota.test.js
@@ -1,0 +1,53 @@
+// Credito OpenAI esaurito: riconoscerlo, non ritentarlo, non raccontarlo.
+//
+// Caso reale del 4 agosto: l'import PDF falliva e il messaggio mostrato
+// all'utente era "429 You have no credits remaining. Add credits to
+// continue using the API at https://platform.openai.com/settings/
+// organization/billing/". Ottimo per noi, pessimo per chi usa l'app: non
+// gli dice cosa fare, e intanto gli racconta con quale fornitore lavoriamo
+// e che abbiamo il conto scoperto.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isQuotaExhausted, userFacingAIError } from '../src/lib/openaiClient.js';
+
+const quotaErr = () => Object.assign(
+  new Error('429 You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.'),
+  { status: 429 },
+);
+
+test('riconosce il credito esaurito dal messaggio', () => {
+  assert.equal(isQuotaExhausted(quotaErr()), true);
+});
+
+test('riconosce il credito esaurito dal codice applicativo', () => {
+  const e = Object.assign(new Error('quota'), { status: 429, code: 'insufficient_quota' });
+  assert.equal(isQuotaExhausted(e), true);
+});
+
+test('NON confonde il limite di frequenza col credito esaurito', () => {
+  // Sono lo stesso codice HTTP ma due cose opposte: il primo passa
+  // aspettando, il secondo no.
+  const rateLimit = Object.assign(new Error('Rate limit reached for requests'), { status: 429 });
+  assert.equal(isQuotaExhausted(rateLimit), false);
+});
+
+test('un errore di altro tipo non è mai credito esaurito', () => {
+  for (const status of [400, 401, 500, 520, undefined]) {
+    assert.equal(isQuotaExhausted(Object.assign(new Error('x'), { status })), false);
+  }
+  assert.equal(isQuotaExhausted(null), false);
+});
+
+test("all'utente non arrivano né il fornitore né la fatturazione", () => {
+  const msg = userFacingAIError(quotaErr());
+  assert.doesNotMatch(msg, /openai/i, 'il nome del fornitore non deve uscire');
+  assert.doesNotMatch(msg, /credit|billing|quota/i, 'lo stato del nostro conto non deve uscire');
+  assert.doesNotMatch(msg, /https?:\/\//, 'nessun link a pannelli che non sono suoi');
+  assert.match(msg, /riprova|a mano/i, "deve dire cosa può fare adesso");
+});
+
+test('per gli altri errori il messaggio originale resta, serve a diagnosticare', () => {
+  const e = Object.assign(new Error('Il servizio AI ha risposto in un formato non valido.'), { status: 502 });
+  assert.equal(userFacingAIError(e), 'Il servizio AI ha risposto in un formato non valido.');
+});

--- a/server/test/openaiRetry.test.js
+++ b/server/test/openaiRetry.test.js
@@ -74,3 +74,20 @@ test('se fallisce due volte, l\'errore del secondo tentativo arriva al chiamante
   );
   assert.equal(calls, 2);
 });
+
+test('NON ritenta quando il credito è esaurito, anche se è un 429', async () => {
+  // Caso reale del 4 agosto. Il 429 di norma si ritenta (limite di
+  // frequenza, passa aspettando), ma il credito finito no: si aspetterebbe
+  // il doppio per ricevere identico rifiuto, e si raddoppierebbe il rumore
+  // nei log su un guasto che si risolve solo ricaricando.
+  let calls = 0;
+  const quota = Object.assign(
+    new Error('429 You have no credits remaining. Add credits to continue using the API.'),
+    { status: 429 },
+  );
+  await assert.rejects(
+    () => withOpenAIRetry(async () => { calls++; throw quota; }),
+    /no credits remaining/,
+  );
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
## La causa vera, e la mia ipotesi sbagliata

L'import PDF non falliva per la dimensione del documento — era la mia ipotesi in #261, ed era **sbagliata**. L'account OpenAI è **senza credito**.

L'ha rivelata il messaggio diagnostico aggiunto poche ore prima nella stessa PR:

> `429 You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/`

Il passaggio alla Files API resta corretto (mandare megabyte dentro un JSON non è il modo), ma non era il fix di questo problema.

## Due problemi che quel messaggio rende evidenti

**1. Veniva ritentato, e non ha senso.** Arriva come `429`, lo stesso codice del limite di frequenza, quindi `withOpenAIRetry` lo trattava come temporaneo. Ma le due cose non si somigliano: un limite di frequenza **passa aspettando**, il credito esaurito **no**. Ritentarlo significa aspettare il doppio per ricevere lo stesso rifiuto, e raddoppiare il rumore nei log su un guasto che si risolve solo ricaricando.

**2. Finiva sotto gli occhi dell'utente.** A una persona quel testo non dice niente di utile — e intanto le racconta con quale fornitore lavoriamo e che abbiamo il conto scoperto.

Ora nei log resta il messaggio **originale**, che è quello che serve a noi; all'utente va una frase che dice cosa può fare adesso: riprovare più tardi o compilare a mano.

## Come

Due funzioni in `lib/openaiClient.js` — il punto che tutti i chiamanti AI già attraversano, quindi riusabili quando serviranno anche altrove:

- `isQuotaExhausted(err)` distingue le due famiglie di 429, per codice (`insufficient_quota`) o per testo;
- `userFacingAIError(err)` produce il messaggio pulito, lasciando intatti gli altri errori — quelli servono a diagnosticare e vanno mostrati.

Lo status passa a **503** per il caso quota: non è un errore della richiesta, è un servizio indisponibile.

## Verifiche

7 nuovi test (**376 lato server**, 113 lato app, tutti verdi), fra cui:

- il caso che tiene separato il **limite di frequenza** dal **credito finito** — stesso codice HTTP, comportamento opposto;
- l'asserzione che nome del fornitore, stato del conto e link alla fatturazione **non escano mai** verso l'utente.

Nessuna migration.

## ⚠️ Azione manuale

Questa PR rende il guasto comprensibile, **non lo risolve**: va ricaricato il credito su [platform.openai.com](https://platform.openai.com/settings/organization/billing/). Finché non c'è credito, **tutte** le funzioni AI restano ferme — non solo l'import PDF, ma anche Check AI, suggerimento e analisi prezzo, ricerca in linguaggio naturale, matching e traduzioni.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_