### PR TITLE
Catene a 3: il ricalcolo non riparte da zero se non è cambiato niente

### DIFF
--- a/server/src/lib/chainFingerprint.js
+++ b/server/src/lib/chainFingerprint.js
@@ -1,0 +1,58 @@
+// server/src/lib/chainFingerprint.js — "è cambiato qualcosa dall'ultimo giro?"
+//
+// Il ricalcolo delle catene a 3 gira ogni 15 minuti, cioè 96 volte al
+// giorno, e ogni volta ricostruisce il grafo dei desideri da zero — il che
+// significa centinaia di chiamate a OpenAI. Se però dall'ultimo giro non è
+// cambiato niente, il risultato è identico a quello di un quarto d'ora
+// prima: con l'app ferma erano 96 ricalcoli uguali al giorno, pagati tutti.
+//
+// COSA CONTA COME CAMBIAMENTO. Gli ingressi del calcolo sono DUE, e il
+// secondo è quello che si dimentica:
+//
+//   1. gli annunci attivi — ovvio: pubblicare, modificare, mettere in
+//      pausa o eliminare cambia i cicli possibili;
+//
+//   2. le proposte di catena in sospeso — meno ovvio, e sbagliarlo
+//      congelerebbe le catene proprio quando servono. Chi è già dentro una
+//      catena viene ESCLUSO dai cicli nuovi: quando una catena scade o
+//      viene completata quelle persone tornano disponibili, e da quel
+//      momento esistono cicli che prima non c'erano — senza che nessuno
+//      abbia toccato un solo annuncio.
+//
+// Per ciascuno bastano due numeri: QUANTI sono e QUAL È la modifica più
+// recente. Se qualcosa nasce, cambia o sparisce, almeno uno dei due si
+// muove. Non serve rileggere le righe: sono due query di aggregazione.
+
+/**
+ * Impronta stabile da conteggi e date. Volutamente una stringa e non un
+ * hash: quando si indaga sui log, "333|2026-08-05T20:11:00Z|2|..." dice
+ * subito cosa è cambiato, mentre un digest non dice niente.
+ *
+ * @param {{count:number, lastChangeAt:string|null}} listings
+ * @param {{count:number, lastChangeAt:string|null}} chains
+ */
+export function chainFingerprint(listings, chains) {
+  const part = (x) => `${Number(x?.count ?? 0)}|${x?.lastChangeAt ?? "-"}`;
+  return `${part(listings)}~${part(chains)}`;
+}
+
+/**
+ * Si può saltare il ricalcolo?
+ *
+ * Solo se l'impronta è identica E il giro di manutenzione appena fatto non
+ * ha cambiato niente: `expire_old_chain_proposals` può aver appena liberato
+ * dei proprietari, e quella liberazione non è ancora visibile
+ * nell'impronta letta un istante prima.
+ *
+ * Senza impronta precedente (primo giro dopo un riavvio) non si salta mai:
+ * meglio un ricalcolo in più che catene ferme perché il server è ripartito.
+ *
+ * @param {string|null} previous impronta dell'ultimo giro completato
+ * @param {string} current impronta di adesso
+ * @param {number} expiredCount catene scadute in questo stesso giro
+ */
+export function canSkipRecompute(previous, current, expiredCount = 0) {
+  if (!previous) return false;
+  if (Number(expiredCount) > 0) return false;
+  return previous === current;
+}

--- a/server/src/models/chains.js
+++ b/server/src/models/chains.js
@@ -16,6 +16,7 @@ import { listActiveListings } from "./listings.js";
 import { scoreChainCandidates, CHAIN_SCORE_PASS_THRESHOLD } from "../ai/chainMatch.js";
 import { explainChain } from "../ai/chainExplain.js";
 import { mapWithConcurrency } from "../lib/concurrency.js";
+import { chainFingerprint, canSkipRecompute } from "../lib/chainFingerprint.js";
 
 // Valutazioni AI dei candidati in volo contemporaneamente. Basso: ognuna può
 // a sua volta spezzarsi in più batch (vedi CHAIN_AI_CONCURRENCY in
@@ -175,6 +176,39 @@ async function ownersWithPendingChain() {
  * chain_proposal per ognuno (via RPC service-role). Ritorna un riepilogo,
  * non lancia eccezioni per un singolo ciclo fallito (continua con gli altri).
  */
+// Impronta dell'ultimo ricalcolo COMPLETATO. In memoria di proposito: se il
+// server riparte si perde e si fa un ricalcolo in più, che costa una volta;
+// una colonna nuova costerebbe una migration da eseguire a mano per sempre.
+let lastFingerprint = null;
+
+/**
+ * Conteggio e data più recente di una tabella, senza rileggerne le righe:
+ * due numeri presi con una query di aggregazione.
+ *
+ * La colonna della data è un parametro perché le due tabelle non sono
+ * uguali: `listings` ha `updated_at` (mantenuta da un trigger), mentre
+ * `chain_proposals` ha solo `created_at` — verificato, non assunto. Su
+ * quest'ultima il segnale del cambiamento è il CONTEGGIO delle catene
+ * ancora 'proposed': quando una si chiude, decade o scade, quel numero
+ * cala e i suoi partecipanti tornano disponibili per cicli nuovi. Due
+ * variazioni opposte nello stesso quarto d'ora (una si chiude, una nasce)
+ * lascerebbero il conteggio uguale, ma la data più recente cambia — le
+ * righe nuove nascono sempre con `now()`.
+ */
+async function tableStamp(table, dateColumn, filter) {
+  let q = supabase.from(table).select(dateColumn, { count: "exact" })
+    .order(dateColumn, { ascending: false }).limit(1);
+  if (filter) q = filter(q);
+  const { data, count, error } = await q;
+  if (error) throw error;
+  return { count: count ?? 0, lastChangeAt: data?.[0]?.[dateColumn] ?? null };
+}
+
+/** Solo per i test: dimentica l'ultimo giro. */
+export function __resetChainFingerprintForTests() {
+  lastFingerprint = null;
+}
+
 export async function findAndProposeChains() {
   if (!supabase) throw new Error("Supabase client not configured");
 
@@ -201,6 +235,32 @@ export async function findAndProposeChains() {
     console.error("[chains] remind_stale_chain_confirmers failed:", remindErr.message);
   } else {
     remindedCount = remindResult ?? 0;
+  }
+
+  // Si può saltare tutto il resto? Il grafo dei desideri dipende da due
+  // cose sole — gli annunci attivi e le catene in sospeso — e se nessuna
+  // delle due si è mossa il risultato sarebbe identico a quello di 15
+  // minuti fa. Le due chiamate di manutenzione qui sopra sono già state
+  // fatte: quelle dipendono dal passare del tempo, non dagli annunci, e
+  // saltarle romperebbe scadenze e promemoria.
+  try {
+    const [listingsStamp, chainsStamp] = await Promise.all([
+      tableStamp("listings", "updated_at", (q) => q.eq("status", "active")),
+      // Stesso filtro di ownersWithPendingChain: sono le catene 'proposed'
+      // a bloccare i loro partecipanti, e quindi le sole che cambiano il
+      // risultato del ricalcolo.
+      tableStamp("chain_proposals", "created_at", (q) => q.eq("status", "proposed")),
+    ]);
+    const fingerprint = chainFingerprint(listingsStamp, chainsStamp);
+    if (canSkipRecompute(lastFingerprint, fingerprint, expiredCount)) {
+      console.log("[chains] nessun cambiamento dall'ultimo giro, ricalcolo saltato:", fingerprint);
+      return { proposed: [], skipped: [], errors: [], expiredCount, remindedCount, unchanged: true };
+    }
+    lastFingerprint = fingerprint;
+  } catch (e) {
+    // Se l'impronta non si riesce a leggere si ricalcola, come prima: il
+    // risparmio è un di più, non deve poter impedire il lavoro vero.
+    console.warn("[chains] impronta non leggibile, si ricalcola:", e?.message || e);
   }
 
   const allActive = await listActiveListings({ limit: 1000 });

--- a/server/test/chainFingerprint.test.js
+++ b/server/test/chainFingerprint.test.js
@@ -1,0 +1,85 @@
+// "È cambiato qualcosa dall'ultimo giro?" per il ricalcolo delle catene a 3.
+//
+// Il ricalcolo gira ogni 15 minuti e ricostruisce il grafo dei desideri da
+// zero, cioè centinaia di chiamate a OpenAI. Con l'app ferma erano 96
+// ricalcoli identici al giorno, pagati tutti.
+//
+// Ma il rischio del salto è l'opposto del risparmio: saltare un giro che
+// SERVIVA significa catene che non compaiono, e nessuno se ne accorge. I
+// test qui sotto stanno tutti su quel lato.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { chainFingerprint, canSkipRecompute } from '../src/lib/chainFingerprint.js';
+
+const L = (count, at) => ({ count, lastChangeAt: at });
+
+test('stessi ingressi, stessa impronta', () => {
+  const a = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, '2026-08-05T19:00:00Z'));
+  const b = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, '2026-08-05T19:00:00Z'));
+  assert.equal(a, b);
+});
+
+test('un annuncio nuovo cambia l\'impronta', () => {
+  const prima = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, null));
+  const dopo = chainFingerprint(L(334, '2026-08-05T20:05:00Z'), L(2, null));
+  assert.notEqual(prima, dopo);
+});
+
+test('un annuncio MODIFICATO cambia l\'impronta anche se il conteggio resta uguale', () => {
+  // Mettere in pausa, cambiare tratta o prezzo non sposta il numero di
+  // annunci attivi... anzi, la pausa sì. Ma una modifica di tratta no: se
+  // guardassimo solo il conteggio, il grafo resterebbe quello vecchio.
+  const prima = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, null));
+  const dopo = chainFingerprint(L(333, '2026-08-05T20:07:00Z'), L(2, null));
+  assert.notEqual(prima, dopo);
+});
+
+test('una catena che si CHIUDE cambia l\'impronta, ed è il caso che si dimentica', () => {
+  // È l'ingresso non ovvio: chi è dentro una catena in sospeso viene
+  // escluso dai cicli nuovi. Quando quella catena si chiude o decade, i
+  // suoi partecipanti tornano disponibili e nascono cicli che prima non
+  // c'erano — senza che nessuno abbia toccato un solo annuncio.
+  const prima = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, '2026-08-05T19:00:00Z'));
+  const dopo = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(1, '2026-08-05T19:00:00Z'));
+  assert.notEqual(prima, dopo);
+});
+
+test('due variazioni opposte non si annullano fra loro', () => {
+  // Una catena si chiude e un'altra nasce nello stesso quarto d'ora: il
+  // conteggio torna uguale, ma la più recente è nata adesso.
+  const prima = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, '2026-08-05T19:00:00Z'));
+  const dopo = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, '2026-08-05T20:10:00Z'));
+  assert.notEqual(prima, dopo);
+});
+
+test('un ingresso vuoto non collide con uno pieno', () => {
+  assert.notEqual(
+    chainFingerprint(L(0, null), L(0, null)),
+    chainFingerprint(L(0, null), L(1, '2026-08-05T20:00:00Z')),
+  );
+});
+
+test('si salta solo con un\'impronta identica', () => {
+  assert.equal(canSkipRecompute('X', 'X', 0), true);
+  assert.equal(canSkipRecompute('X', 'Y', 0), false);
+});
+
+test('al primo giro dopo un riavvio non si salta mai', () => {
+  // Meglio un ricalcolo in più che catene ferme perché il server è
+  // ripartito e non ricorda com'era il mondo prima.
+  assert.equal(canSkipRecompute(null, 'X', 0), false);
+  assert.equal(canSkipRecompute(undefined, 'X', 0), false);
+  assert.equal(canSkipRecompute('', 'X', 0), false);
+});
+
+test('se sono appena scadute delle catene NON si salta, anche con impronta uguale', () => {
+  // La scadenza avviene DENTRO questo stesso giro, un istante prima che
+  // l'impronta venga letta: ha appena liberato dei proprietari, e quella
+  // liberazione non è ancora visibile nei numeri appena letti. Saltare
+  // qui vorrebbe dire aspettare altri 15 minuti per proporre cicli che
+  // sono già possibili adesso.
+  assert.equal(canSkipRecompute('X', 'X', 1), false);
+  assert.equal(canSkipRecompute('X', 'X', 5), false);
+  assert.equal(canSkipRecompute('X', 'X', 0), true);
+});


### PR DESCRIPTION
Trovato **grazie a una mail di Sentry** — cioè dal tracciamento acceso ieri, che ha funzionato esattamente come doveva: un timeout su `/api/chains/recompute` ha portato a guardare quel cron, e lì c'era il consumo vero.

## Cosa faceva

Il ricalcolo delle catene a 3:

- gira **ogni 15 minuti**, 96 volte al giorno, che l'app sia usata o ferma;
- prende fino a **1000 annunci attivi** (oggi 333, quasi tutti di test);
- costruisce il grafo dei desideri **chiedendo all'AI** quanto ogni VENDO soddisfa ogni CERCO, in lotti da 40;
- e **ricomincia da zero ogni volta**.

Con l'app ferma erano **96 ricalcoli identici al giorno**, tutti pagati. È la spiegazione più probabile dei sei euro spesi in pochi giorni con un solo utente e zero pubblico.

## Il fix

Prima di ricostruire il grafo si legge un'impronta degli ingressi. Se è identica a quella dell'ultimo giro completato, si esce senza toccare OpenAI: **due query di aggregazione al posto di centinaia di chiamate**.

## Gli ingressi sono due, e il secondo è quello che si dimentica

1. **Gli annunci attivi** — ovvio: pubblicare, modificare, mettere in pausa cambia i cicli possibili.
2. **Le proposte di catena ancora `proposed`** — meno ovvio, e sbagliarlo congelerebbe le catene proprio quando servono. Chi è dentro una catena viene **escluso** dai cicli nuovi: quando una si chiude o decade, i suoi partecipanti tornano disponibili e nascono cicli che prima non c'erano, **senza che nessuno abbia toccato un annuncio**.

**Verificato invece di assumere**: `chain_proposals` non ha `updated_at`, solo `created_at`. La prima stesura usava `updated_at` su entrambe le tabelle e sarebbe fallita in silenzio (ricalcolando sempre, cioè risparmiando zero). Lì il segnale è il conteggio delle `proposed` più la più recente: due variazioni opposte nello stesso quarto d'ora lascerebbero il conteggio uguale, ma le righe nuove nascono sempre con `now()`.

## Quando NON si salta mai

- **Primo giro dopo un riavvio**: il server non ricorda com'era il mondo. Meglio un ricalcolo in più che catene ferme.
- **Se la manutenzione appena eseguita ha fatto scadere delle catene**: quella liberazione non è ancora visibile nell'impronta letta un istante dopo, e aspettare altri 15 minuti significherebbe non proporre cicli già possibili adesso.
- **Se l'impronta non si riesce a leggere**: si ricalcola come prima. Il risparmio è un di più, non deve poter impedire il lavoro vero.

La manutenzione (scadenze e promemoria) resta invariata e gira a ogni invocazione: dipende dal passare del tempo, non dagli annunci.

L'impronta sta **in memoria** di proposito: un riavvio costa un ricalcolo in più, una colonna nuova costerebbe una migration a mano per sempre.

## Verifiche

9 nuovi test (**401 lato server**, tutti verdi), tutti sul lato pericoloso: saltare un giro che serviva significa catene che non compaiono e nessuno che se ne accorge.

Nessuna migration.

## Nota

Resta aperto il secondo difetto emerso dalla stessa mail: il timeout di 15 secondi sul punteggio delle catene, che quando scade fa sparire un lotto di candidati in silenzio. Da affrontare separatamente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_