### PR TITLE
Catene a 3: un lotto fallito non butta via il lavoro degli altri

### DIFF
--- a/server/src/ai/chainMatch.js
+++ b/server/src/ai/chainMatch.js
@@ -309,13 +309,31 @@ export async function scoreChainCandidates(wantListing, candidates) {
     return validateChainScores(raw, batch.map((c) => c.id));
   });
 
+  // Il ripiego è PER LOTTO, non per l'intero insieme.
+  //
+  // Prima un solo lotto fallito buttava via il lavoro di tutti gli altri:
+  // con 8 lotti e il terzo andato in timeout, i punteggi AI degli altri 7
+  // — già calcolati e già PAGATI — venivano scartati per ricalcolare tutto
+  // con l'euristica. Si perdevano insieme i soldi spesi e la qualità dei
+  // lotti che erano andati benissimo.
+  //
+  // Ora l'euristica copre solo i candidati dei lotti falliti. I due
+  // punteggi convivono nello stesso risultato: è la stessa scala 0-100 e
+  // la stessa soglia di passaggio, ed è esattamente ciò che il ripiego
+  // deterministico è pensato per fare — sostituire l'AI dove non ha
+  // risposto, non ovunque.
   const results = [];
-  for (const validated of perBatch) {
-    if (!validated || !validated.length) {
-      // un batch fallito -> ricadi sull'euristica per l'intero lotto di candidati
-      return heuristicChainScore(wantListing, candidates);
+  let fallbackCount = 0;
+  perBatch.forEach((validated, i) => {
+    if (validated && validated.length) {
+      results.push(...validated);
+      return;
     }
-    results.push(...validated);
+    fallbackCount += 1;
+    results.push(...heuristicChainScore(wantListing, batches[i]));
+  });
+  if (fallbackCount) {
+    console.warn(`[chainMatch] ${fallbackCount}/${batches.length} lotti su euristica (AI non disponibile per quei candidati)`);
   }
 
   const byId = new Map(results.map((r) => [r.id, r]));

--- a/server/test/chainBatchFallback.test.js
+++ b/server/test/chainBatchFallback.test.js
@@ -1,0 +1,55 @@
+// Ripiego per LOTTO nel punteggio delle catene a 3.
+//
+// Il punteggio si calcola a lotti da 40 candidati, in parallelo. Se un
+// lotto non torna (timeout, 520, credito finito) si ricade sul punteggio
+// deterministico — ma solo per QUEI candidati.
+//
+// Prima bastava un lotto andato storto per buttare via il lavoro di tutti
+// gli altri: con 8 lotti e il terzo in timeout, i punteggi AI degli altri
+// sette — già calcolati e già pagati — venivano scartati per rifare tutto
+// con l'euristica. Si perdevano insieme i soldi spesi e la qualità dei
+// lotti riusciti.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { heuristicChainScore } from '../src/ai/chainMatch.js';
+
+const want = { id: 'w1', type: 'train', route_from: 'Roma', route_to: 'Milano', depart_at: '2026-09-10T09:00:00Z' };
+const cand = (id, extra = {}) => ({
+  id, type: 'train', route_from: 'Roma', route_to: 'Milano',
+  depart_at: '2026-09-10T09:00:00Z', user_id: 'u-' + id, ...extra,
+});
+
+test('l\'euristica copre TUTTI i candidati che le vengono passati', () => {
+  // È la proprietà su cui poggia il ripiego per lotto: dando all'euristica
+  // solo i candidati del lotto fallito, quelli devono tornare tutti — se
+  // ne perdesse qualcuno, sparirebbe dai risultati senza che nessuno lo
+  // noti, ed è il difetto che stavamo evitando.
+  const batch = [cand('a'), cand('b'), cand('c')];
+  const out = heuristicChainScore(want, batch);
+  assert.equal(out.length, 3);
+  assert.deepEqual(out.map((x) => x.id).sort(), ['a', 'b', 'c']);
+});
+
+test('ogni punteggio dell\'euristica sta nella stessa scala 0-100 dell\'AI', () => {
+  // I due punteggi finiscono nello stesso elenco e passano per la stessa
+  // soglia: se le scale non coincidessero, un lotto su euristica sarebbe
+  // sistematicamente avvantaggiato o penalizzato rispetto agli altri.
+  const out = heuristicChainScore(want, [cand('a'), cand('b', { route_to: 'Torino' })]);
+  for (const r of out) {
+    assert.ok(Number.isInteger(r.score), `punteggio non intero: ${r.score}`);
+    assert.ok(r.score >= 0 && r.score <= 100, `fuori scala: ${r.score}`);
+  }
+});
+
+test('con un lotto vuoto non restituisce niente e non esplode', () => {
+  assert.deepEqual(heuristicChainScore(want, []), []);
+});
+
+test('i risultati portano l\'id del candidato, non la sua posizione', () => {
+  // I lotti vengono ricomposti in un elenco solo: se il ripiego
+  // restituisse indici invece di id, i punteggi finirebbero sui candidati
+  // sbagliati appena un lotto viene sostituito.
+  const out = heuristicChainScore(want, [cand('zzz'), cand('aaa')]);
+  assert.deepEqual(out.map((x) => x.id).sort(), ['aaa', 'zzz']);
+});


### PR DESCRIPTION
## Prima una correzione

In #266 avevo scritto che un lotto andato in timeout *"fa sparire un lotto di candidati in silenzio"*. **Sbagliato su entrambi i punti**: l'errore veniva catturato, ora è anche segnalato a Sentry, e il sistema ricadeva sul punteggio deterministico. Il ripiego funzionava.

Il difetto vero è un altro, e l'ho trovato solo leggendo il codice invece di fidarmi di quello che avevo detto.

## Il difetto

I candidati si valutano a **lotti da 40**, in parallelo. Bastava che **uno** andasse storto perché si buttasse via il lavoro di tutti gli altri:

```js
for (const validated of perBatch) {
  if (!validated || !validated.length) {
    return heuristicChainScore(wantListing, candidates);  // TUTTI
  }
  results.push(...validated);
}
```

Con 8 lotti e il terzo in timeout, i punteggi AI degli altri sette — **già calcolati e già pagati** — venivano scartati per rifare tutto con l'euristica. Si perdevano insieme i soldi spesi e la qualità dei lotti che erano andati benissimo.

## Il fix

L'euristica copre **solo i candidati dei lotti falliti**. I due punteggi convivono nello stesso risultato: stessa scala 0-100, stessa soglia di passaggio — ed è esattamente ciò che il ripiego deterministico è pensato per fare, cioè sostituire l'AI **dove non ha risposto**, non ovunque.

Quanti lotti sono finiti su euristica finisce nei log: senza quel numero, una qualità peggiorata è indistinguibile da una normale.

## Cosa NON ho toccato, e perché

**Il timeout di 15 secondi.** Potrebbe essere troppo stretto per lotti da 40 candidati, ma **non lo so**, e tararlo a naso adesso significherebbe indovinare: con il credito OpenAI a zero le chiamate si comportano in modo anomalo, quindi il campione di ieri non dice niente.

Ora che i timeout arrivano a Sentry, fra qualche giorno di uso vero si vedrà quanto spesso scattano davvero — e allora si decide con un dato in mano invece che con un'impressione.

## Verifiche

4 nuovi test (**405 lato server**, tutti verdi) sulle proprietà che il ripiego per lotto richiede:

- l'euristica deve coprire **tutti** i candidati che riceve — se ne perdesse uno, quello sparirebbe dai risultati senza che nessuno lo noti;
- deve stare nella **stessa scala** dell'AI, o un lotto su euristica sarebbe sistematicamente avvantaggiato rispetto agli altri;
- deve restituire **id e non posizioni** — ricomponendo i lotti in un elenco solo, gli indici finirebbero sui candidati sbagliati.

Nessuna migration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_