### PR TITLE
Tracciamento errori: arrivano anche i guasti &quot;gestiti&quot;, che erano il punto

### DIFF
--- a/server/src/ai/chainMatch.js
+++ b/server/src/ai/chainMatch.js
@@ -12,6 +12,7 @@
 // fallisce, così la ricerca cicli non si blocca mai per un problema
 // di rete/quota OpenAI.
 import OpenAI from "openai";
+import { reportFault } from "../lib/monitoring.js";
 import { mapWithConcurrency } from "../lib/concurrency.js";
 
 const client = process.env.OPENAI_API_KEY
@@ -260,7 +261,7 @@ async function callOpenAIChainScore(prompt, timeoutMs) {
     return Array.isArray(parsed?.scores) ? parsed.scores : null;
   } catch (e) {
     clearTimeout(timer);
-    console.error("[chainMatch] OpenAI error:", e?.status, e?.message || e);
+    reportFault("chainMatch", e, { status: e?.status });
     return null;
   }
 }

--- a/server/src/ai/descriptionParse.js
+++ b/server/src/ai/descriptionParse.js
@@ -1,6 +1,7 @@
 // server/src/ai/descriptionParse.js
 import { toFile } from "openai";
 import { createOpenAIClient, isQuotaExhausted, userFacingAIError } from "../lib/openaiClient.js";
+import { reportFault } from "../lib/monitoring.js";
 
 const MODEL = process.env.MATCH_AI_MODEL || "gpt-4o-mini";
 const TEMPERATURE = Number(process.env.MATCH_AI_TEMP ?? 0);
@@ -463,7 +464,7 @@ export function mountParseDescriptionRoute(app, requireAuth) {
       const data = await parseDescriptionWithAI(text, locale);
       return res.json({ ok: true, data });
     } catch (err) {
-      console.error("[/ai/parse-description] error:", err?.message || err);
+      reportFault("/ai/parse-description", err, { status: err?.status });
       const status = err?.status || 502;
       return res.status(status).json({
         ok: false,
@@ -483,7 +484,7 @@ export function mountParseDescriptionRoute(app, requireAuth) {
       // "aggiungi credito su platform.openai.com" non gli dice niente, e
       // intanto gli racconta con che fornitore lavoriamo e che abbiamo il
       // conto scoperto.
-      console.error("[/ai/parse-ticket-pdf] error:", err?.message || err);
+      reportFault("/ai/parse-ticket-pdf", err, { status: err?.status });
       const status = isQuotaExhausted(err) ? 503 : (err?.status || 502);
       return res.status(status).json({
         ok: false,

--- a/server/src/ai/priceCheck.js
+++ b/server/src/ai/priceCheck.js
@@ -3,6 +3,7 @@
 // usando la sola conoscenza generale del modello, senza dati di mercato in
 // tempo reale — un parere orientativo, non una quotazione garantita.
 import { createOpenAIClient } from "../lib/openaiClient.js";
+import { reportFault } from "../lib/monitoring.js";
 import { cacheKey, getCached, setCached } from "../lib/aiCache.js";
 
 const client = createOpenAIClient();
@@ -190,7 +191,7 @@ export async function suggestPriceWithAI(draft, locale = "it", { quick = false }
     // deve restare appiccicato alla tratta per 24 ore.
     return setCached(key, { available: true, suggestedPrice: Math.round(suggestedPrice), explanation });
   } catch (e) {
-    console.error("[suggestPriceWithAI] error:", e?.message || e);
+    reportFault("suggestPriceWithAI", e);
     return { available: false, reason: "Analisi non riuscita al momento" };
   }
 }
@@ -248,7 +249,7 @@ export async function checkPriceWithAI(listing, locale = "it") {
 
     return setCached(key, { available: true, verdict, explanation });
   } catch (e) {
-    console.error("[checkPriceWithAI] error:", e?.message || e);
+    reportFault("checkPriceWithAI", e);
     return { available: false, reason: "Analisi non riuscita al momento" };
   }
 }

--- a/server/src/ai/score.js
+++ b/server/src/ai/score.js
@@ -1,5 +1,6 @@
 // server/src/ai/score.js
 import OpenAI from "openai";
+import { reportFault } from "../lib/monitoring.js";
 import { mapWithConcurrency } from "../lib/concurrency.js";
 import { envInt } from "../lib/envNumber.js";
 
@@ -260,7 +261,7 @@ async function callOpenAIJSON({
       const status = e?.status;
       const msg = String(e?.message || e || "");
       const aborted = /abort|timeout/i.test(msg);
-      console.error("[AI] OpenAI error:", status, msg, aborted ? "(aborted)" : "");
+      reportFault("matchScore", e, { status, aborted });
 
       if (attempt + 1 < maxAttempts && shouldRetry(e, status)) {
         // backoff molto leggero per evitare picchi (non cambia l'API)

--- a/server/src/ai/searchParse.js
+++ b/server/src/ai/searchParse.js
@@ -10,6 +10,7 @@
 // deterministico, quindi se l'AI non risponde la ricerca non si rompe —
 // il client ricade sulla ricerca testuale semplice che aveva già.
 import { createOpenAIClient } from "../lib/openaiClient.js";
+import { reportFault } from "../lib/monitoring.js";
 
 const MODEL = process.env.MATCH_AI_MODEL || "gpt-4o-mini";
 const TEMPERATURE = Number(process.env.MATCH_AI_TEMP ?? 0);
@@ -193,7 +194,7 @@ export function mountParseSearchRoute(app, requireAuth) {
       const filters = await parseSearchQueryWithAI(query, locale);
       return res.json({ ok: true, filters });
     } catch (err) {
-      console.error("[/ai/parse-search] error:", err?.message || err);
+      reportFault("/ai/parse-search", err);
       const status = err?.status || 502;
       return res.status(status).json({
         ok: false,

--- a/server/src/lib/mailer.js
+++ b/server/src/lib/mailer.js
@@ -20,6 +20,8 @@
 //                   per mandare a utenti reali serve un dominio proprio
 //                   verificato su Resend (Dashboard → Domains, richiede
 //                   aggiungere record SPF/DKIM al DNS del dominio).
+import { reportFault } from "./monitoring.js";
+
 const API_KEY = (process.env.RESEND_API_KEY || "").trim();
 const FROM = (process.env.RESEND_FROM || "").trim() || "TravelSwap <onboarding@resend.dev>";
 
@@ -44,12 +46,12 @@ export async function sendMail({ to, subject, text }) {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      console.error("[mailer] invio fallito:", res.status, body);
+      reportFault("mailer", new Error(`invio fallito: HTTP ${res.status}`), { body: String(body).slice(0, 300) });
       return false;
     }
     return true;
   } catch (e) {
-    console.error("[mailer] invio fallito:", e?.message || e);
+    reportFault("mailer", e);
     return false;
   }
 }

--- a/server/src/lib/monitoring.js
+++ b/server/src/lib/monitoring.js
@@ -23,6 +23,64 @@ export function captureError(error, context = {}) {
   }
 }
 
+// Ogni quanto ri-segnalare lo STESSO guasto. Senza questo freno, un
+// fornitore giù (OpenAI senza credito, database irraggiungibile) produce
+// una segnalazione per ogni richiesta: con 5.000 eventi al mese sul piano
+// gratuito, un pomeriggio di disservizio brucia la quota e le settimane
+// dopo restiamo ciechi proprio mentre paghiamo per non esserlo.
+const FAULT_THROTTLE_MS = 5 * 60 * 1000;
+const lastReported = new Map();
+let lastSweep = Date.now();
+
+function shouldReport(key) {
+  const now = Date.now();
+  // Pulizia periodica: senza, ogni messaggio d'errore mai visto resta in
+  // memoria per sempre su un processo che non riparte mai.
+  if (now - lastSweep > FAULT_THROTTLE_MS) {
+    lastSweep = now;
+    for (const [k, t] of lastReported) {
+      if (now - t > FAULT_THROTTLE_MS) lastReported.delete(k);
+    }
+  }
+  const prev = lastReported.get(key);
+  if (prev && now - prev < FAULT_THROTTLE_MS) return false;
+  lastReported.set(key, now);
+  return true;
+}
+
+/**
+ * Un guasto: qualcosa che DOVEVA funzionare e non ha funzionato.
+ *
+ * Da usare al posto di `console.error` nei punti dove il codice cattura
+ * un'eccezione e prosegue con un ripiego — sono esattamente i guasti che
+ * restavano invisibili, perché gestiti con eleganza: credito OpenAI
+ * esaurito, email non partita, documento illeggibile. Il ripiego salva
+ * l'utente, il silenzio sepolliva il problema.
+ *
+ * NON va usato per gli errori dell'utente (input non valido, limite di
+ * frequenza raggiunto, ricerca incomprensibile): quelli non sono guasti, e
+ * riempirebbero il tracciamento di rumore fino a renderlo inutile.
+ *
+ * Il log resta SEMPRE, anche senza Sentry configurato e anche quando la
+ * segnalazione viene soffocata dal freno: i log sono il posto dove si
+ * guarda quando si sta già indagando.
+ */
+export function reportFault(scope, error, extra = {}) {
+  const err = error instanceof Error
+    ? error
+    : new Error(String(error?.message || error || "errore senza messaggio"));
+  console.error(`[${scope}]`, err.message || err);
+  if (!monitoringEnabled()) return;
+  if (!shouldReport(`${scope}:${err.message}`.slice(0, 200))) return;
+  captureError(err, { scope, ...extra });
+}
+
+/** Solo per i test. */
+export function __resetFaultThrottleForTests() {
+  lastReported.clear();
+  lastSweep = Date.now();
+}
+
 /** Annota un evento non eccezionale ma degno di nota (es. quota esaurita). */
 export function captureMessage(message, context = {}) {
   if (!monitoringEnabled()) return;

--- a/server/src/services/trust/aiTrust.js
+++ b/server/src/services/trust/aiTrust.js
@@ -1,5 +1,6 @@
 // server/src/services/trust/aiTrust.js
 import { createOpenAIClient } from "../../lib/openaiClient.js";
+import { reportFault } from "../../lib/monitoring.js";
 import { reasonWithoutFalseClaims, fixesWithoutFalseClaims } from "./falseClaims.js";
 
 // Bug preesistente corretto: il costruttore di OpenAI lancia un'eccezione
@@ -258,7 +259,7 @@ export async function aiTrustReview(listing, heur = {}, locale = 'it') {
     // quindi quei dati arrivavano agli utenti finali. Il ragionamento di prima
     // ("l'SDK non mette mai la chiave nel messaggio") era giusto sulla chiave
     // ma non copriva il resto.
-    console.error("[aiTrustReview] error:", e?.status || "", e?.message || e);
+    reportFault("aiTrustReview", e, { status: e?.status });
 
     // Allo status HTTP si può restare: non identifica nulla e serve a chi
     // legge i log a capire subito di che famiglia di problema si tratta

--- a/server/src/services/trust/moderation.js
+++ b/server/src/services/trust/moderation.js
@@ -4,6 +4,7 @@
 // inappropriati/illeciti che il TrustScore generale non è progettato per
 // cogliere. Fail-safe: se la chiave manca o l'API fallisce, non blocca nulla.
 import { createOpenAIClient } from "../../lib/openaiClient.js";
+import { reportFault } from "../../lib/monitoring.js";
 
 const client = createOpenAIClient();
 
@@ -65,7 +66,7 @@ export async function moderateListing(listing) {
     }
     return { flagged, flags };
   } catch (e) {
-    console.error("[moderateListing] error:", e?.message || e);
+    reportFault("moderateListing", e);
     return { flagged: false, flags: [] };
   }
 }

--- a/server/src/services/trust/translate/openaiProvider.js
+++ b/server/src/services/trust/translate/openaiProvider.js
@@ -1,4 +1,5 @@
 import { createOpenAIClient } from "../../../lib/openaiClient.js";
+import { reportFault } from "../../../lib/monitoring.js";
 
 // Se la chiave manca, il costruttore di OpenAI lancia un'eccezione a livello
 // di modulo — a import time, non dentro una funzione — che far cadere
@@ -58,7 +59,7 @@ export async function openaiTranslate({ text, targetLang, sourceLang="auto" }) {
     // normalize non ha alcun effetto, quindi quest'ordine è sempre sicuro.
     return restore(normalize(out), m);
   } catch (e) {
-    console.error("[openaiTranslate] error", e);
+    reportFault("openaiTranslate", e);
     return null; // fallimento distinto da "" (niente da tradurre): il chiamante non deve spacciarlo per un successo
   }
 }

--- a/server/test/reportFault.test.js
+++ b/server/test/reportFault.test.js
@@ -1,0 +1,39 @@
+// reportFault: i guasti "gestiti", quelli che restavano invisibili.
+//
+// Il tracciamento errori riceveva solo i crash. Ma i quattro guasti veri
+// dei primi giorni di agosto — credito OpenAI esaurito, 520 sull'import
+// PDF, reset password rotto — erano tutti CATTURATI dal codice, che
+// proseguiva con un ripiego pulito. Il ripiego salvava l'utente e il
+// silenzio seppelliva il problema: nessuno ne sapeva niente finché non lo
+// incontrava di persona il proprietario dell'app.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { reportFault, monitoringEnabled, __resetFaultThrottleForTests } from '../src/lib/monitoring.js';
+
+test('senza Sentry configurato non parte niente verso l\'esterno', () => {
+  // I test girano senza SENTRY_DSN: reportFault deve limitarsi al log.
+  assert.equal(monitoringEnabled(), false);
+});
+
+test('non lancia mai, con qualunque argomento', () => {
+  __resetFaultThrottleForTests();
+  // Sta dentro una catch: se esplodesse, trasformerebbe un guasto gestito
+  // in un crash — esattamente il contrario del suo scopo.
+  assert.doesNotThrow(() => reportFault('scope', new Error('boom')));
+  assert.doesNotThrow(() => reportFault('scope', null));
+  assert.doesNotThrow(() => reportFault('scope', undefined));
+  assert.doesNotThrow(() => reportFault('scope', 'una stringa'));
+  assert.doesNotThrow(() => reportFault('scope', { status: 500 }));
+  assert.doesNotThrow(() => reportFault(undefined, new Error('x')));
+});
+
+test('non restituisce niente su cui il chiamante possa contare', () => {
+  __resetFaultThrottleForTests();
+  assert.equal(reportFault('scope', new Error('x')), undefined);
+});
+
+test('accetta un contesto senza usarlo per decidere qualcosa', () => {
+  __resetFaultThrottleForTests();
+  assert.doesNotThrow(() => reportFault('mailer', new Error('invio fallito'), { body: 'dettagli' }));
+});


### PR DESCRIPTION
Verificato mentre accendevamo Sentry: il tracciamento costruito in #258 riceveva solo i crash del processo, quelli dell'app nel browser, e gli errori che risalgono fino a Express.

**Non riceveva gli errori catturati dal codice** — quelli dove c'è un `try/catch` che scrive in console e prosegue con un ripiego pulito.

Ma i quattro guasti veri di questi giorni erano **tutti** di quel tipo:

| Guasto | Come si presentava |
|---|---|
| Credito OpenAI esaurito | messaggio pulito all'utente, `console.error` nei log |
| 520 sull'import PDF | idem |
| Reset password rotto | schermata "Link non valido", nessun errore |

Gestiti con eleganza, invisibili a chiunque. Lo strumento che serviva proprio ad accorgersene non se ne accorgeva: è il difetto principale di quel lavoro, non un dettaglio.

## Il fix

`reportFault(scope, err, extra)` in `lib/monitoring.js` sostituisce il `console.error` nei punti dove si cattura e si va avanti.

**Il log resta sempre** — anche senza Sentry configurato, e anche quando la segnalazione viene soffocata dal freno. I log sono il posto dove si guarda quando si sta già indagando; Sentry è quello che ti avvisa che devi indagare.

## Il freno non è un optional

Lo stesso guasto si segnala **al massimo una volta ogni 5 minuti**.

Senza, un fornitore giù produce una segnalazione per ogni richiesta: con 5.000 eventi al mese sul piano gratuito, un pomeriggio di disservizio brucia la quota — e ci lascia ciechi per settimane, proprio mentre paghiamo per non esserlo. La mappa del freno viene ripulita periodicamente: su un processo che non riparte mai, ogni messaggio d'errore mai visto resterebbe in memoria per sempre.

## Dove è agganciato

10 punti dove un guasto è davvero un guasto: import PDF e testo, ricerca in linguaggio naturale, stima e analisi prezzo, TrustScore, moderazione, traduzioni, matching, catene, invio email.

**Volutamente non agganciati** gli errori dell'utente — input non valido, limite di frequenza raggiunto, ricerca incomprensibile. Non sono guasti, e riempirebbero il tracciamento di rumore fino a renderlo inutile: un tracciamento che segnala tutto equivale a uno che non segnala niente.

## Verifiche

4 nuovi test (**389 lato server**, 114 lato app, tutti verdi), fra cui quello che conta di più: `reportFault` **non lancia mai**. Sta dentro una `catch` — se esplodesse trasformerebbe un guasto gestito in un crash, esattamente il contrario del suo scopo.

Nessuna migration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_