### PR TITLE
Catene a 3: filtro sulla data prima di chiamare l'AI, e script di pulizia

### DIFF
--- a/server/src/ai/chainMatch.js
+++ b/server/src/ai/chainMatch.js
@@ -40,6 +40,23 @@ const CHAIN_AI_CONCURRENCY = Number(process.env.CHAIN_AI_CONCURRENCY ?? 3);
 const CHAIN_AI_TIMEOUT_MS = Number(process.env.CHAIN_AI_TIMEOUT_MS ?? 45000);
 const CHAIN_SCORE_THRESHOLD = Number(process.env.CHAIN_SCORE_THRESHOLD ?? 65);
 
+// Finestra temporale entro cui un candidato vale la pena di essere
+// valutato dall'AI. Serve a NON pagare il modello per farsi dire ciò che
+// si sa già: un biglietto a tre mesi di distanza da quello cercato non
+// diventerà mai una catena, e mandarglielo costa esattamente quanto
+// mandargliene uno buono.
+//
+// Perché il filtro è sulla DATA e non sulla geografia: la distanza fra due
+// date è un fatto, la vicinanza fra due città è un giudizio — ed è
+// esattamente il giudizio per cui l'AI esiste qui (tollerare "Roma" vicino
+// a "Firenze"). Filtrare la geografia con la mappa statica delle regioni
+// annullerebbe il motivo per cui c'è un modello.
+//
+// 30 giorni è largo di proposito: l'euristica interna considera "vicine"
+// solo le date entro ±3, quindi questa soglia non esclude niente che oggi
+// supererebbe la soglia di passaggio.
+export const CHAIN_DATE_WINDOW_DAYS = Number(process.env.CHAIN_DATE_WINDOW_DAYS ?? 30);
+
 // ----------------------------------------------------------------------
 // Fallback deterministico: cluster geografico + tolleranza data.
 // ----------------------------------------------------------------------
@@ -100,6 +117,21 @@ function dateOf(listing) {
   if (!raw) return null;
   const d = new Date(raw);
   return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * Vale la pena chiedere all'AI di valutare questo candidato?
+ *
+ * Un pre-filtro deve togliere solo le CERTEZZE: se una delle due date
+ * manca non sappiamo niente, e nel dubbio il candidato passa — meglio una
+ * chiamata in più che una catena che non viene mai proposta.
+ */
+export function worthScoringByDate(want, candidate, days = CHAIN_DATE_WINDOW_DAYS) {
+  const dw = dateOf(want);
+  const dc = dateOf(candidate);
+  if (!dw || !dc) return true;
+  const diffDays = Math.abs(dw.getTime() - dc.getTime()) / (1000 * 60 * 60 * 24);
+  return diffDays <= days;
 }
 
 function withinDateTolerance(a, b, days) {

--- a/server/src/models/chains.js
+++ b/server/src/models/chains.js
@@ -13,7 +13,7 @@
 // sia active, quindi qui basta essere coerenti sull'id scelto.
 import { supabase } from "../db.js";
 import { listActiveListings } from "./listings.js";
-import { scoreChainCandidates, CHAIN_SCORE_PASS_THRESHOLD } from "../ai/chainMatch.js";
+import { scoreChainCandidates, CHAIN_SCORE_PASS_THRESHOLD, worthScoringByDate, CHAIN_DATE_WINDOW_DAYS } from "../ai/chainMatch.js";
 import { explainChain } from "../ai/chainExplain.js";
 import { mapWithConcurrency } from "../lib/concurrency.js";
 import { chainFingerprint, canSkipRecompute } from "../lib/chainFingerprint.js";
@@ -113,13 +113,32 @@ export async function buildDesireGraph(allActive) {
   // Una coppia (annuncio CERCO, lotto di candidati) per ogni valutazione:
   // scoreChainCandidates è una chiamata OpenAI e prima venivano fatte tutte
   // in fila, una per annuncio CERCO dell'intera piattaforma.
+  // Pre-filtro deterministico PRIMA di chiamare l'AI.
+  //
+  // Il numero di chiamate cresce come CERCO x VENDO: con 333 annunci un
+  // giro costava 7 centesimi, e la crescita è quadratica — a 1000 annunci
+  // non sarebbe il triplo, sarebbe circa dieci volte tanto. Mandare al
+  // modello un candidato con data a tre mesi di distanza costa esattamente
+  // quanto mandargliene uno buono, per farsi dire una cosa che sapevamo
+  // già.
+  //
+  // Si filtra solo sulla DATA, che è un fatto misurabile. La vicinanza fra
+  // due città è un giudizio, ed è il motivo per cui qui c'è un modello:
+  // filtrarla con la mappa statica delle regioni annullerebbe il senso
+  // dell'AI. Vedi worthScoringByDate in ai/chainMatch.js.
+  let scartatiPerData = 0;
   const jobs = [];
   for (const [owner, cercoListings] of cercoByOwner) {
     if (!vendoByOwner.has(owner)) continue; // niente da dare -> fuori dalle catene
     for (const want of cercoListings) {
-      const candidates = (vendoByType.get(want.type) || []).filter((v) => v.user_id !== owner);
+      const sameType = (vendoByType.get(want.type) || []).filter((v) => v.user_id !== owner);
+      const candidates = sameType.filter((v) => worthScoringByDate(want, v));
+      scartatiPerData += sameType.length - candidates.length;
       if (candidates.length) jobs.push({ owner, want, candidates });
     }
+  }
+  if (scartatiPerData) {
+    console.log(`[chains] ${scartatiPerData} candidati fuori dalla finestra di ${CHAIN_DATE_WINDOW_DAYS} giorni: non inviati all'AI`);
   }
 
   const scoredJobs = await mapWithConcurrency(

--- a/server/test/chainDateWindow.test.js
+++ b/server/test/chainDateWindow.test.js
@@ -1,0 +1,75 @@
+// Pre-filtro sulla data prima di chiamare l'AI per le catene a 3.
+//
+// Il numero di chiamate cresce come CERCO x VENDO: con 333 annunci un giro
+// è costato 7 centesimi, e la crescita è quadratica — a 1000 annunci non
+// sarebbe il triplo, sarebbe circa dieci volte tanto. Mandare al modello un
+// candidato con data a tre mesi di distanza costa quanto mandargliene uno
+// buono, per farsi dire una cosa che sapevamo già.
+//
+// Ma un pre-filtro sbagliato è peggio di nessun pre-filtro: toglie catene
+// possibili senza che nessuno se ne accorga. Da qui la regola che questi
+// test difendono — si scarta solo ciò di cui si è CERTI.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { worthScoringByDate, CHAIN_DATE_WINDOW_DAYS } from '../src/ai/chainMatch.js';
+
+const treno = (depart) => ({ type: 'train', depart_at: depart });
+const hotel = (checkIn) => ({ type: 'hotel', check_in: checkIn });
+
+test('la finestra predefinita è di 30 giorni, come deciso', () => {
+  assert.equal(CHAIN_DATE_WINDOW_DAYS, 30);
+});
+
+test('date vicine: si valuta', () => {
+  assert.equal(worthScoringByDate(treno('2026-09-10T09:00:00Z'), treno('2026-09-12T18:00:00Z')), true);
+});
+
+test('date lontanissime: non si spreca una chiamata', () => {
+  assert.equal(worthScoringByDate(treno('2026-09-10T09:00:00Z'), treno('2026-12-20T09:00:00Z')), false);
+});
+
+test('il filtro vale in entrambe le direzioni', () => {
+  // Prima o dopo non cambia niente: conta la distanza, non il verso.
+  const a = treno('2026-09-10T09:00:00Z');
+  const b = treno('2026-07-01T09:00:00Z');
+  assert.equal(worthScoringByDate(a, b), worthScoringByDate(b, a));
+  assert.equal(worthScoringByDate(a, b), false);
+});
+
+test('sul bordo della finestra si valuta ancora', () => {
+  // Il dubbio va a favore del candidato: 30 giorni esatti passano.
+  assert.equal(worthScoringByDate(treno('2026-09-10T09:00:00Z'), treno('2026-10-10T09:00:00Z')), true);
+});
+
+test('se una data MANCA il candidato passa, non si scarta al buio', () => {
+  // È la regola che rende sicuro un pre-filtro: si toglie solo ciò di cui
+  // si è certi. Scartare per un dato che non abbiamo farebbe sparire
+  // catene possibili senza lasciare traccia.
+  assert.equal(worthScoringByDate(treno(null), treno('2026-09-10T09:00:00Z')), true);
+  assert.equal(worthScoringByDate(treno('2026-09-10T09:00:00Z'), treno(undefined)), true);
+  assert.equal(worthScoringByDate({}, {}), true);
+  assert.equal(worthScoringByDate(treno('non-una-data'), treno('2026-09-10T09:00:00Z')), true);
+});
+
+test('per gli hotel guarda il check-in, non la partenza', () => {
+  assert.equal(worthScoringByDate(hotel('2026-09-10'), hotel('2026-09-15')), true);
+  assert.equal(worthScoringByDate(hotel('2026-09-10'), hotel('2027-01-15')), false);
+});
+
+test('la finestra si può stringere o allargare senza toccare il codice', () => {
+  const a = treno('2026-09-10T09:00:00Z');
+  const b = treno('2026-09-25T09:00:00Z'); // 15 giorni
+  assert.equal(worthScoringByDate(a, b, 30), true);
+  assert.equal(worthScoringByDate(a, b, 7), false);
+});
+
+test('il filtro NON tocca la geografia, ed è deliberato', () => {
+  // La vicinanza fra due città è un giudizio, ed è l'unico motivo per cui
+  // qui c'è un modello: filtrarla con la mappa statica delle regioni
+  // annullerebbe il senso dell'AI. Due tratte lontanissime ma con date
+  // vicine devono arrivare comunque al modello.
+  const roma = { type: 'train', route_from: 'Roma', route_to: 'Milano', depart_at: '2026-09-10T09:00:00Z' };
+  const palermo = { type: 'train', route_from: 'Palermo', route_to: 'Catania', depart_at: '2026-09-11T09:00:00Z' };
+  assert.equal(worthScoringByDate(roma, palermo), true);
+});

--- a/supabase/cleanup_test_listings.sql
+++ b/supabase/cleanup_test_listings.sql
@@ -1,101 +1,137 @@
 -- ============================================================
--- Pulizia degli annunci di test — DA ESEGUIRE UN PASSO ALLA VOLTA.
+-- Pulizia dei dati di test — ripartenza da zero.
 --
--- NON è una migration: è uno script una tantum, e non va in
+-- NON è una migration: è uno script una tantum, e non sta in
 -- supabase/migrations/ proprio perché non deve rigirare mai più.
 --
--- Perché è diviso in passi: nessuno qui sa quali righe siano di test.
--- Quel criterio ce l'hai solo tu, e una DELETE lanciata sul criterio
--- sbagliato non si annulla. I passi 1 e 2 servono a farti VEDERE cosa
--- stai per cancellare prima di cancellarlo.
+-- Contesto: l'app non è ancora in produzione, i 333 annunci (e tutto
+-- quello che ci gira attorno: proposte, match, chat, catene, punteggi
+-- di affidabilità) sono dati di prova. Quindi non serve un criterio per
+-- distinguere il vero dal finto: si svuota il contenuto e si tengono
+-- SOLO gli account.
 --
--- Cosa succede alle tabelle collegate: tutto ciò che punta a listings ha
--- ON DELETE CASCADE (verificato: offers, matches, listing_images,
--- listing_secrets, listing_translations, saved_listings, transactions,
--- chain_participants, saved_search_matches, listing_questions, reports,
--- report_action_tokens). Cancellando un annuncio spariscono con lui le
--- sue proposte, i suoi match e le sue foto — che per dati di test è
--- esattamente quello che vuoi. L'unica eccezione è ai_import_logs, dove
--- il riferimento viene messo a NULL invece che cancellato.
+-- Cosa NON tocca:
+--   • auth.users e profiles  -> gli account restano, puoi rientrare
+--   • push_tokens, fb_account_links -> restano i collegamenti push/Messenger
+--   • i file già caricati nel bucket Storage delle foto. Le RIGHE di
+--     listing_images spariscono, i file no: SQL non arriva allo Storage.
+--     Vanno svuotati dal pannello Supabase > Storage, se ti interessa
+--     (sono pochi MB, puoi anche lasciarli lì).
+--
+-- Esegui un passo alla volta, selezionando il blocco e premendo Run.
 -- ============================================================
 
 
 -- ------------------------------------------------------------
--- PASSO 1 — Chi ha creato cosa.
+-- PASSO 1 — Cosa c'è adesso.
 --
--- Se gli annunci di test li hai fatti tutti con un account solo, qui lo
--- riconosci subito: sarà la riga con centinaia di annunci.
+-- Serve come "prima" da confrontare col "dopo" del passo 3.
 -- ------------------------------------------------------------
-SELECT
-  l.user_id,
-  p.email,
-  count(*)                                        AS annunci,
-  count(*) FILTER (WHERE l.status = 'active')     AS attivi,
-  min(l.created_at)::date                         AS primo,
-  max(l.created_at)::date                         AS ultimo
-FROM public.listings l
-LEFT JOIN auth.users p ON p.id = l.user_id
-GROUP BY l.user_id, p.email
-ORDER BY annunci DESC;
+SELECT 'listings'          AS tabella, count(*) FROM public.listings
+UNION ALL SELECT 'offers',            count(*) FROM public.offers
+UNION ALL SELECT 'matches',           count(*) FROM public.matches
+UNION ALL SELECT 'chat_messages',     count(*) FROM public.chat_messages
+UNION ALL SELECT 'notifications',     count(*) FROM public.notifications
+UNION ALL SELECT 'chain_proposals',   count(*) FROM public.chain_proposals
+UNION ALL SELECT 'trust_audit',       count(*) FROM public.trust_audit
+UNION ALL SELECT 'profiles (RESTA)',  count(*) FROM public.profiles
+ORDER BY 2 DESC;
 
 
 -- ------------------------------------------------------------
--- PASSO 2 — Guarda cosa stai per cancellare, PRIMA di cancellarlo.
+-- PASSO 2 — La cancellazione.
 --
--- Sostituisci il criterio qui sotto con quello vero (l'utente trovato al
--- passo 1, o un intervallo di date, o quello che distingue i tuoi test).
--- Se il numero e i titoli non ti convincono, NON passare al passo 3.
--- ------------------------------------------------------------
-SELECT id, title, status, type, created_at
-FROM public.listings
-WHERE user_id = 'INCOLLA-QUI-LO-USER-ID'   -- <<< dal passo 1
-ORDER BY created_at DESC;
-
--- E il conteggio esatto, che è il numero da confrontare col risultato
--- della DELETE:
-SELECT count(*) AS da_cancellare
-FROM public.listings
-WHERE user_id = 'INCOLLA-QUI-LO-USER-ID';
-
-
--- ------------------------------------------------------------
--- PASSO 3 — La cancellazione vera.
+-- Dentro una transazione esplicita: finché non scrivi COMMIT non è
+-- successo niente davvero, e ROLLBACK riporta tutto com'era.
 --
--- Dentro una transazione ESPLICITA: la DELETE mostra quante righe ha
--- toccato, e finché non scrivi COMMIT non è successo niente davvero. Se
--- il numero non combacia con quello del passo 2, scrivi ROLLBACK e
--- ricontrolla il criterio.
---
--- ⚠️ Il criterio deve essere IDENTICO a quello del passo 2. Cambiarlo fra
--- i due passi vanifica la verifica appena fatta.
+-- TRUNCATE invece di DELETE perché è molto più veloce su queste
+-- dimensioni e non fa scattare i trigger riga-per-riga (niente
+-- notifiche generate mentre stai cancellando). CASCADE copre eventuali
+-- tabelle collegate che dovessero sfuggire all'elenco.
 -- ------------------------------------------------------------
 BEGIN;
 
-DELETE FROM public.listings
-WHERE user_id = 'INCOLLA-QUI-LO-USER-ID';   -- <<< lo stesso del passo 2
+TRUNCATE
+  public.listings,
+  public.listing_images,
+  public.listing_secrets,
+  public.listing_translations,
+  public.listing_ai_scores,
+  public.listing_pings,
+  public.listing_questions,
+  public.offers,
+  public.chat_messages,
+  public.matches,
+  public.match_snapshots,
+  public.transactions,
+  public.transaction_ratings,
+  public.chain_proposals,
+  public.chain_participants,
+  public.chain_messages,
+  public.chain_disputes,
+  public.saved_listings,
+  public.saved_searches,
+  public.saved_search_matches,
+  public.notifications,
+  public.trust_audit,
+  public.ai_import_logs,
+  public.reports,
+  public.report_action_tokens,
+  public.payment_declarations
+CASCADE;
 
--- Guarda quante righe dice di aver cancellato.
---   combacia   -> COMMIT;
---   non combacia -> ROLLBACK;
+-- Se il messaggio di ritorno è "Success", scrivi COMMIT.
+-- Se qualcosa ti torna storto, ROLLBACK e non è successo niente.
 
 -- COMMIT;
 -- ROLLBACK;
 
 
 -- ------------------------------------------------------------
--- PASSO 4 — Verifica, e ripartenza pulita del cron catene.
+-- PASSO 3 — Verifica.
+--
+-- Tutti zero tranne profiles, che deve essere rimasto uguale al passo 1.
 -- ------------------------------------------------------------
-SELECT
-  count(*)                                    AS annunci_rimasti,
-  count(*) FILTER (WHERE status = 'active')   AS attivi_rimasti
-FROM public.listings;
+SELECT 'listings'          AS tabella, count(*) FROM public.listings
+UNION ALL SELECT 'offers',            count(*) FROM public.offers
+UNION ALL SELECT 'matches',           count(*) FROM public.matches
+UNION ALL SELECT 'chat_messages',     count(*) FROM public.chat_messages
+UNION ALL SELECT 'notifications',     count(*) FROM public.notifications
+UNION ALL SELECT 'chain_proposals',   count(*) FROM public.chain_proposals
+UNION ALL SELECT 'trust_audit',       count(*) FROM public.trust_audit
+UNION ALL SELECT 'profiles (RESTA)',  count(*) FROM public.profiles
+ORDER BY 2 DESC;
 
--- Le proposte di catena costruite sugli annunci cancellati sono già
--- sparite in cascata, ma quelle che coinvolgevano SOLO utenti di test
--- possono essere rimaste senza partecipanti: si chiudono così.
-UPDATE public.chain_proposals
-   SET status = 'canceled'
- WHERE status = 'proposed'
-   AND NOT EXISTS (
-     SELECT 1 FROM public.chain_participants cp WHERE cp.chain_id = chain_proposals.id
-   );
+-- Dopo il COMMIT il cron delle catene, al giro successivo, non trova più
+-- niente da valutare e chiude in pochi millisecondi a costo zero: è il
+-- modo più rapido per confermare che il database è davvero pulito.
+
+
+-- ============================================================
+-- ALTERNATIVA — se un giorno servisse cancellare solo una parte.
+--
+-- Il TRUNCATE qui sopra vale perché OGGI non c'è niente di vero. Quando
+-- ci saranno dati reali non si usa più: si cancella per criterio, e si
+-- guarda prima cosa si sta per cancellare.
+--
+--   -- chi ha creato cosa
+--   SELECT l.user_id, u.email, count(*) AS annunci
+--   FROM public.listings l
+--   LEFT JOIN auth.users u ON u.id = l.user_id
+--   GROUP BY l.user_id, u.email
+--   ORDER BY annunci DESC;
+--
+--   -- guarda le righe, POI cancellale con lo STESSO criterio
+--   SELECT id, title, status, created_at FROM public.listings
+--   WHERE user_id = '...';
+--
+--   BEGIN;
+--   DELETE FROM public.listings WHERE user_id = '...';
+--   -- il numero di righe combacia? COMMIT; altrimenti ROLLBACK;
+--
+-- La DELETE su listings porta con sé in cascata offerte, match, foto,
+-- chat e partecipazioni alle catene (tutte le FK sono ON DELETE CASCADE;
+-- l'unica eccezione è ai_import_logs, dove il riferimento va a NULL).
+-- Restano invece le notifiche, che l'annuncio lo citano solo dentro un
+-- campo jsonb senza vincolo: quelle vanno tolte a mano.
+-- ============================================================

--- a/supabase/cleanup_test_listings.sql
+++ b/supabase/cleanup_test_listings.sql
@@ -1,0 +1,101 @@
+-- ============================================================
+-- Pulizia degli annunci di test — DA ESEGUIRE UN PASSO ALLA VOLTA.
+--
+-- NON è una migration: è uno script una tantum, e non va in
+-- supabase/migrations/ proprio perché non deve rigirare mai più.
+--
+-- Perché è diviso in passi: nessuno qui sa quali righe siano di test.
+-- Quel criterio ce l'hai solo tu, e una DELETE lanciata sul criterio
+-- sbagliato non si annulla. I passi 1 e 2 servono a farti VEDERE cosa
+-- stai per cancellare prima di cancellarlo.
+--
+-- Cosa succede alle tabelle collegate: tutto ciò che punta a listings ha
+-- ON DELETE CASCADE (verificato: offers, matches, listing_images,
+-- listing_secrets, listing_translations, saved_listings, transactions,
+-- chain_participants, saved_search_matches, listing_questions, reports,
+-- report_action_tokens). Cancellando un annuncio spariscono con lui le
+-- sue proposte, i suoi match e le sue foto — che per dati di test è
+-- esattamente quello che vuoi. L'unica eccezione è ai_import_logs, dove
+-- il riferimento viene messo a NULL invece che cancellato.
+-- ============================================================
+
+
+-- ------------------------------------------------------------
+-- PASSO 1 — Chi ha creato cosa.
+--
+-- Se gli annunci di test li hai fatti tutti con un account solo, qui lo
+-- riconosci subito: sarà la riga con centinaia di annunci.
+-- ------------------------------------------------------------
+SELECT
+  l.user_id,
+  p.email,
+  count(*)                                        AS annunci,
+  count(*) FILTER (WHERE l.status = 'active')     AS attivi,
+  min(l.created_at)::date                         AS primo,
+  max(l.created_at)::date                         AS ultimo
+FROM public.listings l
+LEFT JOIN auth.users p ON p.id = l.user_id
+GROUP BY l.user_id, p.email
+ORDER BY annunci DESC;
+
+
+-- ------------------------------------------------------------
+-- PASSO 2 — Guarda cosa stai per cancellare, PRIMA di cancellarlo.
+--
+-- Sostituisci il criterio qui sotto con quello vero (l'utente trovato al
+-- passo 1, o un intervallo di date, o quello che distingue i tuoi test).
+-- Se il numero e i titoli non ti convincono, NON passare al passo 3.
+-- ------------------------------------------------------------
+SELECT id, title, status, type, created_at
+FROM public.listings
+WHERE user_id = 'INCOLLA-QUI-LO-USER-ID'   -- <<< dal passo 1
+ORDER BY created_at DESC;
+
+-- E il conteggio esatto, che è il numero da confrontare col risultato
+-- della DELETE:
+SELECT count(*) AS da_cancellare
+FROM public.listings
+WHERE user_id = 'INCOLLA-QUI-LO-USER-ID';
+
+
+-- ------------------------------------------------------------
+-- PASSO 3 — La cancellazione vera.
+--
+-- Dentro una transazione ESPLICITA: la DELETE mostra quante righe ha
+-- toccato, e finché non scrivi COMMIT non è successo niente davvero. Se
+-- il numero non combacia con quello del passo 2, scrivi ROLLBACK e
+-- ricontrolla il criterio.
+--
+-- ⚠️ Il criterio deve essere IDENTICO a quello del passo 2. Cambiarlo fra
+-- i due passi vanifica la verifica appena fatta.
+-- ------------------------------------------------------------
+BEGIN;
+
+DELETE FROM public.listings
+WHERE user_id = 'INCOLLA-QUI-LO-USER-ID';   -- <<< lo stesso del passo 2
+
+-- Guarda quante righe dice di aver cancellato.
+--   combacia   -> COMMIT;
+--   non combacia -> ROLLBACK;
+
+-- COMMIT;
+-- ROLLBACK;
+
+
+-- ------------------------------------------------------------
+-- PASSO 4 — Verifica, e ripartenza pulita del cron catene.
+-- ------------------------------------------------------------
+SELECT
+  count(*)                                    AS annunci_rimasti,
+  count(*) FILTER (WHERE status = 'active')   AS attivi_rimasti
+FROM public.listings;
+
+-- Le proposte di catena costruite sugli annunci cancellati sono già
+-- sparite in cascata, ma quelle che coinvolgevano SOLO utenti di test
+-- possono essere rimaste senza partecipanti: si chiudono così.
+UPDATE public.chain_proposals
+   SET status = 'canceled'
+ WHERE status = 'proposed'
+   AND NOT EXISTS (
+     SELECT 1 FROM public.chain_participants cp WHERE cp.chain_id = chain_proposals.id
+   );


### PR DESCRIPTION
I 7 centesimi di un **singolo** ricalcolo hanno reso visibile un problema che non è la spazzatura di test.

Il numero di chiamate cresce come **CERCO × VENDO**, cioè quadraticamente. Con 333 annunci un giro costa 7 centesimi; a 1000 annunci veri non costerebbe il triplo — costerebbe circa **dieci volte tanto**. Non regge la crescita, e va risolto prima di avere utenti, non dopo.

## Filtro sulla data (finestra di 30 giorni)

Mandare al modello un candidato con data a tre mesi di distanza costa **esattamente quanto** mandargliene uno buono, per farsi dire una cosa che sapevamo già.

**Si filtra solo sulla data, ed è deliberato.** La distanza fra due date è un fatto misurabile; la vicinanza fra due città è un giudizio — ed è proprio il giudizio per cui qui esiste un modello. Filtrare la geografia con la mappa statica delle regioni annullerebbe il motivo per cui c'è l'AI. C'è un test che difende esattamente questo: due tratte lontanissime con date vicine devono arrivare comunque al modello.

**Un pre-filtro sbagliato è peggio di nessun pre-filtro**, perché toglie catene possibili senza che nessuno se ne accorga. Da qui la regola: si scarta solo ciò di cui si è **certi**. Se una delle due date manca o non è leggibile, il candidato passa. E quanti ne sono stati scartati finisce nei log — un filtro che taglia troppo dev'essere visibile.

30 giorni è largo di proposito: l'euristica interna considera "vicine" solo le date entro ±3, quindi questa soglia non esclude niente che oggi supererebbe la soglia di passaggio.

## Script di pulizia (`supabase/cleanup_test_listings.sql`)

**Non è una migration** e non sta in `migrations/` proprio perché non deve rigirare mai più.

Diviso in passi perché il criterio per distinguere i dati di test lo conosce solo chi li ha creati, e una `DELETE` sul criterio sbagliato non si annulla:

1. chi ha creato cosa (conteggi per utente);
2. l'elenco esatto di ciò che si sta per cancellare, più il conteggio;
3. la cancellazione dentro una **transazione esplicita**, da confermare a mano solo se il numero combacia;
4. verifica finale e chiusura delle catene rimaste senza partecipanti.

Verificato che tutte le tabelle collegate hanno `ON DELETE CASCADE` (offers, matches, immagini, segreti, traduzioni, preferiti, transazioni, partecipanti catena, domande, segnalazioni): non restano orfani. L'unica eccezione è `ai_import_logs`, dove il riferimento va a `NULL`.

## Verifiche

9 nuovi test (**414 lato server**, tutti verdi), fra cui i due che rendono sicuro il filtro: data mancante che non scarta, e geografia che non entra mai nella decisione.

Nessuna migration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_