### PR TITLE
Storia di prezzo e stato degli annunci, prima che si perda

### DIFF
--- a/server/test/db/listingEvents.test.js
+++ b/server/test/db/listingEvents.test.js
@@ -1,0 +1,165 @@
+// La storia di prezzo e stato di un annuncio (listing_events).
+//
+// Nasce da un fatto che si stava perdendo ogni ora: il cron del prezzo
+// dinamico sovrascrive listings.price a ogni giro, e updated_at cambia a
+// ogni scrittura qualunque. Quindi "è stato in vetrina a 70€, poi a 55€,
+// venduto a 40€ dopo cinque giorni" non era ricostruibile — ed è esattamente
+// il dato che serve per stimare se un annuncio si venderà.
+//
+// È tutta roba che vive dentro Postgres: un trigger e una RLS. Nessun mock
+// può vederla, per questo il test sta qui.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { motivoSkip, apri, chiudi, creaUtente, creaAnnuncio, comeUtente } from "./helpers.mjs";
+
+const opzioni = motivoSkip ? { skip: motivoSkip } : {};
+
+async function eventi(c, listingId) {
+  const { rows } = await c.query(
+    "select kind, price, status, dynamic, at from public.listing_events where listing_id = $1 order by id",
+    [listingId],
+  );
+  return rows;
+}
+
+test("alla nascita di un annuncio viene registrato il punto di partenza", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 70 });
+
+    const ev = await eventi(c, l);
+    assert.equal(ev.length, 1);
+    assert.equal(ev[0].kind, "created");
+    assert.equal(Number(ev[0].price), 70);
+    assert.equal(ev[0].status, "active");
+  } finally {
+    await chiudi(c);
+  }
+});
+
+test("ogni cambio di prezzo lascia una riga: è la serie che il decadimento cancellava", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 70 });
+
+    // Due giri del cron del prezzo dinamico.
+    await c.query("update public.listings set price = 55 where id = $1", [l]);
+    await c.query("update public.listings set price = 40 where id = $1", [l]);
+
+    const prezzi = (await eventi(c, l)).map((e) => Number(e.price));
+    assert.deepEqual(prezzi, [70, 55, 40]);
+  } finally {
+    await chiudi(c);
+  }
+});
+
+test("riscrivere lo STESSO prezzo non lascia niente", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 70 });
+
+    // Il cron gira ogni ora su ogni annuncio: senza questo controllo la
+    // tabella si riempirebbe di righe identiche, e la serie diventerebbe
+    // illeggibile proprio per chi dovrà usarla.
+    await c.query("update public.listings set price = 70 where id = $1", [l]);
+    await c.query("update public.listings set title = 'altro titolo' where id = $1", [l]);
+
+    assert.equal((await eventi(c, l)).length, 1);
+  } finally {
+    await chiudi(c);
+  }
+});
+
+test("il cambio di stato data la fine dell'annuncio", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 50 });
+
+    await c.query("update public.listings set status = 'sold'::listing_status where id = $1", [l]);
+
+    const ev = await eventi(c, l);
+    const fine = ev[ev.length - 1];
+    assert.equal(fine.kind, "status");
+    assert.equal(fine.status, "sold");
+    // Il prezzo viaggia insieme allo stato: senza, per sapere a quanto è
+    // stato venduto bisognerebbe risalire all'evento precedente.
+    assert.equal(Number(fine.price), 50);
+  } finally {
+    await chiudi(c);
+  }
+});
+
+test("prezzo e stato che cambiano insieme lasciano due righe distinte", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 50 });
+
+    await c.query(
+      "update public.listings set price = 45, status = 'paused'::listing_status where id = $1",
+      [l],
+    );
+
+    const ev = await eventi(c, l);
+    assert.deepEqual(ev.map((e) => e.kind), ["created", "price", "status"]);
+  } finally {
+    await chiudi(c);
+  }
+});
+
+test("il prezzo dinamico è distinguibile da una scelta del venditore", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 100 });
+    await c.query(
+      "update public.listings set dynamic_pricing_enabled = true, price_floor = 40, list_price = 100, price = 90 where id = $1",
+      [l],
+    );
+
+    const ev = await eventi(c, l);
+    assert.equal(ev[0].dynamic, false, "alla nascita il dinamico era spento");
+    assert.equal(ev[ev.length - 1].dynamic, true, "la discesa successiva è automatica");
+  } finally {
+    await chiudi(c);
+  }
+});
+
+test("nessun utente può leggere la storia dei ribassi altrui", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 60 });
+    await c.query("update public.listings set price = 45 where id = $1", [l]);
+
+    // Nemmeno il proprietario: è materiale di analisi, non contenuto. Chi
+    // compra, sapendo che un annuncio sta scendendo, aspetterebbe — e
+    // cambierebbe il comportamento che stiamo misurando.
+    await comeUtente(c, u, async () => {
+      const { rows } = await c.query("select * from public.listing_events where listing_id = $1", [l]);
+      assert.equal(rows.length, 0, "la RLS senza policy non lascia passare nessuno");
+    });
+  } finally {
+    await chiudi(c);
+  }
+});
+
+test("cancellare un annuncio per davvero porta via la sua storia", opzioni, async () => {
+  const c = await apri();
+  try {
+    const u = await creaUtente(c);
+    const l = await creaAnnuncio(c, { userId: u, price: 60 });
+    await c.query("delete from public.listings where id = $1", [l]);
+
+    // ON DELETE CASCADE: la storia di una riga che non esiste più non serve
+    // a nessuno, e lasciarla orfana significherebbe tenere dati di un utente
+    // che ha chiesto di sparire.
+    assert.equal((await eventi(c, l)).length, 0);
+  } finally {
+    await chiudi(c);
+  }
+});

--- a/supabase/migrations/20260808150000_listing_events.sql
+++ b/supabase/migrations/20260808150000_listing_events.sql
@@ -1,0 +1,117 @@
+-- 20260808150000_listing_events.sql
+--
+-- La storia di un annuncio: com'è cambiato il prezzo, e quando è finito.
+--
+-- PERCHÉ ADESSO, CHE NON SERVE A NESSUNO.
+--
+-- Il dato che serve a rispondere "questo biglietto, a questo prezzo, quante
+-- probabilità ha di vendersi entro venerdì?" è la storia: a quale prezzo un
+-- annuncio è stato in vetrina, per quanto, e com'è andata a finire.
+--
+-- Oggi quella storia si sta cancellando da sola, ogni ora:
+--
+--   • listings.price viene SOVRASCRITTO dal cron del prezzo dinamico a ogni
+--     giro, e da ogni modifica manuale. Sopravvive solo l'ultimo valore:
+--     "è stato a 70€, poi a 55€, venduto a 40€" non è ricostruibile;
+--   • listings.updated_at cambia a OGNI scrittura, quindi non dice quando
+--     l'annuncio è diventato 'sold' o 'expired' — dice solo quand'è stato
+--     toccato l'ultima volta.
+--
+-- Nessuna delle due si recupera a posteriori. Questa tabella non produce
+-- niente di visibile: rende possibile, fra qualche mese, una cosa che
+-- altrimenti non lo sarebbe più.
+--
+-- PERCHÉ UN TRIGGER E NON L'APP. Il prezzo lo riscrive soprattutto il cron,
+-- che passa da PostgREST; e chiunque domani tocchi la tabella da un altro
+-- client la aggirerebbe. Sta a DB per la stessa ragione per cui ci stanno le
+-- regole CERCO/VENDO: è la difesa che vale per qualunque client.
+
+CREATE TABLE IF NOT EXISTS public.listing_events (
+  id bigserial PRIMARY KEY,
+  listing_id uuid NOT NULL REFERENCES public.listings(id) ON DELETE CASCADE,
+  at timestamptz NOT NULL DEFAULT now(),
+  -- 'created' = la riga alla nascita; 'price' = il prezzo è cambiato;
+  -- 'status'  = lo stato è cambiato (è così che si data la fine).
+  kind text NOT NULL CHECK (kind IN ('created', 'price', 'status')),
+  price numeric(10,2),
+  status public.listing_status,
+  -- Il prezzo dinamico riscrive da solo: serve a distinguere una discesa
+  -- automatica da una scelta del venditore, che sono due cose diverse per
+  -- chiunque guarderà questi dati.
+  dynamic boolean NOT NULL DEFAULT false
+);
+
+COMMENT ON TABLE public.listing_events IS
+  'Storia di prezzo e stato di ogni annuncio. Serve a stimare la probabilità di vendita: listings.price viene sovrascritto dal decadimento automatico e non è ricostruibile a posteriori. Solo scrittura da trigger, lettura solo service_role.';
+
+CREATE INDEX IF NOT EXISTS idx_listing_events_listing_at
+  ON public.listing_events (listing_id, at);
+
+-- ------------------------------------------------------------
+-- RLS: nessuno la legge dal client.
+--
+-- È materiale di analisi, non contenuto: contiene la storia dei ribassi di
+-- tutti, e mostrarla a chi compra cambierebbe il comportamento di chi vende.
+-- Attivare la RLS senza definire nessuna policy significa esattamente
+-- "nessun accesso": passa solo service_role, che le scavalca.
+-- ------------------------------------------------------------
+ALTER TABLE public.listing_events ENABLE ROW LEVEL SECURITY;
+
+-- ------------------------------------------------------------
+-- Il trigger.
+--
+-- Si scrive una riga SOLO quando qualcosa cambia davvero (IS DISTINCT FROM),
+-- altrimenti il cron orario riempirebbe la tabella di righe identiche.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.after_listing_write_record_event()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO public.listing_events (listing_id, kind, price, status, dynamic)
+    VALUES (NEW.id, 'created', NEW.price, NEW.status, COALESCE(NEW.dynamic_pricing_enabled, false));
+    RETURN NULL;
+  END IF;
+
+  IF NEW.price IS DISTINCT FROM OLD.price THEN
+    INSERT INTO public.listing_events (listing_id, kind, price, status, dynamic)
+    VALUES (NEW.id, 'price', NEW.price, NEW.status, COALESCE(NEW.dynamic_pricing_enabled, false));
+  END IF;
+
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    INSERT INTO public.listing_events (listing_id, kind, price, status, dynamic)
+    VALUES (NEW.id, 'status', NEW.price, NEW.status, COALESCE(NEW.dynamic_pricing_enabled, false));
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+-- AFTER e non BEFORE: la storia registra ciò che è successo, e se la
+-- scrittura sull'annuncio venisse annullata questa riga sparirebbe con lei
+-- (stessa transazione). Non deve mai poter impedire una scrittura.
+DROP TRIGGER IF EXISTS after_listing_write_record_event ON public.listings;
+CREATE TRIGGER after_listing_write_record_event
+AFTER INSERT OR UPDATE OF price, status ON public.listings
+FOR EACH ROW EXECUTE FUNCTION public.after_listing_write_record_event();
+
+-- ------------------------------------------------------------
+-- Il passato che si può ancora salvare.
+--
+-- Degli annunci già esistenti non abbiamo la storia — è proprio il punto —
+-- ma almeno il loro stato di oggi va messo a verbale, altrimenti quelli
+-- pubblicati prima di questa migration resterebbero senza nemmeno un punto
+-- di partenza. `published_at` come data dell'evento, non now(): la riga
+-- descrive la nascita dell'annuncio, non il momento in cui l'abbiamo
+-- registrata.
+-- ------------------------------------------------------------
+INSERT INTO public.listing_events (listing_id, at, kind, price, status, dynamic)
+SELECT l.id, COALESCE(l.published_at, l.created_at, now()), 'created',
+       l.price, l.status, COALESCE(l.dynamic_pricing_enabled, false)
+FROM public.listings l
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.listing_events e WHERE e.listing_id = l.id
+);

--- a/supabase/verify_schema.sql
+++ b/supabase/verify_schema.sql
@@ -17,7 +17,7 @@
 -- Le colonne di una tabella mancante non vengono elencate: si vedrebbe
 -- l'intera tabella riga per riga, e la riga 'tabella' dice già tutto.
 --
--- Oggetti attesi: 31 tabelle, 265 colonne, 78 funzioni, 20 trigger.
+-- Oggetti attesi: 32 tabelle, 272 colonne, 79 funzioni, 21 trigger.
 -- ============================================================
 
 WITH attesi(tipo, oggetto) AS (VALUES
@@ -31,6 +31,7 @@ WITH attesi(tipo, oggetto) AS (VALUES
 ('tabella',  'fb_link_codes'),
 ('tabella',  'fb_sessions'),
 ('tabella',  'listing_ai_scores'),
+('tabella',  'listing_events'),
 ('tabella',  'listing_images'),
 ('tabella',  'listing_pings'),
 ('tabella',  'listing_questions'),
@@ -112,6 +113,13 @@ WITH attesi(tipo, oggetto) AS (VALUES
 ('colonna',  'listing_ai_scores.listing_id'),
 ('colonna',  'listing_ai_scores.payload'),
 ('colonna',  'listing_ai_scores.reliability'),
+('colonna',  'listing_events.at'),
+('colonna',  'listing_events.dynamic'),
+('colonna',  'listing_events.id'),
+('colonna',  'listing_events.kind'),
+('colonna',  'listing_events.listing_id'),
+('colonna',  'listing_events.price'),
+('colonna',  'listing_events.status'),
 ('colonna',  'listing_images.id'),
 ('colonna',  'listing_images.listing_id'),
 ('colonna',  'listing_images.position'),
@@ -325,6 +333,7 @@ WITH attesi(tipo, oggetto) AS (VALUES
 ('funzione', 'accept_terms'),
 ('funzione', 'account_deletion_blockers'),
 ('funzione', 'after_insert_offers_update_listing'),
+('funzione', 'after_listing_write_record_event'),
 ('funzione', 'after_update_listings_invalidate_translations'),
 ('funzione', 'after_update_offers_propagate'),
 ('funzione', 'anonymize_account'),
@@ -396,6 +405,7 @@ WITH attesi(tipo, oggetto) AS (VALUES
 ('funzione', 'sync_pnr_fingerprint'),
 ('funzione', 'update_listing_trust_score'),
 ('trigger',  'after_chain_proposal_canceled'),
+('trigger',  'after_listing_write_record_event'),
 ('trigger',  'after_offer_notify'),
 ('trigger',  'on_auth_user_created'),
 ('trigger',  'on_auth_user_email_confirmed'),


### PR DESCRIPTION
Non si vede, non serve a nessuno oggi, e va fatto adesso: il dato si sta cancellando da solo ogni ora.

## Cosa si stava perdendo

Per rispondere a *"questo biglietto, a questo prezzo, quante probabilità ha di vendersi entro venerdì?"* serve la **storia**: a quale prezzo un annuncio è stato in vetrina, per quanto, e com'è finita. Oggi:

- **`listings.price` viene sovrascritto** dal cron del prezzo dinamico a ogni giro, e da ogni modifica manuale. Sopravvive solo l'ultimo valore, quindi *"è stato a 70€, poi a 55€, venduto a 40€"* non è ricostruibile — ed è proprio la variabile che il venditore controlla.
- **`listings.updated_at` cambia a ogni scrittura**, quindi non dice quando l'annuncio è diventato `sold` o `expired`: dice solo quand'è stato toccato l'ultima volta.

Nessuna delle due si recupera a posteriori. È lo stesso fatto che ci aveva già costretti a escludere il prezzo dall'impronta delle catene.

## Le scelte

**Trigger, non applicazione.** Il prezzo lo riscrive soprattutto il cron via PostgREST, e qualunque altro client aggirerebbe un controllo lato app — stessa ragione per cui le regole CERCO/VENDO stanno a DB.

**Solo quando cambia davvero** (`IS DISTINCT FROM`). Il cron passa ogni ora su ogni annuncio: senza quel filtro la tabella si riempirebbe di righe identiche, rendendo illeggibile la serie proprio a chi dovrà usarla.

**`AFTER` e non `BEFORE`.** La storia registra ciò che è successo e non deve mai poter impedire una scrittura; stessa transazione, quindi un salvataggio annullato si porta via anche la sua riga.

**RLS attiva senza nessuna policy**, cioè nessun accesso dal client — nemmeno per il proprietario. È materiale di analisi, non contenuto: chi compra, sapendo che un annuncio sta scendendo, aspetterebbe, e cambierebbe il comportamento che vogliamo misurare. Passa solo `service_role`.

**Il passato che si può ancora salvare.** Degli annunci esistenti la storia non c'è (è il punto), ma il loro stato di oggi viene messo a verbale, datato con `published_at` e non con `now()`: la riga descrive la nascita dell'annuncio, non il momento della migration. Il blocco è idempotente.

## Verifiche

**8 test nuovi contro Postgres vero** (`server/test/db/`), perché è tutta roba che vive nel database e nessun mock può vederla: la serie dei prezzi, il non-duplicato a prezzo invariato, la data della fine, prezzo e stato che cambiano insieme, il dinamico distinguibile da una scelta del venditore, la RLS che non lascia passare nemmeno il proprietario, e il `CASCADE`.

Verificato a parte anche il recupero del passato: su un annuncio inserito a trigger disattivato, la riga esce datata alla pubblicazione (20 giorni prima) e la seconda esecuzione non aggiunge nulla.

- **470 test server** con `DATABASE_URL` impostata — nessuno saltato
- schema ricostruito da zero **74/74** su Postgres 16
- `verify_schema.sql` rigenerato: 32 tabelle, 272 colonne, 79 funzioni, 21 trigger
- **nessuna modifica lato app**: bundle invariato, nessun deploy necessario

## ⚠️ Azione manuale

La migration `20260808150000_listing_events.sql` va eseguita nel SQL Editor di Supabase — **già eseguita e verificata** da chi ha aperto la PR (tabella, trigger, RLS a zero policy, zero annunci senza storia).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RY6QwYWAp6ZGqxmKnNPv2o)_