### PR TITLE
Costi OpenAI catene: risposta per indice, impronta insensibile al prezzo, script di pulizia robusto

### DIFF
--- a/server/src/ai/chainMatch.js
+++ b/server/src/ai/chainMatch.js
@@ -29,9 +29,12 @@ const CHAIN_AI_CONCURRENCY = Number(process.env.CHAIN_AI_CONCURRENCY ?? 3);
 // quindi non era l'API a essere lenta — era il limite a essere corto.
 //
 // Perché 15 secondi non bastavano: a ogni chiamata il modello riceve fino
-// a 40 candidati e deve restituirne 40, ognuno con punteggio e
-// motivazione. È molto testo da generare, e il SDK ritenta anche da solo
-// dentro la stessa finestra, mangiandosela.
+// a 40 candidati e deve restituirne 40, e il SDK ritenta anche da solo
+// dentro la stessa finestra, mangiandosela. (All'epoca doveva anche
+// scrivere uuid e motivazione per ognuno: da quando risponde a indici
+// nudi genera molto meno testo, ma il limite resta largo — in un cron
+// non c'è nessuno che aspetta, e un timeout si paga senza prendere
+// niente in cambio.)
 //
 // Perché allargare non costa niente: questo gira in un cron, non c'è
 // nessuno che aspetta. Un timeout invece costa DUE volte — la chiamata
@@ -214,21 +217,33 @@ function truncate(s, n) {
   return str.length > n ? str.slice(0, n) + "…" : str;
 }
 
-function slimListing(l) {
+// Cosa vede il modello di un annuncio.
+//
+// NON l'uuid: un uuid sono ~20 token, e il modello deve riscriverlo per
+// ogni candidato per dire a chi si riferisce il punteggio. Con 40
+// candidati per chiamata sono ~800 token di sola targhetta, in USCITA,
+// dove costano quattro volte l'ingresso. Al modello basta un numero
+// progressivo: la corrispondenza indice -> uuid la teniamo qui, dove è
+// gratis e non può sbagliarsi.
+//
+// NON il prezzo: i criteri di punteggio qui sotto parlano solo di città e
+// date, il prezzo non entra in nessuno di essi — era testo pagato a ogni
+// giro senza cambiare una virgola del risultato. È anche ciò che rendeva
+// il ricalcolo sensibile al decadimento automatico dei prezzi.
+function slimListing(l, i) {
   const r = routeOf(l);
-  return {
-    id: l.id,
+  const out = {
     type: l.type,
     from: truncate(r.from, 60),
     to: truncate(r.to, 60),
     date: dateOf(l)?.toISOString() ?? null,
-    price: l.price ?? null,
   };
+  return i == null ? out : { i, ...out };
 }
 
 function buildChainPrompt(wantListing, candidatesBatch) {
   const want = slimListing(wantListing);
-  const candidates = candidatesBatch.map(slimListing);
+  const candidates = candidatesBatch.map((c, i) => slimListing(c, i));
   return `Sei un motore di normalizzazione fuzzy per uno scambio di biglietti/prenotazioni di viaggio.
 Un utente CERCA questo: ${JSON.stringify(want)}
 
@@ -242,8 +257,8 @@ IMPORTANTE: una vicinanza geografica solo generica (es. "entrambe nel sud Italia
 Linee guida punteggio: 20=nessuna corrispondenza, 35-45=solo uno dei due criteri (area larga sola, o data vicina sola) — sotto soglia, 65+=area larga E data vicina insieme, 75+=stessa città esatta anche con data più lontana, 90+=stessa città e data entrambe vicine.
 
 Rispondi SOLO con:
-{"scores": [{"id": "<uuid>", "score": <int 0-100>, "reason": "<max 100 char, in italiano>"}]}
-Un elemento per OGNI candidato, nessuna omissione.
+{"scores": [{"i": <indice del candidato>, "score": <int 0-100>}]}
+Un elemento per OGNI candidato, nessuna omissione. Nient'altro: niente motivazioni, niente testo fuori dal JSON.
 
 Candidati: ${JSON.stringify(candidates)}`;
 }
@@ -273,11 +288,10 @@ async function callOpenAIChainScore(prompt, timeoutMs, candidateCount = null) {
                   items: {
                     type: "object",
                     additionalProperties: false,
-                    required: ["id", "score", "reason"],
+                    required: ["i", "score"],
                     properties: {
-                      id: { type: "string" },
+                      i: { type: "integer", minimum: 0 },
                       score: { type: "integer", minimum: 0, maximum: 100 },
-                      reason: { type: "string", maxLength: 120 },
                     },
                   },
                 },
@@ -314,20 +328,36 @@ async function callOpenAIChainScore(prompt, timeoutMs, candidateCount = null) {
   }
 }
 
-function validateChainScores(raw, knownIds) {
+/**
+ * Dalla risposta a indici agli id veri.
+ *
+ * L'indice è comodo per il modello ma è anche un modo nuovo di sbagliare:
+ * un indice fuori dal lotto, o lo stesso indice due volte, prima non era
+ * rappresentabile (un uuid inventato non stava nell'elenco e cadeva da
+ * solo). Qui si scartano entrambi i casi invece di fidarsi della
+ * posizione.
+ *
+ * @param {Array} raw risposta del modello
+ * @param {Array} batch i candidati inviati, NELLO STESSO ORDINE del prompt
+ */
+export function validateChainScores(raw, batch) {
   if (!Array.isArray(raw)) return null;
-  const ids = new Set(knownIds);
   const out = [];
+  const visti = new Set();
   for (const x of raw) {
-    if (!x || !ids.has(x.id)) continue;
+    // null/undefined/"" fuori PRIMA della conversione: Number(null) è 0, e
+    // uno 0 nato da un campo vuoto attribuirebbe quel punteggio al primo
+    // candidato del lotto — un annuncio a caso, senza che si veda. Una
+    // cifra scritta come stringa ("1") invece si accetta: è una variazione
+    // innocua, e scartarla butterebbe via una risposta già pagata.
+    if (x?.i === null || x?.i === undefined || x?.i === "") continue;
+    const i = Number(x.i);
+    if (!Number.isInteger(i) || i < 0 || i >= batch.length) continue;
+    if (visti.has(i)) continue;
+    visti.add(i);
     let s = Number.isFinite(Number(x.score)) ? Math.round(Number(x.score)) : 0;
     s = Math.max(0, Math.min(100, s));
-    out.push({
-      id: x.id,
-      score: s,
-      reason: typeof x.reason === "string" ? x.reason.slice(0, 200) : "",
-      model: MODEL,
-    });
+    out.push({ id: batch[i].id, score: s, reason: "", model: MODEL });
   }
   return out;
 }
@@ -354,7 +384,7 @@ export async function scoreChainCandidates(wantListing, candidates) {
   const perBatch = await mapWithConcurrency(batches, CHAIN_AI_CONCURRENCY, async (batch) => {
     const prompt = buildChainPrompt(wantListing, batch);
     const raw = await callOpenAIChainScore(prompt, CHAIN_AI_TIMEOUT_MS, batch.length);
-    return validateChainScores(raw, batch.map((c) => c.id));
+    return validateChainScores(raw, batch);
   });
 
   // Il ripiego è PER LOTTO, non per l'intero insieme.

--- a/server/src/lib/chainFingerprint.js
+++ b/server/src/lib/chainFingerprint.js
@@ -19,21 +19,68 @@
 //      momento esistono cicli che prima non c'erano — senza che nessuno
 //      abbia toccato un solo annuncio.
 //
-// Per ciascuno bastano due numeri: QUANTI sono e QUAL È la modifica più
-// recente. Se qualcosa nasce, cambia o sparisce, almeno uno dei due si
-// muove. Non serve rileggere le righe: sono due query di aggregazione.
+// PERCHÉ NON BASTA `updated_at`. La prima versione guardava, per gli
+// annunci, quanti fossero e quale fosse l'ultima modifica. Sembrava
+// gratis — due aggregazioni invece di una lettura — ma qualsiasi UPDATE su
+// `listings` sposta `updated_at`, anche uno che al grafo dei desideri non
+// dice niente. Il decadimento automatico dei prezzi ne scrive uno ogni
+// giro su ogni annuncio in scadenza: bastava quello per invalidare
+// l'impronta ogni 15 minuti e ricalcolare tutto, a pagamento, senza che
+// nulla di rilevante fosse cambiato.
+//
+// Quindi l'impronta si costruisce sui CAMPI che il grafo usa davvero —
+// chi possiede cosa, di che tipo, da dove a dove, quando — leggendo le
+// righe. È una query in più contro centinaia di chiamate a un modello: il
+// confronto non è nemmeno vicino. E il prezzo, che al punteggio delle
+// catene non partecipa, resta fuori.
+import { createHash } from "node:crypto";
 
 /**
- * Impronta stabile da conteggi e date. Volutamente una stringa e non un
- * hash: quando si indaga sui log, "333|2026-08-05T20:11:00Z|2|..." dice
- * subito cosa è cambiato, mentre un digest non dice niente.
+ * Impronta stabile. Volutamente leggibile e non un hash unico: nei log
+ * "333|a1b2c3~2|2026-08-05T19:00:00Z" dice subito QUALE dei due ingressi
+ * si è mosso, mentre un digest solo non direbbe niente.
  *
- * @param {{count:number, lastChangeAt:string|null}} listings
- * @param {{count:number, lastChangeAt:string|null}} chains
+ * @param {{count:number, digest?:string, lastChangeAt?:string|null}} listings
+ * @param {{count:number, digest?:string, lastChangeAt?:string|null}} chains
  */
 export function chainFingerprint(listings, chains) {
-  const part = (x) => `${Number(x?.count ?? 0)}|${x?.lastChangeAt ?? "-"}`;
+  const part = (x) => `${Number(x?.count ?? 0)}|${x?.digest ?? x?.lastChangeAt ?? "-"}`;
   return `${part(listings)}~${part(chains)}`;
+}
+
+// I campi che entrano nel grafo dei desideri, e SOLO quelli. Aggiungerne
+// uno qui è obbligatorio quando il matching comincia a usarlo: se un campo
+// conta per il punteggio ma non per l'impronta, cambiarlo non fa
+// ricalcolare niente e la catena giusta non compare mai.
+//
+// `location` c'è perché routeOf() la usa come ripiego quando route_from/
+// route_to sono vuote: due annunci identici tranne che lì darebbero grafi
+// diversi.
+function structuralLine(l) {
+  return [
+    l?.id, l?.user_id, l?.status, l?.type, l?.cerco_vendo,
+    l?.route_from, l?.route_to, l?.location,
+    l?.depart_at, l?.check_in,
+    l?.accepts_swap, l?.swap_wanted,
+  ].map((v) => (v == null ? "" : String(v))).join("|");
+}
+
+/**
+ * Impronta degli annunci attivi a partire dalle righe già lette.
+ *
+ * Ordinata prima di digerire: l'ordine in cui il database restituisce le
+ * righe non è garantito, e un'impronta che cambia per il solo ordine
+ * farebbe ricalcolare tutto a caso.
+ *
+ * @param {Array<object>} rows annunci attivi
+ */
+export function listingsStamp(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  const righe = list.map(structuralLine).sort();
+  return {
+    count: list.length,
+    digest: createHash("sha1").update(righe.join("\n")).digest("hex").slice(0, 12),
+  };
 }
 
 /**

--- a/server/src/models/chains.js
+++ b/server/src/models/chains.js
@@ -16,7 +16,7 @@ import { listActiveListings } from "./listings.js";
 import { scoreChainCandidates, CHAIN_SCORE_PASS_THRESHOLD, worthScoringByDate, CHAIN_DATE_WINDOW_DAYS } from "../ai/chainMatch.js";
 import { explainChain } from "../ai/chainExplain.js";
 import { mapWithConcurrency } from "../lib/concurrency.js";
-import { chainFingerprint, canSkipRecompute } from "../lib/chainFingerprint.js";
+import { chainFingerprint, canSkipRecompute, listingsStamp } from "../lib/chainFingerprint.js";
 
 // Valutazioni AI dei candidati in volo contemporaneamente. Basso: ognuna può
 // a sua volta spezzarsi in più batch (vedi CHAIN_AI_CONCURRENCY in
@@ -262,27 +262,34 @@ export async function findAndProposeChains() {
   // minuti fa. Le due chiamate di manutenzione qui sopra sono già state
   // fatte: quelle dipendono dal passare del tempo, non dagli annunci, e
   // saltarle romperebbe scadenze e promemoria.
+  const allActive = await listActiveListings({ limit: 1000 });
+
   try {
-    const [listingsStamp, chainsStamp] = await Promise.all([
-      tableStamp("listings", "updated_at", (q) => q.eq("status", "active")),
-      // Stesso filtro di ownersWithPendingChain: sono le catene 'proposed'
-      // a bloccare i loro partecipanti, e quindi le sole che cambiano il
-      // risultato del ricalcolo.
-      tableStamp("chain_proposals", "created_at", (q) => q.eq("status", "proposed")),
-    ]);
-    const fingerprint = chainFingerprint(listingsStamp, chainsStamp);
+    // Stesso filtro di ownersWithPendingChain: sono le catene 'proposed'
+    // a bloccare i loro partecipanti, e quindi le sole che cambiano il
+    // risultato del ricalcolo.
+    const chainsStamp = await tableStamp("chain_proposals", "created_at", (q) => q.eq("status", "proposed"));
+    const fingerprint = chainFingerprint(listingsStamp(allActive), chainsStamp);
     if (canSkipRecompute(lastFingerprint, fingerprint, expiredCount)) {
       console.log("[chains] nessun cambiamento dall'ultimo giro, ricalcolo saltato:", fingerprint);
       return { proposed: [], skipped: [], errors: [], expiredCount, remindedCount, unchanged: true };
     }
+    // Perché ricalcoliamo, in chiaro nei log: senza il confronto fra le due
+    // impronte, un ricalcolo che non salta mai è indistinguibile da uno che
+    // salta correttamente ma non viene mai interpellato. Con questa riga si
+    // legge subito QUALE dei due ingressi si è mosso — o se il precedente
+    // non c'era perché il processo era appena ripartito.
+    console.log(
+      `[chains] ricalcolo: impronta ${lastFingerprint ? `${lastFingerprint} -> ${fingerprint}` : `${fingerprint} (primo giro dopo un riavvio)`}`
+      + (expiredCount ? `, ${expiredCount} catene appena scadute` : "")
+    );
     lastFingerprint = fingerprint;
   } catch (e) {
-    // Se l'impronta non si riesce a leggere si ricalcola, come prima: il
+    // Se l'impronta non si riesce a calcolare si ricalcola, come prima: il
     // risparmio è un di più, non deve poter impedire il lavoro vero.
     console.warn("[chains] impronta non leggibile, si ricalcola:", e?.message || e);
   }
 
-  const allActive = await listActiveListings({ limit: 1000 });
   const { edges, bestEdgeListing, listingById } = await buildDesireGraph(allActive);
   const cycles = findThreeCycles(edges);
 

--- a/server/test/chainFingerprint.test.js
+++ b/server/test/chainFingerprint.test.js
@@ -10,9 +10,28 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { chainFingerprint, canSkipRecompute } from '../src/lib/chainFingerprint.js';
+import { chainFingerprint, canSkipRecompute, listingsStamp } from '../src/lib/chainFingerprint.js';
 
 const L = (count, at) => ({ count, lastChangeAt: at });
+
+// Un annuncio come lo legge listActiveListings, ridotto ai campi che
+// contano qui.
+const ann = (over = {}) => ({
+  id: 'aaaaaaaa-0000-0000-0000-000000000001',
+  user_id: 'u1',
+  status: 'active',
+  type: 'train',
+  cerco_vendo: 'VENDO',
+  route_from: 'Roma',
+  route_to: 'Milano',
+  location: null,
+  depart_at: '2026-09-10T09:00:00Z',
+  check_in: null,
+  accepts_swap: true,
+  swap_wanted: 'Firenze',
+  price: 80,
+  ...over,
+});
 
 test('stessi ingressi, stessa impronta', () => {
   const a = chainFingerprint(L(333, '2026-08-05T20:00:00Z'), L(2, '2026-08-05T19:00:00Z'));
@@ -71,6 +90,70 @@ test('al primo giro dopo un riavvio non si salta mai', () => {
   assert.equal(canSkipRecompute(null, 'X', 0), false);
   assert.equal(canSkipRecompute(undefined, 'X', 0), false);
   assert.equal(canSkipRecompute('', 'X', 0), false);
+});
+
+// ----------------------------------------------------------------------
+// L'impronta degli annunci: sui CAMPI, non su updated_at.
+// ----------------------------------------------------------------------
+
+test('il PREZZO non cambia l\'impronta, ed è il motivo per cui questa funzione esiste', () => {
+  // La regressione vera: l'impronta guardava listings.updated_at, e il
+  // decadimento automatico dei prezzi scrive un UPDATE per ogni annuncio
+  // in scadenza a ogni giro. Bastava quello per invalidare l'impronta ogni
+  // 15 minuti e ricalcolare tutte le catene, a pagamento, senza che nulla
+  // di rilevante per i cicli fosse cambiato. Il prezzo al punteggio delle
+  // catene non partecipa: qui deve essere invisibile.
+  const prima = listingsStamp([ann({ price: 80 })]);
+  const dopo = listingsStamp([ann({ price: 41.5 })]);
+  assert.equal(prima.digest, dopo.digest);
+});
+
+test('l\'ordine delle righe non conta', () => {
+  // Postgres non garantisce un ordine se non glielo si chiede, e
+  // un'impronta che cambia per il solo ordine farebbe ricalcolare a caso.
+  const a = ann({ id: 'a' });
+  const b = ann({ id: 'b' });
+  assert.equal(listingsStamp([a, b]).digest, listingsStamp([b, a]).digest);
+});
+
+test('cambiare tratta, data, tipo o direzione cambia l\'impronta', () => {
+  const base = listingsStamp([ann()]).digest;
+  for (const modifica of [
+    { route_to: 'Torino' },
+    { route_from: 'Napoli' },
+    { depart_at: '2026-09-11T09:00:00Z' },
+    { type: 'hotel' },
+    { cerco_vendo: 'CERCO' },
+    { user_id: 'u2' },
+    { swap_wanted: 'Bologna' },
+    { accepts_swap: false },
+    { location: 'Roma-->Milano' },
+    { status: 'paused' },
+  ]) {
+    assert.notEqual(listingsStamp([ann(modifica)]).digest, base, `invisibile: ${JSON.stringify(modifica)}`);
+  }
+});
+
+test('un annuncio in più cambia conteggio e impronta', () => {
+  const uno = listingsStamp([ann({ id: 'a' })]);
+  const due = listingsStamp([ann({ id: 'a' }), ann({ id: 'b' })]);
+  assert.equal(uno.count, 1);
+  assert.equal(due.count, 2);
+  assert.notEqual(uno.digest, due.digest);
+});
+
+test('nessun annuncio è uno stato valido, non un errore', () => {
+  const vuoto = listingsStamp([]);
+  assert.equal(vuoto.count, 0);
+  assert.equal(listingsStamp(null).digest, vuoto.digest);
+  assert.notEqual(listingsStamp([ann()]).digest, vuoto.digest);
+});
+
+test('l\'impronta completa distingue i due ingressi', () => {
+  const annunci = listingsStamp([ann()]);
+  const catene = { count: 2, lastChangeAt: '2026-08-05T19:00:00Z' };
+  const f = chainFingerprint(annunci, catene);
+  assert.match(f, /^1\|[0-9a-f]{12}~2\|2026-08-05T19:00:00Z$/);
 });
 
 test('se sono appena scadute delle catene NON si salta, anche con impronta uguale', () => {

--- a/server/test/chainScoreIndices.test.js
+++ b/server/test/chainScoreIndices.test.js
@@ -1,0 +1,87 @@
+// Il modello risponde per INDICE, non per uuid.
+//
+// Perché: un uuid sono ~20 token, e il modello lo deve riscrivere per ogni
+// candidato solo per dire a chi si riferisce il punteggio. Con 40 candidati
+// per chiamata sono ~800 token di sola targhetta, in USCITA — dove costano
+// quattro volte l'ingresso. Sul conto OpenAI l'uscita era la voce più cara
+// di tutte ($5.04 contro $4.16 di ingresso).
+//
+// Ma un indice è anche un modo NUOVO di sbagliare: un uuid inventato non
+// stava nell'elenco e cadeva da solo, mentre un indice sbagliato punta
+// comunque a una riga esistente — quella di qualcun altro. Attribuire il
+// punteggio di un annuncio a un altro creerebbe catene fra persone che non
+// si incastrano, e sarebbe invisibile. Questi test stanno tutti lì.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validateChainScores } from '../src/ai/chainMatch.js';
+
+const batch = [
+  { id: 'aaaaaaaa-0000-0000-0000-000000000001', type: 'train' },
+  { id: 'bbbbbbbb-0000-0000-0000-000000000002', type: 'train' },
+  { id: 'cccccccc-0000-0000-0000-000000000003', type: 'train' },
+];
+
+test('l\'indice torna all\'id giusto, nell\'ordine del prompt', () => {
+  const out = validateChainScores([{ i: 2, score: 80 }, { i: 0, score: 40 }], batch);
+  assert.deepEqual(out.map((x) => [x.id, x.score]), [
+    [batch[2].id, 80],
+    [batch[0].id, 40],
+  ]);
+});
+
+test('un indice fuori dal lotto viene scartato, non attribuito a caso', () => {
+  // È il caso pericoloso: 7 su un lotto da 3 non deve diventare
+  // "l'ultimo" o "il primo" per comodità.
+  const out = validateChainScores([{ i: 7, score: 99 }, { i: -1, score: 99 }, { i: 1, score: 70 }], batch);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].id, batch[1].id);
+});
+
+test('un indice ripetuto conta una volta sola', () => {
+  // Due punteggi diversi per lo stesso candidato: si tiene il primo e si
+  // ignora il secondo, invece di far vincere l'ultimo arrivato.
+  const out = validateChainScores([{ i: 1, score: 90 }, { i: 1, score: 10 }], batch);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].score, 90);
+});
+
+test('un indice vuoto NON diventa il primo candidato', () => {
+  // Number(null) è 0: senza il controllo esplicito, un campo vuoto
+  // assegnerebbe quel punteggio al primo annuncio del lotto — uno a caso,
+  // e in silenzio.
+  const out = validateChainScores(
+    [{ i: null, score: 90 }, { i: undefined, score: 90 }, { i: '', score: 90 }, { i: 1.5, score: 90 }],
+    batch,
+  );
+  assert.equal(out.length, 0);
+});
+
+test('una cifra scritta come stringa si accetta', () => {
+  // Variazione innocua e non ambigua: scartarla butterebbe via una
+  // risposta già pagata.
+  const out = validateChainScores([{ i: '1', score: 90 }], batch);
+  assert.deepEqual(out.map((x) => x.id), [batch[1].id]);
+});
+
+test('il punteggio resta dentro 0-100 e intero', () => {
+  const out = validateChainScores([{ i: 0, score: 250 }, { i: 1, score: -5 }, { i: 2, score: 71.6 }], batch);
+  assert.deepEqual(out.map((x) => x.score), [100, 0, 72]);
+});
+
+test('un punteggio non numerico vale 0, non fa cadere il candidato', () => {
+  const out = validateChainScores([{ i: 0, score: 'ottimo' }], batch);
+  assert.deepEqual(out.map((x) => [x.id, x.score]), [[batch[0].id, 0]]);
+});
+
+test('una risposta non-array resta null: è il segnale di "AI non pervenuta"', () => {
+  // Serve a scoreChainCandidates per distinguere "nessun candidato valido"
+  // da "chiamata fallita, usa l'euristica per QUESTO lotto".
+  assert.equal(validateChainScores(null, batch), null);
+  assert.equal(validateChainScores({ scores: [] }, batch), null);
+  assert.deepEqual(validateChainScores([], batch), []);
+});
+
+test('un lotto vuoto non accetta nessun indice', () => {
+  assert.deepEqual(validateChainScores([{ i: 0, score: 90 }], []), []);
+});

--- a/supabase/cleanup_test_listings.sql
+++ b/supabase/cleanup_test_listings.sql
@@ -23,6 +23,30 @@
 
 
 -- ------------------------------------------------------------
+-- PASSO 0 — Quali tabelle esistono davvero.
+--
+-- Non tutte le migration sono state applicate a mano, quindi qualche
+-- tabella prevista dal repo può mancare dal database. Questa query te lo
+-- dice invece di fartelo scoprire con un errore a metà cancellazione.
+--
+-- Le righe che tornano qui sono migration da eseguire, non un problema
+-- della pulizia: il passo 2 salta da solo quello che non c'è.
+-- ------------------------------------------------------------
+SELECT t AS tabella_mancante
+FROM unnest(ARRAY[
+  'listings','listing_images','listing_secrets','listing_translations',
+  'listing_ai_scores','listing_pings','listing_questions',
+  'offers','chat_messages','matches','match_snapshots',
+  'transactions','transaction_ratings',
+  'chain_proposals','chain_participants','chain_messages','chain_disputes',
+  'saved_listings','saved_searches','saved_search_matches',
+  'notifications','trust_audit','ai_import_logs',
+  'reports','report_action_tokens','payment_declarations'
+]) AS t
+WHERE to_regclass('public.' || t) IS NULL;
+
+
+-- ------------------------------------------------------------
 -- PASSO 1 — Cosa c'è adesso.
 --
 -- Serve come "prima" da confrontare col "dopo" del passo 3.
@@ -48,37 +72,37 @@ ORDER BY 2 DESC;
 -- dimensioni e non fa scattare i trigger riga-per-riga (niente
 -- notifiche generate mentre stai cancellando). CASCADE copre eventuali
 -- tabelle collegate che dovessero sfuggire all'elenco.
+--
+-- L'elenco è costruito a runtime saltando le tabelle che non esistono:
+-- un TRUNCATE scritto a mano fallisce tutto per una tabella sola che
+-- manca, e con le migration applicate a mano succede davvero.
 -- ------------------------------------------------------------
 BEGIN;
 
-TRUNCATE
-  public.listings,
-  public.listing_images,
-  public.listing_secrets,
-  public.listing_translations,
-  public.listing_ai_scores,
-  public.listing_pings,
-  public.listing_questions,
-  public.offers,
-  public.chat_messages,
-  public.matches,
-  public.match_snapshots,
-  public.transactions,
-  public.transaction_ratings,
-  public.chain_proposals,
-  public.chain_participants,
-  public.chain_messages,
-  public.chain_disputes,
-  public.saved_listings,
-  public.saved_searches,
-  public.saved_search_matches,
-  public.notifications,
-  public.trust_audit,
-  public.ai_import_logs,
-  public.reports,
-  public.report_action_tokens,
-  public.payment_declarations
-CASCADE;
+DO $$
+DECLARE
+  t         text;
+  presenti  text[] := '{}';
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'listings','listing_images','listing_secrets','listing_translations',
+    'listing_ai_scores','listing_pings','listing_questions',
+    'offers','chat_messages','matches','match_snapshots',
+    'transactions','transaction_ratings',
+    'chain_proposals','chain_participants','chain_messages','chain_disputes',
+    'saved_listings','saved_searches','saved_search_matches',
+    'notifications','trust_audit','ai_import_logs',
+    'reports','report_action_tokens','payment_declarations'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NOT NULL THEN
+      presenti := presenti || ('public.' || t);
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE 'Svuoto % tabelle: %', array_length(presenti, 1),
+                                      array_to_string(presenti, ', ');
+  EXECUTE 'TRUNCATE ' || array_to_string(presenti, ', ') || ' CASCADE';
+END $$;
 
 -- Se il messaggio di ritorno è "Success", scrivi COMMIT.
 -- Se qualcosa ti torna storto, ROLLBACK e non è successo niente.


### PR DESCRIPTION
Tre cose, nate dalla stessa osservazione: il cron delle catene continuava a costare ~3 centesimi ogni 15 minuti con l'app ferma.

## 1. L'uscita del modello era la voce più cara del conto

Dal consumo OpenAI: **output $5.04 contro input $4.16**. Gli output token costano 4× gli input, e li stavamo sprecando su due campi:

- **l'uuid**, riscritto dal modello per ogni candidato solo per dire a chi si riferisce il punteggio — ~20 token a candidato, ~800 per chiamata da 40;
- **`reason`**, generata per ogni candidato e **mai letta da nessuno**: `models/chains.js` usa solo `score`.

Ora il prompt numera i candidati e il modello risponde `{"i": 0, "score": 72}`. Tolto anche il `price` dal payload: i criteri di punteggio parlano solo di città e date, il prezzo non entra in nessuno di essi.

Per lotto da 40 candidati, stima su lunghezza del JSON:

| | prima | dopo |
|---|---|---|
| ingresso | ~1510 token | ~1028 (−32%) |
| uscita | ~933 token | ~201 (−78%) |

L'indice però è un modo **nuovo** di sbagliare: un uuid inventato non stava nell'elenco e cadeva da solo, mentre un indice sbagliato punta comunque a una riga esistente — quella di qualcun altro — e attribuirebbe il punteggio all'annuncio sbagliato senza che si veda. `validateChainScores` scarta fuori intervallo, ripetuti, non interi e vuoti (`Number(null)` è `0`, che sarebbe finito sul primo candidato del lotto). 9 test nuovi.

## 2. Il ricalcolo non saltava mai, per colpa del decadimento prezzi

L'impronta "è cambiato qualcosa?" guardava `listings.updated_at`. Ma **qualsiasi** UPDATE sposta quella colonna, compreso quello di `recomputeDynamicPrices`, che riscrive il prezzo di ogni annuncio in scadenza a ogni giro. Risultato: impronta diversa ogni 15 minuti, ricalcolo completo ogni volta, a pagamento, senza che nulla di rilevante per i cicli fosse cambiato.

Ora l'impronta si costruisce sui **campi che il grafo dei desideri usa davvero** (proprietario, tipo, direzione CERCO/VENDO, tratta, date, `accepts_swap`/`swap_wanted`, stato), a partire dalle righe già lette da `listActiveListings` — una query che c'era già, contro centinaia di chiamate a un modello.

Aggiunto un log che stampa `impronta precedente -> attuale`: senza quello, un ricalcolo che non salta mai è indistinguibile da uno che salta correttamente ma non viene mai interpellato.

## 3. Lo script di pulizia falliva su una tabella mancante

`ERROR: 42P01: relation "public.chain_disputes" does not exist` — l'elenco del `TRUNCATE` era scritto dal repo, ma il database non ha tutte le migration. Ora l'elenco si costruisce a runtime con `to_regclass` e salta ciò che non esiste; un PASSO 0 mostra in anticipo quali tabelle mancano.

## ⚠️ Azione manuale

`chain_disputes` e le sue due RPC mancano in produzione: `screens/ChainChatScreen.js` → `lib/chains.js:105` chiama `report_chain_problem`, quindi oggi il pulsante "Segnala un problema" nella chat degli scambi a 3 fallisce. Verifica:

```sql
SELECT to_regclass('public.chain_disputes')       AS tabella,
       to_regproc('public.report_chain_problem')  AS rpc_segnala,
       to_regproc('public.resolve_chain_dispute') AS rpc_risolvi;
```

Se tornano `null`, eseguire `supabase/migrations/20260730160000_chain_disputes.sql`.

## Verifiche

- 429 test server verdi (9 nuovi sugli indici, 6 nuovi sull'impronta strutturale)
- Il test chiave sull'impronta è quello che verifica che **cambiare il prezzo non la sposti**, ed è la regressione vera
- Nessuna modifica al client: il protocollo a indici è interno alla chiamata OpenAI